### PR TITLE
fix: macOS install + trigger test off-by-1 count (#164, #184)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,12 +85,15 @@ main() {
     "https://github.com/${REPO}/releases/download/${tag}/checksums.txt"
 
   echo "Verifying checksum..."
-  if command -v sha256sum >/dev/null 2>&1; then
-    (cd "$tmpdir" && grep "${asset_name}" checksums.txt | sha256sum -c --status)
-  elif command -v shasum >/dev/null 2>&1; then
+  # Try shasum first (native on macOS and supports -c flag)
+  # Fall back to sha256sum (Linux, but only if it supports -c flag)
+  if command -v shasum >/dev/null 2>&1; then
     (cd "$tmpdir" && grep "${asset_name}" checksums.txt | shasum -a 256 -c --status)
+  elif command -v sha256sum >/dev/null 2>&1 && sha256sum --help 2>&1 | grep -q -- '-c'; then
+    (cd "$tmpdir" && grep "${asset_name}" checksums.txt | sha256sum -c --status)
   else
-    echo "Warning: no sha256sum or shasum found, skipping checksum verification"
+    echo "Error: No compatible checksum utility found (sha256sum or shasum)" >&2
+    exit 1
   fi
   echo "Checksum verified ✓"
 

--- a/internal/models/trigger_metrics.go
+++ b/internal/models/trigger_metrics.go
@@ -37,38 +37,44 @@ func ComputeTriggerMetrics(results []TriggerResult) *TriggerMetrics {
 		return nil
 	}
 
-	var tp, fp, tn, fn float64
+	// Track actual counts for display and weighted values for scoring.
+	var tpCount, fpCount, tnCount, fnCount int
+	var tpW, fpW, tnW, fnW float64
 	for _, r := range results {
 		w := triggerConfidenceWeight(r.Confidence)
 		switch {
 		case r.ShouldTrigger && r.DidTrigger:
-			tp += w
+			tpCount++
+			tpW += w
 		case !r.ShouldTrigger && r.DidTrigger:
-			fp += w
+			fpCount++
+			fpW += w
 		case !r.ShouldTrigger && !r.DidTrigger:
-			tn += w
+			tnCount++
+			tnW += w
 		case r.ShouldTrigger && !r.DidTrigger:
-			fn += w
+			fnCount++
+			fnW += w
 		}
 	}
 
-	total := tp + fp + tn + fn
+	total := tpW + fpW + tnW + fnW
 
-	precision := triggerSafeDivide(tp, tp+fp)
-	recall := triggerSafeDivide(tp, tp+fn)
+	precision := triggerSafeDivide(tpW, tpW+fpW)
+	recall := triggerSafeDivide(tpW, tpW+fnW)
 
 	var f1 float64
 	if precision+recall > 0 {
 		f1 = 2 * precision * recall / (precision + recall)
 	}
 
-	accuracy := triggerSafeDivide(tp+tn, total)
+	accuracy := triggerSafeDivide(tpW+tnW, total)
 
 	return &TriggerMetrics{
-		TP:        int(math.Round(tp)),
-		FP:        int(math.Round(fp)),
-		TN:        int(math.Round(tn)),
-		FN:        int(math.Round(fn)),
+		TP:        tpCount,
+		FP:        fpCount,
+		TN:        tnCount,
+		FN:        fnCount,
 		Precision: triggerRoundTo4(precision),
 		Recall:    triggerRoundTo4(recall),
 		F1:        triggerRoundTo4(f1),

--- a/internal/models/trigger_metrics_test.go
+++ b/internal/models/trigger_metrics_test.go
@@ -144,11 +144,38 @@ func TestComputeTriggerMetrics(t *testing.T) {
 				{ShouldTrigger: true, DidTrigger: true, Confidence: "medium"},  // TP 0.5
 				{ShouldTrigger: true, DidTrigger: false, Confidence: "medium"}, // FN 0.5
 			},
-			// tp=0.5, fn=0.5; precision=1.0, recall=0.5, f1=0.6667, accuracy=0.5
-			// TP rounds to 1, FN rounds to 1 (int display)
+			// tp_w=0.5, fn_w=0.5; precision=1.0, recall=0.5, f1=0.6667, accuracy=0.5
+			// Integer counts: TP=1, FN=1 (actual result counts, not weighted)
 			want: &TriggerMetrics{
 				TP: 1, FP: 0, TN: 0, FN: 1,
 				Precision: 1.0, Recall: 0.5, F1: 0.6667, Accuracy: 0.5,
+			},
+		},
+		{
+			name: "medium confidence does not reduce integer counts (issue #184)",
+			results: func() []TriggerResult {
+				// 8 should-trigger (6 high + 2 medium), 8 should-not-trigger (6 high + 2 medium)
+				// None triggered → all should-trigger are FN, all should-not-trigger are TN.
+				var r []TriggerResult
+				for i := 0; i < 6; i++ {
+					r = append(r, TriggerResult{ShouldTrigger: true, DidTrigger: false, Confidence: "high"})
+				}
+				for i := 0; i < 2; i++ {
+					r = append(r, TriggerResult{ShouldTrigger: true, DidTrigger: false, Confidence: "medium"})
+				}
+				for i := 0; i < 6; i++ {
+					r = append(r, TriggerResult{ShouldTrigger: false, DidTrigger: false, Confidence: "high"})
+				}
+				for i := 0; i < 2; i++ {
+					r = append(r, TriggerResult{ShouldTrigger: false, DidTrigger: false, Confidence: "medium"})
+				}
+				return r
+			}(),
+			// FN count = 8 (not 7), TN count = 8 (not 7)
+			// Weighted: fn_w=7.0, tn_w=7.0 → accuracy = 7.0/14.0 = 0.5
+			want: &TriggerMetrics{
+				TP: 0, FP: 0, TN: 8, FN: 8,
+				Precision: 0.0, Recall: 0.0, F1: 0.0, Accuracy: 0.5,
 			},
 		},
 	}


### PR DESCRIPTION
## Fixes

### #164 — install.sh fails on macOS
The script used `sha256sum` which doesn't exist on macOS. Now prioritizes `shasum -a 256` (native macOS), falls back to `sha256sum`, and errors if neither is available.

### #184 — Trigger test result values off by 1
`ComputeTriggerMetrics` was using confidence-weighted sums for integer TP/FP/TN/FN counts. Medium-confidence prompts (weight 0.5) caused counts to be fractional — e.g., 6 high + 2 medium = 7.0 instead of 8. Fix separates integer counts (always whole) from weighted precision/recall/F1.

Closes #164
Closes #184

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>