### PR TITLE
fix: diff grader reads post-execution workspace files

### DIFF
--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -256,6 +256,11 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 
 	duration := time.Since(start)
 
+	// Capture workspace files while they are still in post-execution state.
+	// The deferred session.Disconnect() may modify or restore workspace files,
+	// so we snapshot them now to guarantee graders see the agent's changes.
+	workspaceFiles := captureWorkspaceFiles(workspaceDir)
+
 	// Build response
 	resp := &ExecutionResponse{
 		FinalOutput:      joinStrings(eventsCollector.OutputParts()),
@@ -267,6 +272,7 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 		ErrorMsg:         errMsg,
 		Success:          err == nil,
 		WorkspaceDir:     workspaceDir,
+		WorkspaceFiles:   workspaceFiles,
 		SessionID:        sessionID,
 		Usage:            usageCollector.UsageStats(),
 	}
@@ -407,6 +413,36 @@ func (e *CopilotEngine) setupWorkspace(resources []ResourceFile) (string, error)
 	}
 
 	return workspaceDir, nil
+}
+
+// captureWorkspaceFiles reads all files from the workspace directory into memory,
+// preserving the post-execution state. This is called before session.Disconnect()
+// to ensure graders see the agent's modifications even if the SDK restores the
+// workspace to its pre-execution state during disconnect.
+// Keys are forward-slash-separated paths relative to dir for cross-platform consistency.
+func captureWorkspaceFiles(dir string) map[string][]byte {
+	if dir == "" {
+		return nil
+	}
+
+	files := make(map[string][]byte)
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		// Normalize to forward slashes so map keys match eval YAML paths on all platforms.
+		files[filepath.ToSlash(rel)] = content
+		return nil
+	})
+	return files
 }
 
 func joinStrings(parts []string) string {

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -75,8 +75,9 @@ type ExecutionResponse struct {
 	ToolCalls        []models.ToolCall
 	ErrorMsg         string
 	Success          bool
-	WorkspaceDir     string // Path to workspace directory (for file grading)
-	SessionID        string // Copilot session ID
+	WorkspaceDir     string            // Path to workspace directory (for file grading)
+	WorkspaceFiles   map[string][]byte // Post-execution workspace file contents captured before session disconnect
+	SessionID        string            // Copilot session ID
 	Usage            *models.UsageStats
 }
 

--- a/internal/execution/mock.go
+++ b/internal/execution/mock.go
@@ -73,13 +73,14 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 	}
 
 	resp := &ExecutionResponse{
-		FinalOutput:  output,
-		Events:       []copilot.SessionEvent{},
-		ModelID:      m.modelID,
-		DurationMs:   time.Since(start).Milliseconds(),
-		ToolCalls:    []models.ToolCall{},
-		Success:      true,
-		WorkspaceDir: m.workspace,
+		FinalOutput:    output,
+		Events:         []copilot.SessionEvent{},
+		ModelID:        m.modelID,
+		DurationMs:     time.Since(start).Milliseconds(),
+		ToolCalls:      []models.ToolCall{},
+		Success:        true,
+		WorkspaceDir:   m.workspace,
+		WorkspaceFiles: captureWorkspaceFiles(m.workspace),
 	}
 
 	return resp, nil

--- a/internal/execution/workspace_test.go
+++ b/internal/execution/workspace_test.go
@@ -52,3 +52,35 @@ func TestSetupWorkspaceResources_EmptyWorkspace(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "escapes workspace")
 }
+
+func TestCaptureWorkspaceFiles_CapturesAllFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "root.txt"), []byte("root content"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "nested.txt"), []byte("nested content"), 0o644))
+
+	files := captureWorkspaceFiles(dir)
+	require.Len(t, files, 2)
+	assert.Equal(t, "root content", string(files["root.txt"]))
+	assert.Equal(t, "nested content", string(files["sub/nested.txt"]))
+}
+
+func TestCaptureWorkspaceFiles_EmptyDir(t *testing.T) {
+	files := captureWorkspaceFiles(t.TempDir())
+	assert.Empty(t, files)
+}
+
+func TestCaptureWorkspaceFiles_EmptyString(t *testing.T) {
+	files := captureWorkspaceFiles("")
+	assert.Nil(t, files)
+}
+
+func TestCaptureWorkspaceFiles_UsesForwardSlashes(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "c.txt"), []byte("deep"), 0o644))
+
+	files := captureWorkspaceFiles(dir)
+	_, ok := files["a/b/c.txt"]
+	assert.True(t, ok, "keys should use forward slashes regardless of OS")
+}

--- a/internal/graders/diff_grader.go
+++ b/internal/graders/diff_grader.go
@@ -19,6 +19,7 @@ type diffGrader struct {
 	expectedFiles   []models.DiffExpectedFileParameters
 	contextDir      string
 	updateSnapshots bool
+	workspaceFiles  map[string][]byte // captured post-execution file contents
 }
 
 // SnapshotUpdate describes snapshot file changes performed by the diff grader.
@@ -65,7 +66,7 @@ func (dg *diffGrader) Kind() models.GraderKind { return models.GraderKindDiff }
 func (dg *diffGrader) Grade(ctx context.Context, gradingContext *Context) (*models.GraderResults, error) {
 	return measureTime(func() (*models.GraderResults, error) {
 		workspaceDir := gradingContext.WorkspaceDir
-		if workspaceDir == "" {
+		if workspaceDir == "" && len(gradingContext.WorkspaceFiles) == 0 {
 			return &models.GraderResults{
 				Name:     dg.name,
 				Type:     models.GraderKindDiff,
@@ -75,8 +76,12 @@ func (dg *diffGrader) Grade(ctx context.Context, gradingContext *Context) (*mode
 			}, nil
 		}
 
-		if err := dg.validateAllPaths(workspaceDir); err != nil {
-			return nil, err
+		dg.workspaceFiles = gradingContext.WorkspaceFiles
+
+		if workspaceDir != "" {
+			if err := dg.validateAllPaths(workspaceDir); err != nil {
+				return nil, err
+			}
 		}
 
 		var failures []string
@@ -97,14 +102,12 @@ func (dg *diffGrader) Grade(ctx context.Context, gradingContext *Context) (*mode
 func (dg *diffGrader) checkExpectedFile(workspaceDir string, ef models.DiffExpectedFileParameters) ([]string, *SnapshotUpdate) {
 	var failures []string
 
-	fullPath := filepath.Join(workspaceDir, ef.Path)
-	actualContent, err := os.ReadFile(fullPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			failures = append(failures, fmt.Sprintf("Expected file not found in workspace: %s", ef.Path))
-		} else {
-			failures = append(failures, fmt.Sprintf("Failed to read workspace file %s: %v", ef.Path, err))
-		}
+	// Prefer captured workspace files (post-execution snapshot) over the filesystem.
+	// The workspace directory may have been modified after the session disconnected,
+	// so captured files represent the true post-execution state.
+	actualContent, found := dg.readWorkspaceFile(workspaceDir, ef.Path)
+	if !found {
+		failures = append(failures, fmt.Sprintf("Expected file not found in workspace: %s", ef.Path))
 		// Count all sub-checks as failures when file is unreadable
 		if ef.Snapshot != "" {
 			failures = append(failures, fmt.Sprintf("Snapshot comparison skipped (file not found): %s", ef.Path))
@@ -127,6 +130,32 @@ func (dg *diffGrader) checkExpectedFile(workspaceDir string, ef models.DiffExpec
 	}
 
 	return failures, update
+}
+
+// readWorkspaceFile returns the content of a workspace file, preferring captured
+// post-execution files over the filesystem. Returns (content, true) on success or
+// (nil, false) when the file is not found.
+func (dg *diffGrader) readWorkspaceFile(workspaceDir string, filePath string) ([]byte, bool) {
+	normalizedPath := filepath.ToSlash(filePath)
+
+	// Prefer captured workspace files — they reflect post-execution state
+	// even if session disconnect modified the on-disk workspace.
+	if dg.workspaceFiles != nil {
+		if content, ok := dg.workspaceFiles[normalizedPath]; ok {
+			return content, true
+		}
+	}
+
+	// Fall back to reading from the workspace directory on disk.
+	if workspaceDir != "" {
+		fullPath := filepath.Join(workspaceDir, filePath)
+		content, err := os.ReadFile(fullPath)
+		if err == nil {
+			return content, true
+		}
+	}
+
+	return nil, false
 }
 
 // checkSnapshot compares workspace file content against the expected snapshot file.

--- a/internal/graders/diff_grader_test.go
+++ b/internal/graders/diff_grader_test.go
@@ -147,3 +147,124 @@ func TestDiffGrader_UpdateSnapshots_BlocksPathTraversal(t *testing.T) {
 	_, statErr := os.Stat(outsideSnapshot)
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
 }
+
+// TestDiffGrader_WorkspaceFiles_PrefersCapturedOverFilesystem verifies that the diff grader
+// reads from captured WorkspaceFiles (post-execution snapshot) instead of the on-disk
+// workspace. This is the core fix for #165: after session.Disconnect(), the workspace
+// filesystem may revert to pre-execution state, but captured files retain agent changes.
+func TestDiffGrader_WorkspaceFiles_PrefersCapturedOverFilesystem(t *testing.T) {
+	// Workspace dir has the OLD (pre-execution) content, simulating
+	// what happens when session.Disconnect() restores the workspace.
+	workspaceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workspaceDir, "api-version.ts"),
+		[]byte("// original file without preview version"),
+		0o644,
+	))
+
+	// Captured files have the POST-execution content — the agent's actual changes.
+	capturedFiles := map[string][]byte{
+		"api-version.ts": []byte("export const previewVersion = \"@previewVersion\";\nconst versions = {\n  v2025-05-04-preview: \"2025-05-04-preview\"\n};\n"),
+	}
+
+	grader, err := NewDiffGrader("diff", models.DiffGraderParameters{
+		ExpectedFiles: []models.DiffExpectedFileParameters{
+			{
+				Path: "api-version.ts",
+				Contains: []string{
+					"+@previewVersion",
+					`+v2025-05-04-preview: "2025-05-04-preview"`,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := grader.Grade(context.Background(), &Context{
+		WorkspaceDir:   workspaceDir,
+		WorkspaceFiles: capturedFiles,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Passed, "grader should use captured files, not reverted filesystem: %s", result.Feedback)
+	assert.Equal(t, 1.0, result.Score)
+}
+
+// TestDiffGrader_WorkspaceFiles_FallsBackToFilesystem verifies that when no captured
+// files are provided (legacy behavior), the grader still reads from the workspace
+// directory on disk.
+func TestDiffGrader_WorkspaceFiles_FallsBackToFilesystem(t *testing.T) {
+	workspaceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workspaceDir, "result.txt"),
+		[]byte("hello world"),
+		0o644,
+	))
+
+	grader, err := NewDiffGrader("diff", models.DiffGraderParameters{
+		ExpectedFiles: []models.DiffExpectedFileParameters{
+			{
+				Path:     "result.txt",
+				Contains: []string{"+hello world"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// No WorkspaceFiles → should fall back to filesystem
+	result, err := grader.Grade(context.Background(), &Context{
+		WorkspaceDir: workspaceDir,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+	assert.Equal(t, 1.0, result.Score)
+}
+
+// TestDiffGrader_WorkspaceFiles_MissingFragmentFails verifies that when captured files
+// exist but don't contain the expected fragment, the grader correctly fails.
+func TestDiffGrader_WorkspaceFiles_MissingFragmentFails(t *testing.T) {
+	capturedFiles := map[string][]byte{
+		"config.yaml": []byte("key: old_value\n"),
+	}
+
+	grader, err := NewDiffGrader("diff", models.DiffGraderParameters{
+		ExpectedFiles: []models.DiffExpectedFileParameters{
+			{
+				Path:     "config.yaml",
+				Contains: []string{"+key: new_value"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := grader.Grade(context.Background(), &Context{
+		WorkspaceDir:   "", // no workspace dir
+		WorkspaceFiles: capturedFiles,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.Passed)
+	assert.Contains(t, result.Feedback, "missing expected fragment")
+}
+
+// TestDiffGrader_WorkspaceFiles_FileNotInCapturedOrDisk ensures proper failure
+// when a file exists in neither captured files nor on disk.
+func TestDiffGrader_WorkspaceFiles_FileNotInCapturedOrDisk(t *testing.T) {
+	workspaceDir := t.TempDir()
+
+	grader, err := NewDiffGrader("diff", models.DiffGraderParameters{
+		ExpectedFiles: []models.DiffExpectedFileParameters{
+			{
+				Path:     "missing.txt",
+				Contains: []string{"+something"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := grader.Grade(context.Background(), &Context{
+		WorkspaceDir:   workspaceDir,
+		WorkspaceFiles: map[string][]byte{},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.Passed)
+	assert.Contains(t, result.Feedback, "not found")
+}

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -36,6 +36,11 @@ type Context struct {
 	// where you want to verify artifacts or outputs.
 	WorkspaceDir string
 
+	// WorkspaceFiles holds post-execution workspace file contents captured before the
+	// session disconnects. Graders should prefer these over reading from WorkspaceDir
+	// because the filesystem may be modified after session disconnect.
+	WorkspaceFiles map[string][]byte
+
 	// Session holds the session digest with tool call counts, token usage, and tools used.
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1245,6 +1245,7 @@ func (r *TestRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		DurationMS:       resp.DurationMs,
 		Metadata:         make(map[string]any),
 		WorkspaceDir:     resp.WorkspaceDir,
+		WorkspaceFiles:   resp.WorkspaceFiles,
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,


### PR DESCRIPTION
## Summary

Closes #165

The diff grader was reading workspace files from the filesystem **after** the Copilot SDK session had disconnected. Since `session.Disconnect()` may restore workspace files to their pre-execution state, the grader would see original file content instead of the agent's modifications — causing `contains` fragment checks to fail even though the agent made the correct changes.

## Root Cause

In `CopilotEngine.Execute()`, `session.Disconnect()` is deferred and fires when the function returns. By the time the runner calls `runGraders()`, the disconnect has already occurred. If the SDK restores/modifies workspace files during disconnect, the diff grader reads pre-execution content from the filesystem.

## Fix

1. **Capture workspace files in memory** before session disconnect via `captureWorkspaceFiles()` — walks the workspace dir and stores all file contents in a `map[string][]byte`
2. **Thread captured files** through `ExecutionResponse.WorkspaceFiles` → `graders.Context.WorkspaceFiles` → `diffGrader.workspaceFiles`
3. **Diff grader prefers captured files** over filesystem reads via `readWorkspaceFile()`, with forward-slash path normalization for cross-platform consistency
4. **Falls back to filesystem** when no captured files are available (backward compatible)

## Files Changed

| File | Change |
|------|--------|
| `internal/execution/engine.go` | Add `WorkspaceFiles` field to `ExecutionResponse` |
| `internal/execution/copilot.go` | Add `captureWorkspaceFiles()`, call before response |
| `internal/execution/mock.go` | Capture files in MockEngine for consistency |
| `internal/graders/grader.go` | Add `WorkspaceFiles` field to `Context` |
| `internal/orchestration/runner.go` | Pass `WorkspaceFiles` in `buildGraderContext()` |
| `internal/graders/diff_grader.go` | Add `readWorkspaceFile()` preferring captured files |
| `internal/execution/workspace_test.go` | Tests for `captureWorkspaceFiles()` |
| `internal/graders/diff_grader_test.go` | 4 new tests for workspace file preference behavior |

## Testing

- All existing tests pass (`go test ./internal/graders/... ./internal/execution/... ./internal/orchestration/...`)
- `go vet ./...` clean
- New tests verify: captured files preferred over filesystem, filesystem fallback, missing fragment detection, file-not-found handling

Working as Linus (Backend Developer)