### PR TITLE
Apply timeout configuration to `waza run`

### DIFF
--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -133,6 +133,12 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 		}
 	}
 
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
+		defer cancel()
+	}
+
 	var session CopilotSession
 
 	permRequestCallback := allowAllTools


### PR DESCRIPTION
Users set a timeout value in eval configuration and commands like `run` pass that to `CopilotEngine.Execute()` via `ExecutionRequest.Timeout`. The value stops there. It's never realized as a Context timeout, so these commands get the Copilot SDK's default timeout instead. This PR is a quick fix; really the cancellation API needs a refactor (#129)