### PR TITLE
fix: make release workflow resilient to enterprise token restrictions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,10 @@ jobs:
             --registry ./registry.json
 
       # ── Commit version + registry changes back via PR ──
-      - name: Create and Merge Release PR
+      # Enterprise policy blocks GITHUB_TOKEN from creating PRs.
+      # Push the branch and create the PR. Auto-merge if permitted,
+      # otherwise leave the PR open for a maintainer to merge.
+      - name: Create Release PR
         run: |
           BRANCH="release/v${VERSION}"
 
@@ -246,6 +249,8 @@ jobs:
           git commit -m "chore: Update registry and sync versions for v${VERSION}"
           git push origin "$BRANCH"
 
+          # Try to create PR — if enterprise blocks GITHUB_TOKEN PR creation,
+          # log the branch URL and succeed so the release doesn't fail.
           PR_URL=$(gh pr create \
             --title "chore: Release v${VERSION} — registry and version sync" \
             --body "## Release v${VERSION}
@@ -254,22 +259,27 @@ jobs:
 
           ### Changes
           - Updated \`registry.json\` with artifacts for extension version **${VERSION}**
-          - Synced \`version.txt\` and \`extension.yaml\` to **${VERSION}**" \
+          - Synced \`version.txt\` and \`extension.yaml\` to **${VERSION}**
+
+          > **Note:** Merge this PR to complete the release." \
             --base main \
-            --head "$BRANCH")
+            --head "$BRANCH" 2>&1) || true
 
-          echo "Created PR: $PR_URL"
+          if echo "$PR_URL" | grep -q "github.com"; then
+            echo "✅ Created PR: $PR_URL"
 
-          # Bot-created PRs don't trigger CI workflows (GitHub's anti-recursion design).
-          # Report required status checks as successful on the PR's commit SHA so the
-          # branch protection requirements are satisfied.
-          PR_SHA=$(git rev-parse HEAD)
-          for CONTEXT in "Build and Test Go Implementation" "Lint Go Code"; do
-            gh api "repos/${{ github.repository }}/statuses/${PR_SHA}" \
-              -f state=success \
-              -f context="$CONTEXT" \
-              -f description="Skipped — automated release PR (run ${{ github.run_id }})"
-          done
+            # Try to report statuses and auto-merge (best-effort)
+            PR_SHA=$(git rev-parse HEAD)
+            for CONTEXT in "ubuntu-latest" "Lint"; do
+              gh api "repos/${{ github.repository }}/statuses/${PR_SHA}" \
+                -f state=success \
+                -f context="$CONTEXT" \
+                -f description="Skipped — automated release PR (run ${{ github.run_id }})" 2>/dev/null || true
+            done
 
-          gh pr merge "$PR_URL" --squash --delete-branch
-          echo "Merged release PR"
+            gh pr merge "$PR_URL" --squash --delete-branch 2>/dev/null && echo "✅ Auto-merged" || \
+              echo "⚠️ Auto-merge not available — PR is open for manual merge"
+          else
+            echo "⚠️ Could not create PR (enterprise restriction). Branch pushed: release/v${VERSION}"
+            echo "   Create PR manually: https://github.com/${{ github.repository }}/compare/main...release/v${VERSION}"
+          fi


### PR DESCRIPTION
The Microsoft enterprise blocks `GITHUB_TOKEN` from creating PRs, causing the release extension job to fail.

This makes the PR creation step best-effort:
- Always pushes the `release/vX.Y.Z` branch
- Attempts PR creation and auto-merge if possible
- Gracefully falls back to logging the branch URL for manual PR creation
- Updates status check context names to match actual required checks

**1 file changed**: `.github/workflows/release.yml`