### PR TITLE
Fix test that leaks files into the repo

### DIFF
--- a/cmd/waza/cmd_run_test.go
+++ b/cmd/waza/cmd_run_test.go
@@ -2221,6 +2221,8 @@ tasks:
 }
 
 func TestRunCommandForSpec_NilCmd_OverridesTrials(t *testing.T) {
+	resetRunGlobals()
+
 	// Setup
 	tmp := t.TempDir()
 	specPath := filepath.Join(tmp, "eval.yaml")
@@ -2253,18 +2255,6 @@ metrics: []
 `, filepath.Base(taskPath))
 
 	require.NoError(t, os.WriteFile(specPath, []byte(specYAML), 0644))
-
-	// Save/Restore globals
-	oldTrials := trials
-	oldOutputPath := outputPath
-	oldContextDir := contextDir
-	oldFormat := format
-	defer func() {
-		trials = oldTrials
-		outputPath = oldOutputPath
-		contextDir = oldContextDir
-		format = oldFormat
-	}()
 
 	// Set flags
 	trials = 3


### PR DESCRIPTION
Running `go test ./cmd/waza/...` left two untracked files in the repo:

```
cmd/waza/.override-cache/
cmd/waza/<timestamp>-session.jsonl
```

These were created by `TestRunCommandForSpec_NilCmd_OverridesTrials`, which calls `runCommandForSpec` directly without first resetting the package-level flag variables. When it ran after `TestRunCommand_CLIFlagsOverrideWazaYaml`, it inherited that test's globals:

- `sessionLog = true` → wrote a `.jsonl` session log to the working directory
- `enableCache = true` + `runCacheDir = ".override-cache"` → created a cache directory in the working directory

Because this test doesn't `os.Chdir` into a temp dir (unlike the `.waza.yaml` integration tests), those files landed in `cmd/waza/` — the default working directory for `go test`.

## Fix

Added `resetRunGlobals()` at the top of the test, matching the convention used by every other test in the file. This resets `sessionLog`, `enableCache`, and all other flag variables to their zero/default values before the test runs.

Also removed the manual save/restore block for `trials`, `outputPath`, `contextDir`, and `format` — `resetRunGlobals()` already covers these, and the partial restore was the root cause (it didn't restore `sessionLog`, `enableCache`, or `runCacheDir`).
