### PR TITLE
docs: add cache command, prompt mode, and complete schema reference

### DIFF
--- a/site/src/content/docs/guides/graders.mdx
+++ b/site/src/content/docs/guides/graders.mdx
@@ -325,6 +325,7 @@ Uses a second LLM to evaluate the agent's work. The judge LLM calls `set_waza_gr
 | `prompt`           | `string` | _(required)_ | Instructions for the judge LLM                       |
 | `model`            | `string` | _(required)_ | Model to use for judging                             |
 | `continue_session` | `bool`   | `false`      | Resume the agent's session (judge sees full context) |
+| `mode`             | `string` | `independent` | Judging mode: `independent` (standard) or `pairwise` (compare two, requires `--baseline`) |
 
 ### How it works
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -573,6 +573,45 @@ waza results compare run-id-1 run-id-2 --format json
 |------|-------------|
 | `--format` | Output format: `table` or `json` (default: `table`) |
 
+## waza cache
+
+Manage evaluation result cache.
+
+```bash
+waza cache clear [--cache-dir=.waza-cache]
+```
+
+### Subcommands
+
+#### waza cache clear
+
+Clear all cached evaluation results.
+
+The cache stores test outcomes to speed up repeated evaluations with the same inputs. Cached results are keyed by spec configuration, task definition, model, and fixture file contents.
+
+```bash
+waza cache clear
+waza cache clear --cache-dir /path/to/cache
+```
+
+##### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--cache-dir` | Cache directory to clear (default: `.waza-cache`) |
+
+### Examples
+
+```bash
+# Clear default cache
+waza cache clear
+
+# Clear custom cache directory
+waza cache clear --cache-dir .my-cache
+```
+
+---
+
 ## waza dev
 
 Improve skill compliance iteratively.

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -168,6 +168,89 @@ config:
   executor: copilot-sdk
 ```
 
+### max_attempts
+
+**Type:** integer  
+**Default:** 0
+
+Maximum retry attempts per task on failure. Set to 0 for no retries.
+
+```yaml
+config:
+  max_attempts: 3
+```
+
+### group_by
+
+**Type:** string  
+**Default:** (none)
+
+Group results by a field in the output (e.g., `tags`, `task_id`). Useful for organizing results when running many tasks.
+
+```yaml
+config:
+  group_by: tags
+```
+
+### fail_fast
+
+**Type:** boolean  
+**Default:** false
+
+Stop the entire evaluation run on the first task failure instead of continuing.
+
+```yaml
+config:
+  fail_fast: true
+```
+
+### skill_directories
+
+**Type:** list[string]  
+**Default:** `[]`
+
+Additional directories to search for skills beyond the default `skills/` directory.
+
+```yaml
+config:
+  skill_directories:
+    - ./custom-skills
+    - /opt/shared-skills
+```
+
+### required_skills
+
+**Type:** list[string]  
+**Default:** `[]`
+
+Skills that must be available before the evaluation runs. The run will fail if any required skill is not found.
+
+```yaml
+config:
+  required_skills:
+    - code-analyzer
+    - test-runner
+```
+
+### mcp_servers
+
+**Type:** object  
+**Default:** (none)
+
+MCP (Model Context Protocol) server configurations for this evaluation. Each key is a server name, and the value is its configuration.
+
+```yaml
+config:
+  mcp_servers:
+    filesystem:
+      command: /path/to/server
+      args: [--root, /data]
+    github:
+      url: http://localhost:3000
+```
+
+---
+
 ## graders Section
 
 List of validation rules. Used across tasks.


### PR DESCRIPTION
Fixes 3 documentation gaps in the site:

**Gap 1: Add `waza cache` to CLI reference**
- Added complete section for `waza cache clear` command
- Includes subcommand description, flags, and examples
- Based on actual command implementation in cmd/waza/cmd_cache.go

**Gap 2: Add `mode` field to Prompt grader docs**
- Added mode option to Prompt grader table in graders guide
- Documents: independent (default) and pairwise modes
- pairwise mode requires --baseline flag

**Gap 3: Complete schema.mdx config fields**
- Added 6 missing config fields: max_attempts, group_by, fail_fast, skill_directories, required_skills, mcp_servers
- Each field includes type, default, description, and YAML examples
- Cross-referenced with internal/models/spec.go Config struct

**Verification:**
- Site builds successfully with all 16 pages
- No markdown rendering errors
- All CLI reference pages display correctly