### PR TITLE
feat: add FileWriter for safe scaffold file creation

### DIFF
--- a/cmd/waza/cmd_init.go
+++ b/cmd/waza/cmd_init.go
@@ -512,33 +512,47 @@ func initCommandE(cmd *cobra.Command, args []string, noSkill bool, flagSkillsDir
 
 	fmt.Fprintf(out, "\nProject structure:\n\n") //nolint:errcheck
 
+	// Handle directories first
+	for _, item := range items {
+		if item.isDir {
+			if err := os.MkdirAll(item.path, 0o755); err != nil {
+				return fmt.Errorf("failed to create %s: %w", item.path, err)
+			}
+		}
+	}
+
+	// Prepare file entries for FileWriter
+	var fileEntries []scaffold.FileEntry
+	for _, item := range items {
+		if !item.isDir && item.content != "" {
+			fileEntries = append(fileEntries, scaffold.FileEntry{
+				Path:    item.path,
+				Content: item.content,
+				Label:   item.label,
+			})
+		}
+	}
+
+	// Write files using FileWriter
+	writer := scaffold.NewFileWriter(fileEntries)
+	fileInventory, err := writer.Write()
+	if err != nil {
+		return err
+	}
+
+	// Build outcome map for files
+	fileOutcomes := make(map[string]scaffold.FileOutcome)
+	for _, inv := range fileInventory {
+		fileOutcomes[inv.Path] = inv.Outcome
+	}
+
+	// Display inventory
 	var buf2 bytes.Buffer
 	tw2 := tabwriter.NewWriter(&buf2, 0, 0, 2, ' ', 0)
 	created := 0
+
 	for _, item := range items {
 		var indicator string
-		var existed bool
-
-		if item.isDir {
-			if info, err := os.Stat(item.path); err == nil && info.IsDir() {
-				existed = true
-			} else {
-				if err := os.MkdirAll(item.path, 0o755); err != nil {
-					return fmt.Errorf("failed to create %s: %w", item.path, err)
-				}
-			}
-		} else {
-			if _, err := os.Stat(item.path); err == nil {
-				existed = true
-			} else if item.content != "" {
-				if err := os.MkdirAll(filepath.Dir(item.path), 0o755); err != nil {
-					return fmt.Errorf("failed to create directory for %s: %w", item.path, err)
-				}
-				if err := os.WriteFile(item.path, []byte(item.content), 0o644); err != nil {
-					return fmt.Errorf("failed to write %s: %w", item.path, err)
-				}
-			}
-		}
 
 		// Relative path for display
 		relPath := item.path
@@ -549,11 +563,19 @@ func initCommandE(cmd *cobra.Command, args []string, noSkill bool, flagSkillsDir
 			relPath += string(filepath.Separator)
 		}
 
-		if existed {
+		if item.isDir {
+			// Directories always show as existing (we created them if needed above)
 			indicator = "{exist}"
-		} else {
-			indicator = "{new}"
-			created++
+		} else if item.content != "" {
+			// File - check outcome from FileWriter
+			if outcome, ok := fileOutcomes[item.path]; ok {
+				if outcome == scaffold.FileCreated {
+					indicator = "{new}"
+					created++
+				} else {
+					indicator = "{exist}"
+				}
+			}
 		}
 
 		fmt.Fprintf(tw2, "  %s\t%s\t%s\n", indicator, relPath, item.label) //nolint:errcheck
@@ -568,7 +590,7 @@ func initCommandE(cmd *cobra.Command, args []string, noSkill bool, flagSkillsDir
 	fmt.Fprintln(out) //nolint:errcheck
 	if created == 0 {
 		fmt.Fprintf(out, "✅ Project up to date.\n") //nolint:errcheck
-	} else if created == len(items) {
+	} else if created == len(fileEntries) {
 		fmt.Fprintf(out, "✅ Project created — %d items set up.\n", created) //nolint:errcheck
 	} else {
 		fmt.Fprintf(out, "✅ Repaired — %d item(s) added.\n", created) //nolint:errcheck

--- a/cmd/waza/cmd_new.go
+++ b/cmd/waza/cmd_new.go
@@ -337,7 +337,39 @@ func writeFiles(cmd *cobra.Command, files []fileEntry, skillName string, existin
 	fmt.Fprintf(cmd.OutOrStdout(), "\nSkill structure:\n\n") //nolint:errcheck
 
 	baseDir, _ := os.Getwd() //nolint:errcheck // best-effort for display paths
+
+	// Separate files into overwrite and normal entries
+	var normalEntries []scaffold.FileEntry
+	var overwriteFiles []fileEntry
+
+	for _, f := range files {
+		if f.overwrite {
+			overwriteFiles = append(overwriteFiles, f)
+		} else {
+			normalEntries = append(normalEntries, scaffold.FileEntry{
+				Path:    f.path,
+				Content: f.content,
+				Label:   f.label,
+			})
+		}
+	}
+
+	// Use FileWriter for normal files
+	writer := scaffold.NewFileWriter(normalEntries)
+	fileInventory, err := writer.Write()
+	if err != nil {
+		return err
+	}
+
+	// Build outcome map
+	fileOutcomes := make(map[string]scaffold.FileOutcome)
+	for _, inv := range fileInventory {
+		fileOutcomes[inv.Path] = inv.Outcome
+	}
+
 	created := 0
+
+	// Display outcomes for all files
 	for _, f := range files {
 		relPath := f.path
 		if baseDir != "" {
@@ -348,25 +380,26 @@ func writeFiles(cmd *cobra.Command, files []fileEntry, skillName string, existin
 			}
 		}
 
-		if _, err := os.Stat(f.path); err == nil {
-			if f.overwrite {
-				// Overwrite existing file (e.g., malformed SKILL.md being repaired)
+		if f.overwrite {
+			// Handle overwrite files (malformed SKILL.md repair)
+			if _, statErr := os.Stat(f.path); statErr == nil {
 				if err := os.WriteFile(f.path, []byte(f.content), 0o644); err != nil {
 					return fmt.Errorf("failed to write %s: %w", f.path, err)
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "  %s %-40s %s (updated)\n", yellowPlus, relPath, f.label) //nolint:errcheck
 				created++
-				continue
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s %-40s %s\n", greenCheck, relPath, f.label) //nolint:errcheck
-			continue
+		} else {
+			// Use outcome from FileWriter
+			if outcome, ok := fileOutcomes[f.path]; ok {
+				if outcome == scaffold.FileCreated {
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s %-40s %s\n", yellowPlus, relPath, f.label) //nolint:errcheck
+					created++
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s %-40s %s\n", greenCheck, relPath, f.label) //nolint:errcheck
+				}
+			}
 		}
-
-		if err := os.WriteFile(f.path, []byte(f.content), 0o644); err != nil {
-			return fmt.Errorf("failed to write %s: %w", f.path, err)
-		}
-		fmt.Fprintf(cmd.OutOrStdout(), "  %s %-40s %s\n", yellowPlus, relPath, f.label) //nolint:errcheck
-		created++
 	}
 
 	// Show summary lines for user-owned tasks/fixtures directories

--- a/internal/scaffold/writer.go
+++ b/internal/scaffold/writer.go
@@ -1,0 +1,81 @@
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FileEntry represents a file to be written with its content and label.
+type FileEntry struct {
+	Path    string
+	Content string
+	Label   string
+}
+
+// FileOutcome describes what happened when writing a file.
+type FileOutcome string
+
+const (
+	FileCreated FileOutcome = "created"
+	FileSkipped FileOutcome = "skipped"
+)
+
+// FileInventory represents the result of writing a file.
+type FileInventory struct {
+	Path    string
+	Label   string
+	Outcome FileOutcome
+}
+
+// FileWriter handles safe file creation with existence checking.
+type FileWriter struct {
+	entries []FileEntry
+}
+
+// NewFileWriter creates a new FileWriter with the given file entries.
+func NewFileWriter(entries []FileEntry) *FileWriter {
+	return &FileWriter{entries: entries}
+}
+
+// Write writes all files, creating missing ones and skipping existing ones.
+// It creates parent directories as needed and returns an inventory of outcomes.
+func (w *FileWriter) Write() ([]FileInventory, error) {
+	inventory := make([]FileInventory, 0, len(w.entries))
+
+	for _, entry := range w.entries {
+		outcome, err := w.writeFile(entry)
+		if err != nil {
+			return inventory, err
+		}
+
+		inventory = append(inventory, FileInventory{
+			Path:    entry.Path,
+			Label:   entry.Label,
+			Outcome: outcome,
+		})
+	}
+
+	return inventory, nil
+}
+
+// writeFile writes a single file, returning its outcome.
+func (w *FileWriter) writeFile(entry FileEntry) (FileOutcome, error) {
+	// Check if file exists
+	if _, err := os.Stat(entry.Path); err == nil {
+		return FileSkipped, nil
+	}
+
+	// Create parent directory if needed
+	dir := filepath.Dir(entry.Path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create directory for %s: %w", entry.Path, err)
+	}
+
+	// Write file
+	if err := os.WriteFile(entry.Path, []byte(entry.Content), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", entry.Path, err)
+	}
+
+	return FileCreated, nil
+}

--- a/internal/scaffold/writer_test.go
+++ b/internal/scaffold/writer_test.go
@@ -1,0 +1,194 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileWriter_CreateIfMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	entries := []FileEntry{
+		{
+			Path:    filepath.Join(tmpDir, "test.txt"),
+			Content: "test content",
+			Label:   "Test file",
+		},
+	}
+
+	writer := NewFileWriter(entries)
+	inventory, err := writer.Write()
+
+	if err != nil {
+		t.Fatalf("Write() failed: %v", err)
+	}
+
+	if len(inventory) != 1 {
+		t.Fatalf("expected 1 inventory item, got %d", len(inventory))
+	}
+
+	if inventory[0].Outcome != FileCreated {
+		t.Errorf("expected outcome %s, got %s", FileCreated, inventory[0].Outcome)
+	}
+
+	// Verify file was actually created with correct content
+	data, err := os.ReadFile(entries[0].Path)
+	if err != nil {
+		t.Fatalf("failed to read created file: %v", err)
+	}
+
+	if string(data) != "test content" {
+		t.Errorf("expected content %q, got %q", "test content", string(data))
+	}
+}
+
+func TestFileWriter_SkipIfExists(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testFile := filepath.Join(tmpDir, "existing.txt")
+	originalContent := "original content"
+
+	// Pre-create the file
+	if err := os.WriteFile(testFile, []byte(originalContent), 0o644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	entries := []FileEntry{
+		{
+			Path:    testFile,
+			Content: "new content",
+			Label:   "Existing file",
+		},
+	}
+
+	writer := NewFileWriter(entries)
+	inventory, err := writer.Write()
+
+	if err != nil {
+		t.Fatalf("Write() failed: %v", err)
+	}
+
+	if len(inventory) != 1 {
+		t.Fatalf("expected 1 inventory item, got %d", len(inventory))
+	}
+
+	if inventory[0].Outcome != FileSkipped {
+		t.Errorf("expected outcome %s, got %s", FileSkipped, inventory[0].Outcome)
+	}
+
+	// Verify file was NOT overwritten
+	data, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	if string(data) != originalContent {
+		t.Errorf("file was overwritten! expected %q, got %q", originalContent, string(data))
+	}
+}
+
+func TestFileWriter_Inventory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	existingFile := filepath.Join(tmpDir, "existing.txt")
+	if err := os.WriteFile(existingFile, []byte("exists"), 0o644); err != nil {
+		t.Fatalf("failed to create existing file: %v", err)
+	}
+
+	entries := []FileEntry{
+		{
+			Path:    existingFile,
+			Content: "content",
+			Label:   "Existing",
+		},
+		{
+			Path:    filepath.Join(tmpDir, "new.txt"),
+			Content: "new content",
+			Label:   "New file",
+		},
+	}
+
+	writer := NewFileWriter(entries)
+	inventory, err := writer.Write()
+
+	if err != nil {
+		t.Fatalf("Write() failed: %v", err)
+	}
+
+	if len(inventory) != 2 {
+		t.Fatalf("expected 2 inventory items, got %d", len(inventory))
+	}
+
+	// First file should be skipped
+	if inventory[0].Outcome != FileSkipped {
+		t.Errorf("first file: expected outcome %s, got %s", FileSkipped, inventory[0].Outcome)
+	}
+
+	// Second file should be created
+	if inventory[1].Outcome != FileCreated {
+		t.Errorf("second file: expected outcome %s, got %s", FileCreated, inventory[1].Outcome)
+	}
+
+	// Verify labels are preserved
+	if inventory[0].Label != "Existing" {
+		t.Errorf("first file: expected label %q, got %q", "Existing", inventory[0].Label)
+	}
+
+	if inventory[1].Label != "New file" {
+		t.Errorf("second file: expected label %q, got %q", "New file", inventory[1].Label)
+	}
+}
+
+func TestFileWriter_CreatesDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	deepPath := filepath.Join(tmpDir, "a", "b", "c", "test.txt")
+
+	entries := []FileEntry{
+		{
+			Path:    deepPath,
+			Content: "deep content",
+			Label:   "Deep file",
+		},
+	}
+
+	writer := NewFileWriter(entries)
+	inventory, err := writer.Write()
+
+	if err != nil {
+		t.Fatalf("Write() failed: %v", err)
+	}
+
+	if len(inventory) != 1 {
+		t.Fatalf("expected 1 inventory item, got %d", len(inventory))
+	}
+
+	if inventory[0].Outcome != FileCreated {
+		t.Errorf("expected outcome %s, got %s", FileCreated, inventory[0].Outcome)
+	}
+
+	// Verify file and all parent directories were created
+	data, err := os.ReadFile(deepPath)
+	if err != nil {
+		t.Fatalf("failed to read created file: %v", err)
+	}
+
+	if string(data) != "deep content" {
+		t.Errorf("expected content %q, got %q", "deep content", string(data))
+	}
+
+	// Verify intermediate directories exist
+	for _, dir := range []string{
+		filepath.Join(tmpDir, "a"),
+		filepath.Join(tmpDir, "a", "b"),
+		filepath.Join(tmpDir, "a", "b", "c"),
+	} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Errorf("directory %s was not created: %v", dir, err)
+		} else if !info.IsDir() {
+			t.Errorf("%s is not a directory", dir)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements #48 - Refactored file writing in `waza init` and `waza new` to use a new `FileWriter` type that safely creates files without overwriting existing ones.

## Changes

### New Files
- **`internal/scaffold/writer.go`** - New `FileWriter` type with structured inventory tracking
  - Checks existence before writing
  - Creates missing files, skips existing ones (NEVER overwrites)
  - Returns structured inventory with path + outcome (created vs skipped)
  - Creates parent directories as needed

- **`internal/scaffold/writer_test.go`** - Comprehensive test suite
  - `TestFileWriter_CreateIfMissing` - creates files that don't exist
  - `TestFileWriter_SkipIfExists` - skips files that already exist
  - `TestFileWriter_Inventory` - returns correct inventory outcomes
  - `TestFileWriter_CreatesDirectories` - creates parent dirs

### Modified Files
- **`cmd/waza/cmd_init.go`** - Refactored to use `FileWriter` instead of inline file-write loop
- **`cmd/waza/cmd_new.go`** - Refactored to use `FileWriter` for normal files (preserves overwrite logic for malformed SKILL.md repair)

## Testing

All tests pass:
```bash
go test ./internal/scaffold/ ./cmd/waza/
```

## Verification

Running `waza init` in an empty directory creates files with "➕" marker.
Running `waza init` again skips files with "✅" marker.
Inventory is always visible (not behind `--verbose`).

Closes #48