### PR TITLE
waza check uses configured token limits from .waza.yaml

### DIFF
--- a/cmd/waza/cmd_check.go
+++ b/cmd/waza/cmd_check.go
@@ -380,8 +380,8 @@ func checkReadiness(skillDir string, wsCtx *workspace.WorkspaceContext) (*readin
 	report.skillName = sk.Frontmatter.Name
 
 	// 3. Run compliance scoring
-	tokenLimit := resolveSkillTokenLimit(filepath.Dir(skillDir))
-	warnThreshold := resolveWarningThreshold(filepath.Dir(skillDir))
+	tokenLimit := resolveSkillTokenLimit(skillDir)
+	warnThreshold := resolveWarningThreshold(skillDir)
 	complianceData, err := (&checks.ComplianceScoreChecker{TokenLimit: tokenLimit, WarningThreshold: warnThreshold}).Score(sk)
 	if err != nil {
 		return nil, err
@@ -408,7 +408,6 @@ func checkReadiness(skillDir string, wsCtx *workspace.WorkspaceContext) (*readin
 
 	// 4b. Check token warning threshold
 	if !report.tokenExceeded {
-		warnThreshold := resolveWarningThreshold(filepath.Dir(skillDir))
 		if warnThreshold > 0 && report.tokenCount >= warnThreshold {
 			report.tokenWarning = true
 		}
@@ -480,24 +479,30 @@ func checkReadiness(skillDir string, wsCtx *workspace.WorkspaceContext) (*readin
 func resolveSkillTokenLimit(startDir string) int {
 	// Try project config first (.waza.yaml tokens.limits section)
 	if cfg, err := projectconfig.Load(startDir); err == nil && cfg.Tokens.Limits != nil {
-		limCfg := checks.TokenLimitsConfig{
-			Defaults:  cfg.Tokens.Limits.Defaults,
-			Overrides: cfg.Tokens.Limits.Overrides,
+		defaults := cfg.Tokens.Limits.Defaults
+		if defaults == nil {
+			defaults = make(map[string]int)
 		}
-		if limCfg.Defaults != nil {
-			// Compute workspace-relative prefix so workspace-root-relative
-			// patterns (e.g. "plugin/skills/**/SKILL.md") can match.
-			prefix := ""
-			if wd, wdErr := os.Getwd(); wdErr == nil {
-				if abs, absErr := filepath.Abs(startDir); absErr == nil {
-					if rel, relErr := filepath.Rel(wd, abs); relErr == nil && rel != "." {
-						prefix = filepath.ToSlash(rel)
-					}
+		overrides := cfg.Tokens.Limits.Overrides
+		if overrides == nil {
+			overrides = make(map[string]int)
+		}
+		limCfg := checks.TokenLimitsConfig{
+			Defaults:  defaults,
+			Overrides: overrides,
+		}
+		// Compute workspace-relative prefix so workspace-root-relative
+		// patterns (e.g. "plugin/skills/**/SKILL.md") can match.
+		prefix := ""
+		if wd, wdErr := os.Getwd(); wdErr == nil {
+			if abs, absErr := filepath.Abs(startDir); absErr == nil {
+				if rel, relErr := filepath.Rel(wd, abs); relErr == nil && rel != "." {
+					prefix = filepath.ToSlash(rel)
 				}
 			}
-			lr := checks.GetLimitForFile("SKILL.md", limCfg, prefix)
-			return lr.Limit
 		}
+		lr := checks.GetLimitForFile("SKILL.md", limCfg, prefix)
+		return lr.Limit
 	}
 
 	// Try .token-limits.json (fallback)

--- a/cmd/waza/cmd_check_test.go
+++ b/cmd/waza/cmd_check_test.go
@@ -233,6 +233,69 @@ Body content here.
 	assert.False(t, report.hasEval)
 }
 
+func TestCheckReadiness_WazaYamlOverridesOnly(t *testing.T) {
+	// Regression: resolveSkillTokenLimit must honor overrides even when
+	// defaults is absent from .waza.yaml tokens.limits.
+	tmpDir := t.TempDir()
+
+	wazaYAML := `tokens:
+  limits:
+    overrides:
+      "SKILL.md": 3000
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".waza.yaml"), []byte(wazaYAML), 0644))
+
+	skillContent := `---
+name: override-limit-test
+description: This is a test skill to verify that waza check reads token limits from the overrides section of waza yaml config.
+---
+
+# Override Limit Test
+
+Body content here.
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "SKILL.md"), []byte(skillContent), 0644))
+
+	// checkReadiness resolves the token limit via resolveSkillTokenLimit.
+	// Before the fix, an overrides-only config fell through to DefaultLimits
+	// (SKILL.md: 500). After the fix it should pick up the 3000 override.
+	t.Chdir(tmpDir)
+
+	report, err := checkReadiness(tmpDir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 3000, report.tokenLimit, "should use override limit from .waza.yaml, not built-in default 500")
+	assert.False(t, report.tokenExceeded)
+}
+
+func TestCheckReadiness_WazaYamlDefaultsLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	wazaYAML := `tokens:
+  limits:
+    defaults:
+      "SKILL.md": 4000
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".waza.yaml"), []byte(wazaYAML), 0644))
+
+	skillContent := `---
+name: defaults-limit-test
+description: This is a test skill to verify that waza check reads token limits from the defaults section of waza yaml config.
+---
+
+# Defaults Limit Test
+
+Body content here.
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "SKILL.md"), []byte(skillContent), 0644))
+
+	t.Chdir(tmpDir)
+
+	report, err := checkReadiness(tmpDir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 4000, report.tokenLimit, "should use default limit from .waza.yaml")
+	assert.False(t, report.tokenExceeded)
+}
+
 func TestGenerateNextSteps(t *testing.T) {
 	// Test with high compliance - should have no steps
 	t.Run("high compliance no issues", func(t *testing.T) {


### PR DESCRIPTION
`waza check` ignored token limits configured in `.waza.yaml` and always fell back to the built-in default of 500 tokens for `SKILL.md`. Meanwhile, `waza tokens check` correctly read the configured limit. For example, with a `.waza.yaml` setting of 3000 tokens:

- `waza tokens check` → limit: **3000** ✅
- `waza check` → limit: **500** ❌

## Root Cause

Two bugs in `resolveSkillTokenLimit()` in `cmd/waza/cmd_check.go`:

1. **Unnecessary nil guard on `Defaults`** — An `if limCfg.Defaults != nil` guard wrapped the entire limit resolution. When a user configured only the `overrides` section (no `defaults`), the function skipped the `.waza.yaml` config entirely and fell back to built-in defaults (`SKILL.md: 500`). The equivalent function in `waza tokens check` (`resolveLimitsConfig` in `tokens/helpers.go`) did not have this guard.

2. **Wrong directory passed to config lookup** — `checkReadiness` called `resolveSkillTokenLimit(filepath.Dir(skillDir))`, starting the `.waza.yaml` search from the *parent* of the skill directory. When `.waza.yaml` lives at the same level as the skill, it was never found.

## Fix

- Removed the `if limCfg.Defaults != nil` guard and added nil-safe map initialization for both `Defaults` and `Overrides`, matching the pattern used in `resolveLimitsConfig`.
- Changed `checkReadiness` to pass `skillDir` directly (not `filepath.Dir(skillDir)`) to both `resolveSkillTokenLimit` and `resolveWarningThreshold`. `projectconfig.Load` already walks up the directory tree, so starting from the skill directory itself is correct.
