### PR TITLE
fix: update EvalGet test fixture for code grader validation

### DIFF
--- a/internal/jsonrpc/handlers_test.go
+++ b/internal/jsonrpc/handlers_test.go
@@ -98,7 +98,7 @@ graders:
     name: check-output
     config:
       assertions:
-        - "hello"
+        - "len(output) > 0"
 tasks:
   - "tasks/*.yaml"
 `


### PR DESCRIPTION
Follow-up to #195. The TestHandler_EvalGet_Success fixture had a code grader without config. Added config.assertions to satisfy the new validation.