### PR TITLE
fix: update docs link to GitHub Pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go CLI for evaluating AI agent skills — scaffold eval suites, run benchmarks, and compare results across models.
 
-📖 **[Getting Started / Docs](https://proud-beach-0e05cbe0f.2.azurestaticapps.net/)**
+📖 **[Getting Started / Docs](https://microsoft.github.io/waza/)**
 
 ## Installation
 


### PR DESCRIPTION
The Getting Started / Docs link in README.md pointed to a stale Azure Static Web Apps URL from a one-time deployment that was never updated. Updated to the correct GitHub Pages URL (`microsoft.github.io/waza`).

Closes no issue — cleanup.