### PR TITLE
docs: update CLI reference, README, and site docs for v0.23+ features

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,16 @@ Run an evaluation benchmark from a spec file.
 | `--discover` | | Auto skill discovery — walks directory tree for SKILL.md + eval.yaml (root/tests/evals) |
 | `--strict` | | Fail if any SKILL.md lacks eval coverage (use with `--discover`) |
 | `--suggest` | | Generate a Copilot suggestion report based on test outcomes (`mock` engine emits a deterministic fake report) |
+| `--output-dir <dir>` | | Directory for structured output; each run creates a UTC timestamped subdirectory. Mutually exclusive with `--output`. |
+| `--tags <patterns>` | | Filter tasks by tags, using glob patterns (repeatable) |
+| `--model <name>` | | Override model (repeatable for multi-model comparison) |
+| `--recommend` | | Generate heuristic recommendation after multi-model run |
+| `--judge-model <model>` | | Model for LLM-as-judge graders (overrides execution model) |
+| `--session-log` | | Enable session event logging (NDJSON) |
+| `--session-dir <dir>` | | Directory for session log files (default: current directory) |
+| `--no-summary` | | Skip writing combined summary.json for multi-skill runs |
+| `--update-snapshots` | | Update or create diff grader snapshot files to match current output |
+| `--skip-graders` | | Skip grading (execution only); grade later with `waza grade` |
 
 **Result Caching**
 
@@ -638,6 +648,27 @@ Run graders against agent output without executing an agent. Designed for standa
 ```bash
 waza run eval.yaml --output results.json
 waza grade eval.yaml --results results.json
+```
+
+### `waza session list`
+
+List session event logs in a directory.
+
+| Flag | Description |
+|------|-------------|
+| `--dir <dir>` | Directory to search for session logs (default: `.`) |
+
+```bash
+waza session list
+waza session list --dir ./sessions
+```
+
+### `waza session view <session-file>`
+
+Render a session timeline from an NDJSON event log.
+
+```bash
+waza session view session-2025-06-15.ndjson
 ```
 
 ## Cloud Storage

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -3,7 +3,7 @@ title: Writing Eval Specs
 description: Complete guide to YAML structure for evaluation benchmarks.
 ---
 
-<!--cspell:ignore fastapi inlines -->
+{/* cspell:ignore fastapi inlines */}
 
 A complete reference for writing `eval.yaml` specifications and task definitions.
 

--- a/site/src/content/docs/guides/graders.mdx
+++ b/site/src/content/docs/guides/graders.mdx
@@ -3,7 +3,7 @@ title: Graders
 description: Complete reference for all 12 grader types — how they work, configuration options, and real-world examples.
 ---
 
-<!-- cspell:ignore astrojs fastapi -->
+{/* cspell:ignore astrojs fastapi */}
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
@@ -42,8 +42,8 @@ waza ships with **several built-in grader types**. Pick the right one for the jo
 | [Action Sequence](#action-sequence-action_sequence)    | `action_sequence`  | Tool call ordering and completeness                  |
 | [Skill Invocation](#skill-invocation-skill_invocation) | `skill_invocation` | Which skills were invoked and in what order          |
 | [Program](#program)                                    | `program`          | External command (any language) grades via exit code |
-| [Tool Constraint](#tool-constraint)                    | `tool_constraint`  | Tool Constraint                                      |
-| [Trigger](#trigger)                                    | `trigger`          | Trigger                                              |
+| [Tool Constraint](#tool-constraint)                    | `tool_constraint`  | Validate tool usage constraints (expect/reject lists and argument patterns) |
+| [Trigger](#trigger)                                    | `trigger`          | Heuristic grader for validating whether a prompt should activate a skill   |
 
 ---
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -52,6 +52,14 @@ waza run [eval.yaml | skill-name]
 | `--update-snapshots` | | bool | false | Update or create `diff` grader snapshot files to match current workspace output |
 | `--discover` | | string | | Auto skill discovery — walks directory tree for SKILL.md + eval.yaml (root/tests/evals) |
 | `--strict` | | bool | false | Fail if any SKILL.md lacks eval coverage (use with `--discover`) |
+| `--suggest` | | bool | false | Generate a Copilot suggestion report based on test outcomes |
+| `--recommend` | | bool | false | Generate heuristic recommendation after multi-model run |
+| `--session-log` | | bool | false | Enable session event logging (NDJSON) |
+| `--session-dir` | | string | `.` | Directory for session log files |
+| `--no-summary` | | bool | false | Skip combined summary.json for multi-skill runs |
+| `--skip-graders` | | bool | false | Skip grading (execution only); grade later with `waza grade` |
+| `--transcript-dir` | | string | | Save per-task transcript JSON files |
+| `--no-cache` | | bool | false | Explicitly disable result caching |
 
 ### Examples
 
@@ -98,6 +106,16 @@ waza run --discover ./skills/
 
 # Auto discovery with strict mode (fail if any SKILL.md lacks eval coverage)
 waza run --discover --strict ./skills/
+
+# Skip grading, then grade separately
+waza run eval.yaml --skip-graders -o results.json
+waza grade eval.yaml --results results.json
+
+# Session event logging
+waza run eval.yaml --session-log --session-dir ./logs
+
+# Multi-model comparison with recommendation
+waza run eval.yaml --model gpt-4o --model claude-sonnet-4.6 --recommend
 ```
 
 ## waza init
@@ -548,6 +566,65 @@ Iteratively:
 5. Re-scores
 6. Repeats until target reached
 
+## waza grade
+
+Re-grade previous evaluation results without re-executing the agent.
+
+```bash
+waza grade <eval.yaml>
+```
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--results` | | string | | **Required.** Path to `waza run` output JSON |
+| `--task` | | string | | Grade a specific task ID only |
+| `--workspace` | | string | `.` | Agent workspace directory for file-based graders |
+| `--judge-model` | | string | | Model for prompt graders (overrides execution model) |
+| `--output` | `-o` | string | | Write full EvaluationOutcome JSON |
+| `--verbose` | `-v` | bool | false | Verbose output |
+
+### Examples
+
+```bash
+# Grade all tasks from a previous run
+waza grade eval.yaml --results results.json
+
+# Grade a specific task
+waza grade eval.yaml --results results.json --task "basic-function"
+
+# Use a different judge model
+waza grade eval.yaml --results results.json --judge-model claude-opus-4.6
+
+# Save graded results for comparison
+waza grade eval.yaml --results results.json -o graded.json
+```
+
+## waza session
+
+Manage and inspect session event logs.
+
+### waza session list
+
+List session event logs in a directory.
+
+```bash
+waza session list [--dir <path>]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dir` | string | `.` | Directory to search for session logs |
+
+### waza session view
+
+Render a session timeline from an NDJSON event log.
+
+```bash
+waza session view <session-file>
+```
+
 ## waza serve
 
 Start the interactive dashboard.
@@ -589,7 +666,7 @@ Waza supports multiple grader types for comprehensive evaluation. See the comple
 | `skill_invocation` | Skill orchestration sequence validation |
 | `prompt` | LLM-as-judge evaluation with rubrics |
 | `tool_constraint` | Validate tool usage constraints (e.g., required/forbidden tools, argument patterns) |
-| `trigger_tests` | Prompt trigger accuracy detection |
+| `trigger` | Prompt trigger accuracy — detects whether a prompt should activate a skill |
 
 ### tool_constraint Grader
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -3,7 +3,7 @@ title: YAML Schema
 description: Complete reference for eval.yaml and task file formats.
 ---
 
-<!-- cspell:ignore myteamwaza -->
+{/* cspell:ignore myteamwaza */}
 
 Complete reference for YAML schema used in waza evaluations.
 

--- a/site/src/content/docs/reference/waza-yaml.mdx
+++ b/site/src/content/docs/reference/waza-yaml.mdx
@@ -1,0 +1,189 @@
+---
+title: Project Configuration (.waza.yaml)
+description: Complete reference for .waza.yaml project configuration.
+---
+
+The `.waza.yaml` file configures project-level defaults for Waza. Place it in your project root — Waza searches up the directory tree (max 10 levels) to find it.
+
+## Quick Start
+
+```yaml
+# .waza.yaml
+paths:
+  skills: skills/
+  evals: evals/
+  results: results/
+
+defaults:
+  model: claude-sonnet-4.6
+  timeout: 300
+  workers: 4
+```
+
+## Configuration Sections
+
+### paths
+
+Directory paths relative to the project root.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `skills` | string | `skills/` | Directory containing skill definitions |
+| `evals` | string | `evals/` | Directory containing evaluation specs |
+| `results` | string | `results/` | Directory for evaluation results |
+
+### defaults
+
+Default execution parameters applied to all commands unless overridden by CLI flags.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `engine` | string | `copilot-sdk` | Execution engine |
+| `model` | string | `claude-sonnet-4.6` | Default model for execution |
+| `judgeModel` | string | | Model for LLM-as-judge graders |
+| `timeout` | int | `300` | Task timeout in seconds |
+| `parallel` | bool | `false` | Enable parallel execution |
+| `workers` | int | `4` | Number of parallel workers |
+| `verbose` | bool | `false` | Enable verbose output |
+| `sessionLog` | bool | `false` | Enable session event logging |
+
+### cache
+
+Result caching configuration.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable result caching |
+| `dir` | string | `.waza-cache` | Cache directory |
+
+### server
+
+Dashboard server configuration for `waza serve`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `port` | int | `3000` | Dashboard server port |
+| `resultsDir` | string | `results/` | Directory served by the dashboard |
+
+### dev
+
+Settings for the `waza dev` iterative improvement command.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model` | string | `claude-sonnet-4-20250514` | Model for dev mode |
+| `target` | string | `medium-high` | Target adherence level |
+| `maxIterations` | int | `5` | Maximum improvement iterations |
+
+### tokens
+
+Token budget configuration for `waza check` and `waza tokens` commands.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `warningThreshold` | int | `500` | Token count warning threshold |
+| `fallbackLimit` | int | `1000` | Default limit for unmatched files |
+
+#### tokens.limits
+
+Per-file token limits with glob pattern matching.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `defaults` | map | Glob patterns → token limits (e.g., `"*.md": 2000`) |
+| `overrides` | map | Exact file paths → token limits (higher precedence) |
+
+```yaml
+tokens:
+  warningThreshold: 2500
+  fallbackLimit: 2000
+  limits:
+    defaults:
+      "SKILL.md": 500
+      "references/**/*.md": 1000
+      "*.md": 2000
+    overrides:
+      "README.md": 3000
+```
+
+### graders
+
+Grader execution settings.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `programTimeout` | int | `30` | Timeout for external grader programs (seconds) |
+
+### storage
+
+Remote result storage for team collaboration. See [Azure Storage Guide](../../guides/azure-storage/).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `provider` | string | | Storage provider (`azure-blob`) |
+| `accountName` | string | | Azure Storage account name |
+| `containerName` | string | `waza-results` | Blob container name |
+| `enabled` | bool | `false` | Enable remote uploads |
+
+```yaml
+storage:
+  provider: azure-blob
+  accountName: myteamwaza
+  containerName: waza-results
+  enabled: true
+```
+
+## Complete Example
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/waza/main/schemas/config.schema.json
+
+paths:
+  skills: skills/
+  evals: evals/
+  results: results/
+
+defaults:
+  engine: copilot-sdk
+  model: claude-sonnet-4.6
+  timeout: 300
+  parallel: false
+  workers: 4
+
+cache:
+  enabled: false
+  dir: .waza-cache
+
+server:
+  port: 3000
+  resultsDir: results/
+
+dev:
+  model: claude-sonnet-4-20250514
+  target: medium-high
+  maxIterations: 5
+
+tokens:
+  warningThreshold: 500
+  fallbackLimit: 1000
+  limits:
+    defaults:
+      "*.md": 800
+    overrides:
+      "special.md": 5000
+
+graders:
+  programTimeout: 30
+
+storage:
+  provider: azure-blob
+  accountName: myteamwaza
+  containerName: waza-results
+  enabled: true
+```
+
+## Next Steps
+
+- **[CLI Commands](../cli/)** — Full command reference
+- **[Token Limits Guide](../../guides/token-limits/)** — Token budget details
+- **[Azure Storage](../../guides/azure-storage/)** — Cloud storage setup


### PR DESCRIPTION
Comprehensive docs update: adds missing waza run flags, waza grade/session sections, .waza.yaml reference page, fixes grader descriptions and MDX comment syntax.