### PR TITLE
test: add coverage for suggest and jsonrpc packages

### DIFF
--- a/.squad/decisions/inbox/copilot-directive-20260421.md
+++ b/.squad/decisions/inbox/copilot-directive-20260421.md
@@ -1,0 +1,4 @@
+### 2026-04-21T11:25:00Z: User directive
+**By:** Shayne Boyer (via Copilot)
+**What:** Always answer Copilot review feedback and ensure CI passes before merging any PR. No exceptions.
+**Why:** User request — captured for team memory

--- a/internal/jsonrpc/handlers_extra_test.go
+++ b/internal/jsonrpc/handlers_extra_test.go
@@ -1,0 +1,482 @@
+package jsonrpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dialTCP(addr string) (net.Conn, error) {
+	return net.DialTimeout("tcp", addr, 2*time.Second)
+}
+
+// --- task.list success ---
+
+func TestHandler_TaskList_Success(t *testing.T) {
+	dir := t.TempDir()
+
+	evalContent := `name: task-list-eval
+skill: test-skill
+config:
+  trials_per_task: 1
+  timeout_seconds: 30
+  executor: mock
+  model: test
+tasks:
+  - "tasks/*.yaml"
+`
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte(evalContent), 0644))
+
+	tasksDir := filepath.Join(dir, "tasks")
+	require.NoError(t, os.MkdirAll(tasksDir, 0755))
+
+	taskContent := `id: task-alpha
+name: Alpha Task
+inputs:
+  prompt: "Do something"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "alpha.yaml"), []byte(taskContent), 0644))
+
+	server := newTestServer()
+	resp := rpcCall(t, server, "task.list", map[string]string{"path": evalPath})
+	assert.Nil(t, resp.Error)
+
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result TaskListResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.Len(t, result.Tasks, 1)
+	assert.Equal(t, "task-alpha", result.Tasks[0].ID)
+	assert.Equal(t, "Alpha Task", result.Tasks[0].Name)
+}
+
+func TestHandler_TaskList_MultipleTasks(t *testing.T) {
+	dir := t.TempDir()
+
+	evalContent := `name: multi-task-eval
+config:
+  trials_per_task: 1
+  timeout_seconds: 30
+  executor: mock
+  model: test
+tasks:
+  - "tasks/*.yaml"
+`
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte(evalContent), 0644))
+
+	tasksDir := filepath.Join(dir, "tasks")
+	require.NoError(t, os.MkdirAll(tasksDir, 0755))
+
+	for i, name := range []string{"alpha", "beta", "gamma"} {
+		upper := strings.ToUpper(name[:1]) + name[1:]
+		content := fmt.Sprintf("id: task-%s\nname: %s Task\ninputs:\n  prompt: \"task %d\"\n", name, upper, i)
+		require.NoError(t, os.WriteFile(filepath.Join(tasksDir, name+".yaml"), []byte(content), 0644))
+	}
+
+	server := newTestServer()
+	resp := rpcCall(t, server, "task.list", map[string]string{"path": evalPath})
+	assert.Nil(t, resp.Error)
+
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result TaskListResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.Len(t, result.Tasks, 3)
+}
+
+func TestHandler_TaskList_MissingPath(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "task.list", map[string]string{"path": ""})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+func TestHandler_TaskList_InvalidParams(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "task.list", "not an object")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+// --- task.get success ---
+
+func TestHandler_TaskGet_Success(t *testing.T) {
+	dir := t.TempDir()
+
+	evalContent := `name: task-get-eval
+config:
+  trials_per_task: 1
+  timeout_seconds: 30
+  executor: mock
+  model: test
+tasks:
+  - "tasks/*.yaml"
+`
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte(evalContent), 0644))
+
+	tasksDir := filepath.Join(dir, "tasks")
+	require.NoError(t, os.MkdirAll(tasksDir, 0755))
+
+	taskContent := `id: get-this-task
+name: Get This Task
+inputs:
+  prompt: "hello world"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "task1.yaml"), []byte(taskContent), 0644))
+
+	server := newTestServer()
+	resp := rpcCall(t, server, "task.get", map[string]string{
+		"path":    evalPath,
+		"task_id": "get-this-task",
+	})
+	assert.Nil(t, resp.Error)
+	require.NotNil(t, resp.Result)
+
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	// Result is a TestCase, check it has our task ID
+	assert.Contains(t, string(data), "get-this-task")
+}
+
+func TestHandler_TaskGet_NotFoundTask(t *testing.T) {
+	dir := t.TempDir()
+
+	evalContent := `name: task-get-eval
+config:
+  trials_per_task: 1
+  timeout_seconds: 30
+  executor: mock
+  model: test
+tasks:
+  - "tasks/*.yaml"
+`
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte(evalContent), 0644))
+
+	tasksDir := filepath.Join(dir, "tasks")
+	require.NoError(t, os.MkdirAll(tasksDir, 0755))
+
+	taskContent := `id: existing-task
+name: Existing Task
+inputs:
+  prompt: "hello"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "task.yaml"), []byte(taskContent), 0644))
+
+	server := newTestServer()
+	resp := rpcCall(t, server, "task.get", map[string]string{
+		"path":    evalPath,
+		"task_id": "nonexistent-task-id",
+	})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+func TestHandler_TaskGet_MissingTaskID(t *testing.T) {
+	dir := t.TempDir()
+
+	evalContent := `name: task-get-eval
+config:
+  trials_per_task: 1
+  timeout_seconds: 30
+  executor: mock
+  model: test
+tasks:
+  - "tasks/*.yaml"
+`
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte(evalContent), 0644))
+
+	server := newTestServer()
+	resp := rpcCall(t, server, "task.get", map[string]string{
+		"path":    evalPath,
+		"task_id": "",
+	})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+func TestHandler_TaskGet_EvalNotFound(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "task.get", map[string]string{
+		"path":    "/nonexistent/eval.yaml",
+		"task_id": "some-task",
+	})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeEvalNotFound, resp.Error.Code)
+}
+
+// --- run.cancel ---
+
+func TestHandler_RunCancel_Success(t *testing.T) {
+	dir := t.TempDir()
+	evalContent := `name: cancel-eval
+config:
+  trials_per_task: 1
+  timeout_seconds: 30
+  executor: mock
+  model: test
+tasks:
+  - "tasks/*.yaml"
+`
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte(evalContent), 0644))
+
+	registry := NewMethodRegistry()
+	hctx := NewHandlerContext()
+	RegisterHandlers(registry, hctx)
+	server := NewServer(registry, nil)
+
+	// Start a run — inject a "running" state manually to avoid timing issues
+	hctx.mu.Lock()
+	hctx.nextRunID++
+	runID := fmt.Sprintf("run-%d", hctx.nextRunID)
+	hctx.runs[runID] = &RunState{ID: runID, Status: "running"}
+	_, cancel := createTestCancel()
+	hctx.cancelFuncs[runID] = cancel
+	hctx.mu.Unlock()
+
+	// Cancel it
+	resp := rpcCall(t, server, "run.cancel", map[string]string{"run_id": runID})
+	assert.Nil(t, resp.Error)
+
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result RunCancelResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.True(t, result.Canceled)
+
+	// Verify status changed
+	hctx.mu.Lock()
+	state := hctx.runs[runID]
+	_, cancelExists := hctx.cancelFuncs[runID]
+	hctx.mu.Unlock()
+	assert.Equal(t, "canceled", state.Status)
+	assert.False(t, cancelExists, "cancel func should be cleaned up")
+}
+
+func TestHandler_RunCancel_AlreadyCompleted(t *testing.T) {
+	registry := NewMethodRegistry()
+	hctx := NewHandlerContext()
+	RegisterHandlers(registry, hctx)
+	server := NewServer(registry, nil)
+
+	// Manually inject a completed run
+	hctx.mu.Lock()
+	hctx.runs["run-done"] = &RunState{ID: "run-done", Status: "completed"}
+	hctx.mu.Unlock()
+
+	resp := rpcCall(t, server, "run.cancel", map[string]string{"run_id": "run-done"})
+	assert.Nil(t, resp.Error)
+
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result RunCancelResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.False(t, result.Canceled, "cannot cancel a completed run")
+}
+
+func TestHandler_RunCancel_MissingRunID(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "run.cancel", map[string]string{"run_id": ""})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+func TestHandler_RunCancel_InvalidParams(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "run.cancel", "not json")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+// --- eval.list edge cases ---
+
+func TestHandler_EvalList_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	server := newTestServer()
+	resp := rpcCall(t, server, "eval.list", map[string]string{"dir": dir})
+	assert.Nil(t, resp.Error)
+
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result EvalListResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.Nil(t, result.Evals)
+}
+
+// --- eval.get edge cases ---
+
+func TestHandler_EvalGet_MissingPath(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "eval.get", map[string]string{"path": ""})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+func TestHandler_EvalGet_InvalidParams(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "eval.get", "not an object")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+// --- eval.validate edge cases ---
+
+func TestHandler_EvalValidate_MissingPath(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "eval.validate", map[string]string{"path": ""})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+func TestHandler_EvalValidate_NotFound(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "eval.validate", map[string]string{"path": "/nonexistent/eval.yaml"})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeEvalNotFound, resp.Error.Code)
+}
+
+func TestHandler_EvalValidate_MalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte("not: [valid: yaml: ::::"), 0644))
+
+	server := newTestServer()
+	resp := rpcCall(t, server, "eval.validate", map[string]string{"path": evalPath})
+	assert.Nil(t, resp.Error)
+
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result EvalValidateResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.False(t, result.Valid)
+	assert.NotEmpty(t, result.Errors)
+	// Should contain YAML syntax error
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "YAML syntax") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected YAML syntax error, got: %v", result.Errors)
+}
+
+// --- eval.run edge cases ---
+
+func TestHandler_EvalRun_MissingPath(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "eval.run", map[string]string{"path": ""})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+func TestHandler_EvalRun_InvalidParams(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "eval.run", "not json")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+// --- run.status edge cases ---
+
+func TestHandler_RunStatus_MissingRunID(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "run.status", map[string]string{"run_id": ""})
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+func TestHandler_RunStatus_InvalidParams(t *testing.T) {
+	server := newTestServer()
+	resp := rpcCall(t, server, "run.status", "bad params")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, CodeInvalidParams, resp.Error.Code)
+}
+
+// --- TCP transport ---
+
+func TestTCPListener_StartAndClose(t *testing.T) {
+	registry := NewMethodRegistry()
+	registry.Register("ping", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return map[string]string{"pong": "ok"}, nil
+	})
+	server := NewServer(registry, nil)
+
+	listener, err := NewTCPListener("127.0.0.1:0", server)
+	require.NoError(t, err)
+	require.NotNil(t, listener)
+	require.NotNil(t, listener.Addr())
+
+	// Close should work without error
+	require.NoError(t, listener.Close())
+}
+
+func TestTCPListener_InvalidAddress(t *testing.T) {
+	registry := NewMethodRegistry()
+	server := NewServer(registry, nil)
+
+	_, err := NewTCPListener("invalid:address:too:many:colons:-1", server)
+	assert.Error(t, err)
+}
+
+func TestTCPListener_ServeAndQuery(t *testing.T) {
+	registry := NewMethodRegistry()
+	registry.Register("ping", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return map[string]string{"status": "ok"}, nil
+	})
+	server := NewServer(registry, nil)
+
+	listener, err := NewTCPListener("127.0.0.1:0", server)
+	require.NoError(t, err)
+
+	// Serve in background
+	go func() {
+		_ = listener.Serve()
+	}()
+	defer listener.Close() //nolint:errcheck
+
+	// Give server time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Connect and send a request
+	addr := listener.Addr().String()
+	conn, err := dialTCP(addr)
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	reqLine := `{"jsonrpc":"2.0","method":"ping","params":{},"id":1}` + "\n"
+	_, err = conn.Write([]byte(reqLine))
+	require.NoError(t, err)
+
+	// Read response
+	var out bytes.Buffer
+	buf := make([]byte, 4096)
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	n, err := conn.Read(buf)
+	require.NoError(t, err)
+	out.Write(buf[:n])
+
+	var resp Response
+	require.NoError(t, json.Unmarshal(out.Bytes(), &resp))
+	assert.Nil(t, resp.Error)
+	assert.Equal(t, "2.0", resp.JSONRPC)
+}
+
+func createTestCancel() (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}

--- a/internal/jsonrpc/handlers_extra_test.go
+++ b/internal/jsonrpc/handlers_extra_test.go
@@ -1,7 +1,7 @@
 package jsonrpc
 
 import (
-	"bytes"
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -450,10 +450,7 @@ func TestTCPListener_ServeAndQuery(t *testing.T) {
 	}()
 	defer listener.Close() //nolint:errcheck
 
-	// Give server time to start
-	time.Sleep(50 * time.Millisecond)
-
-	// Connect and send a request
+	// Connect and send a request — no sleep needed, listener is already active
 	addr := listener.Addr().String()
 	conn, err := dialTCP(addr)
 	require.NoError(t, err)
@@ -463,16 +460,14 @@ func TestTCPListener_ServeAndQuery(t *testing.T) {
 	_, err = conn.Write([]byte(reqLine))
 	require.NoError(t, err)
 
-	// Read response
-	var out bytes.Buffer
-	buf := make([]byte, 4096)
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
-	n, err := conn.Read(buf)
-	require.NoError(t, err)
-	out.Write(buf[:n])
+	// Read response line (newline-delimited JSON)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	scanner := bufio.NewScanner(conn)
+	require.True(t, scanner.Scan(), "expected response line")
+	require.NoError(t, scanner.Err())
 
 	var resp Response
-	require.NoError(t, json.Unmarshal(out.Bytes(), &resp))
+	require.NoError(t, json.Unmarshal(scanner.Bytes(), &resp))
 	assert.Nil(t, resp.Error)
 	assert.Equal(t, "2.0", resp.JSONRPC)
 }

--- a/internal/jsonrpc/methods_test.go
+++ b/internal/jsonrpc/methods_test.go
@@ -1,0 +1,174 @@
+package jsonrpc
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMethodRegistry_NewIsEmpty(t *testing.T) {
+	reg := NewMethodRegistry()
+	assert.Empty(t, reg.Methods())
+	assert.Nil(t, reg.Lookup("anything"))
+}
+
+func TestMethodRegistry_RegisterAndLookup(t *testing.T) {
+	reg := NewMethodRegistry()
+	handler := func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return "ok", nil
+	}
+	reg.Register("test.method", handler)
+
+	found := reg.Lookup("test.method")
+	require.NotNil(t, found)
+
+	// Verify handler works
+	result, err := found(context.Background(), nil)
+	assert.Nil(t, err)
+	assert.Equal(t, "ok", result)
+}
+
+func TestMethodRegistry_LookupMissing(t *testing.T) {
+	reg := NewMethodRegistry()
+	reg.Register("exists", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return nil, nil
+	})
+	assert.Nil(t, reg.Lookup("does.not.exist"))
+}
+
+func TestMethodRegistry_Methods_ReturnsList(t *testing.T) {
+	reg := NewMethodRegistry()
+	reg.Register("alpha", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return nil, nil
+	})
+	reg.Register("beta", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return nil, nil
+	})
+	reg.Register("gamma", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return nil, nil
+	})
+
+	methods := reg.Methods()
+	sort.Strings(methods)
+	assert.Equal(t, []string{"alpha", "beta", "gamma"}, methods)
+}
+
+func TestMethodRegistry_OverwriteHandler(t *testing.T) {
+	reg := NewMethodRegistry()
+	reg.Register("method", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return "first", nil
+	})
+	reg.Register("method", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return "second", nil
+	})
+
+	handler := reg.Lookup("method")
+	require.NotNil(t, handler)
+	result, _ := handler(context.Background(), nil)
+	assert.Equal(t, "second", result, "later registration should overwrite")
+}
+
+func TestMethodRegistry_EmptyMethodName(t *testing.T) {
+	reg := NewMethodRegistry()
+	reg.Register("", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return "empty", nil
+	})
+
+	handler := reg.Lookup("")
+	require.NotNil(t, handler)
+	result, _ := handler(context.Background(), nil)
+	assert.Equal(t, "empty", result)
+}
+
+func TestMethodRegistry_HandlerReturnsError(t *testing.T) {
+	reg := NewMethodRegistry()
+	reg.Register("fail", func(_ context.Context, _ json.RawMessage) (any, *Error) {
+		return nil, ErrInternalError("broke")
+	})
+
+	handler := reg.Lookup("fail")
+	require.NotNil(t, handler)
+	result, rpcErr := handler(context.Background(), nil)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, CodeInternalError, rpcErr.Code)
+}
+
+func TestMethodRegistry_HandlerReceivesParams(t *testing.T) {
+	reg := NewMethodRegistry()
+	reg.Register("echo", func(_ context.Context, params json.RawMessage) (any, *Error) {
+		var p map[string]string
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, ErrInvalidParams(err.Error())
+		}
+		return p, nil
+	})
+
+	handler := reg.Lookup("echo")
+	require.NotNil(t, handler)
+
+	params, _ := json.Marshal(map[string]string{"key": "value"})
+	result, rpcErr := handler(context.Background(), params)
+	assert.Nil(t, rpcErr)
+	m, ok := result.(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "value", m["key"])
+}
+
+func TestMethodRegistry_HandlerReceivesMalformedParams(t *testing.T) {
+	reg := NewMethodRegistry()
+	reg.Register("strict", func(_ context.Context, params json.RawMessage) (any, *Error) {
+		var p struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, ErrInvalidParams(err.Error())
+		}
+		return p.Name, nil
+	})
+
+	handler := reg.Lookup("strict")
+	require.NotNil(t, handler)
+
+	result, rpcErr := handler(context.Background(), json.RawMessage(`not json`))
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, CodeInvalidParams, rpcErr.Code)
+}
+
+func TestMethodRegistry_MultipleRegistrations(t *testing.T) {
+	reg := NewMethodRegistry()
+
+	// Register many methods to verify map scaling
+	for i := 0; i < 50; i++ {
+		name := "method." + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		reg.Register(name, func(_ context.Context, _ json.RawMessage) (any, *Error) {
+			return nil, nil
+		})
+	}
+
+	methods := reg.Methods()
+	assert.Len(t, methods, 50)
+}
+
+func TestRegisterHandlers_AllMethodsPresent(t *testing.T) {
+	reg := NewMethodRegistry()
+	hctx := NewHandlerContext()
+	RegisterHandlers(reg, hctx)
+
+	expected := []string{
+		"eval.list", "eval.get", "eval.validate", "eval.run",
+		"task.list", "task.get", "run.status", "run.cancel",
+	}
+
+	for _, method := range expected {
+		assert.NotNil(t, reg.Lookup(method), "method %q should be registered", method)
+	}
+
+	// No extra methods
+	assert.Len(t, reg.Methods(), len(expected))
+}

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -1,0 +1,570 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/waza/internal/jsonrpc"
+)
+
+// ========================================
+// server.go — additional coverage
+// ========================================
+
+func TestNewServer_NilLogger(t *testing.T) {
+	srv := NewServer(nil)
+	if srv == nil {
+		t.Fatal("NewServer(nil) returned nil")
+	}
+	// Should use default logger without panicking.
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		Params:  json.RawMessage(`{}`),
+		ID:      json.RawMessage(`1`),
+	}
+	resp := srv.HandleRequest(context.Background(), req)
+	if resp == nil || resp.Error != nil {
+		t.Errorf("HandleRequest failed with nil logger: %v", resp)
+	}
+}
+
+func TestHandleNotificationsInitialized(t *testing.T) {
+	srv := NewServer(slog.Default())
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+		Params:  json.RawMessage(`{}`),
+		ID:      json.RawMessage(`1`),
+	}
+	resp := srv.HandleRequest(context.Background(), req)
+	if resp != nil {
+		t.Error("expected nil response for notifications/initialized")
+	}
+}
+
+func TestHandleToolsCall_InvalidParams(t *testing.T) {
+	srv := NewServer(slog.Default())
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  json.RawMessage(`not valid json`),
+		ID:      json.RawMessage(`1`),
+	}
+	resp := srv.HandleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for invalid params")
+	}
+	if resp.Error.Code != jsonrpc.CodeInvalidParams {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, jsonrpc.CodeInvalidParams)
+	}
+}
+
+func TestHandleToolsCall_TaskList(t *testing.T) {
+	srv := NewServer(slog.Default())
+	dir := t.TempDir()
+	args, _ := json.Marshal(map[string]string{"eval_path": filepath.Join(dir, "nonexistent.yaml")})
+	params, _ := json.Marshal(toolsCallParams{Name: "waza_task_list", Arguments: args})
+
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  params,
+		ID:      json.RawMessage(`10`),
+	}
+
+	resp := srv.HandleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	// Should get an error result (eval file doesn't exist) but not a protocol error.
+	data, _ := json.Marshal(resp.Result)
+	var result toolsCallResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	// The tool call should return isError=true since the file doesn't exist.
+	if !result.IsError {
+		t.Log("task_list on nonexistent file returned success (may return empty list)")
+	}
+}
+
+func TestHandleToolsCall_TaskList_InvalidArgs(t *testing.T) {
+	srv := NewServer(slog.Default())
+	// Pass a JSON string where an object is expected — callTaskList's unmarshal will fail.
+	params := json.RawMessage(`{"name":"waza_task_list","arguments":"not an object"}`)
+
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  params,
+		ID:      json.RawMessage(`11`),
+	}
+
+	resp := srv.HandleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	data, _ := json.Marshal(resp.Result)
+	var result toolsCallResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true for invalid args")
+	}
+}
+
+func TestHandleToolsCall_NilArguments(t *testing.T) {
+	srv := NewServer(slog.Default())
+	// callHandler should handle nil args by converting to {}.
+	params, _ := json.Marshal(toolsCallParams{Name: "waza_eval_list", Arguments: nil})
+
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  params,
+		ID:      json.RawMessage(`12`),
+	}
+
+	resp := srv.HandleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected protocol error: %v", resp.Error)
+	}
+}
+
+func TestDispatchTool_AllNames(t *testing.T) {
+	srv := NewServer(slog.Default())
+	ctx := context.Background()
+
+	// Test that all tool dispatch names are recognized (don't return "unknown tool").
+	toolNames := []string{
+		"waza_eval_list",
+		"waza_eval_get",
+		"waza_eval_validate",
+		"waza_eval_run",
+		"waza_task_list",
+		"waza_run_status",
+		"waza_run_cancel",
+		"waza_results_summary",
+		"waza_results_runs",
+		"waza_skill_check",
+	}
+
+	for _, name := range toolNames {
+		_, rpcErr := srv.dispatchTool(ctx, name, json.RawMessage(`{}`))
+		if rpcErr != nil && rpcErr.Code == jsonrpc.CodeMethodNotFound && strings.Contains(rpcErr.Message, "unknown tool") {
+			t.Errorf("dispatchTool(%q) returned unknown tool error", name)
+		}
+	}
+}
+
+func TestDispatchTool_UnknownTool(t *testing.T) {
+	srv := NewServer(slog.Default())
+	_, rpcErr := srv.dispatchTool(context.Background(), "nonexistent_tool", json.RawMessage(`{}`))
+	if rpcErr == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if rpcErr.Code != jsonrpc.CodeMethodNotFound {
+		t.Errorf("error code = %d, want %d", rpcErr.Code, jsonrpc.CodeMethodNotFound)
+	}
+}
+
+// ========================================
+// tools.go — ToolsDef coverage
+// ========================================
+
+func TestToolsDef_Count(t *testing.T) {
+	tools := ToolsDef()
+	if len(tools) != 10 {
+		t.Errorf("ToolsDef() returned %d tools, want 10", len(tools))
+	}
+}
+
+func TestToolsDef_ValidJSON(t *testing.T) {
+	tools := ToolsDef()
+	for _, tool := range tools {
+		if tool.Name == "" {
+			t.Error("tool has empty name")
+		}
+		if tool.Description == "" {
+			t.Errorf("tool %q has empty description", tool.Name)
+		}
+		// Verify InputSchema is valid JSON.
+		var schema map[string]any
+		if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+			t.Errorf("tool %q has invalid InputSchema: %v", tool.Name, err)
+		}
+	}
+}
+
+func TestToolsDef_UniqueNames(t *testing.T) {
+	tools := ToolsDef()
+	seen := make(map[string]bool)
+	for _, tool := range tools {
+		if seen[tool.Name] {
+			t.Errorf("duplicate tool name: %s", tool.Name)
+		}
+		seen[tool.Name] = true
+	}
+}
+
+// ========================================
+// server.go — skill check with files
+// ========================================
+
+func TestSkillCheck_WithSkillMD(t *testing.T) {
+	srv := NewServer(slog.Default())
+	dir := t.TempDir()
+
+	// Create SKILL.md.
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# My Skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	args, _ := json.Marshal(map[string]string{"skill_path": dir})
+	params, _ := json.Marshal(toolsCallParams{Name: "waza_skill_check", Arguments: args})
+
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  params,
+		ID:      json.RawMessage(`20`),
+	}
+
+	resp := srv.HandleRequest(context.Background(), req)
+	data, _ := json.Marshal(resp.Result)
+	var result toolsCallResult
+	_ = json.Unmarshal(data, &result)
+
+	var check skillCheckResult
+	_ = json.Unmarshal([]byte(result.Content[0].Text), &check)
+
+	if !check.HasSkill {
+		t.Error("expected HasSkill=true")
+	}
+	if check.HasEval {
+		t.Error("expected HasEval=false (no eval.yaml)")
+	}
+}
+
+func TestSkillCheck_WithBothFiles(t *testing.T) {
+	srv := NewServer(slog.Default())
+	dir := t.TempDir()
+
+	// Create SKILL.md and eval.yaml.
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Skill\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "eval.yaml"), []byte("name: test\n"), 0o644)
+
+	args, _ := json.Marshal(map[string]string{"skill_path": dir})
+	params, _ := json.Marshal(toolsCallParams{Name: "waza_skill_check", Arguments: args})
+
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  params,
+		ID:      json.RawMessage(`21`),
+	}
+
+	resp := srv.HandleRequest(context.Background(), req)
+	data, _ := json.Marshal(resp.Result)
+	var result toolsCallResult
+	_ = json.Unmarshal(data, &result)
+
+	var check skillCheckResult
+	_ = json.Unmarshal([]byte(result.Content[0].Text), &check)
+
+	if !check.HasSkill {
+		t.Error("expected HasSkill=true")
+	}
+	if !check.HasEval {
+		t.Error("expected HasEval=true")
+	}
+	if !strings.Contains(check.Message, "ready for deeper check") {
+		t.Errorf("unexpected message: %q", check.Message)
+	}
+}
+
+func TestSkillCheck_WithEvalYml(t *testing.T) {
+	srv := NewServer(slog.Default())
+	dir := t.TempDir()
+
+	// Create eval.yml (not .yaml) — should still be detected.
+	os.WriteFile(filepath.Join(dir, "eval.yml"), []byte("name: test\n"), 0o644)
+
+	args, _ := json.Marshal(map[string]string{"skill_path": dir})
+	params, _ := json.Marshal(toolsCallParams{Name: "waza_skill_check", Arguments: args})
+
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  params,
+		ID:      json.RawMessage(`22`),
+	}
+
+	resp := srv.HandleRequest(context.Background(), req)
+	data, _ := json.Marshal(resp.Result)
+	var result toolsCallResult
+	_ = json.Unmarshal(data, &result)
+
+	var check skillCheckResult
+	_ = json.Unmarshal([]byte(result.Content[0].Text), &check)
+
+	if !check.HasEval {
+		t.Error("expected HasEval=true for eval.yml")
+	}
+}
+
+func TestSkillCheck_EmptySkillPath(t *testing.T) {
+	srv := NewServer(slog.Default())
+	args, _ := json.Marshal(map[string]string{"skill_path": ""})
+	params, _ := json.Marshal(toolsCallParams{Name: "waza_skill_check", Arguments: args})
+
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  params,
+		ID:      json.RawMessage(`23`),
+	}
+
+	resp := srv.HandleRequest(context.Background(), req)
+	data, _ := json.Marshal(resp.Result)
+	var result toolsCallResult
+	_ = json.Unmarshal(data, &result)
+	if !result.IsError {
+		t.Error("expected isError=true for empty skill_path")
+	}
+}
+
+// ========================================
+// quickLinkCheck
+// ========================================
+
+func TestQuickLinkCheck_NoBrokenLinks(t *testing.T) {
+	dir := t.TempDir()
+	// Create SKILL.md with links that exist.
+	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hi"), 0o644)
+	content := "# Skill\n[readme](readme.txt)\n[external](https://example.com)\n"
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+
+	broken, issues := quickLinkCheck(dir)
+	if broken != 0 {
+		t.Errorf("broken = %d, want 0; issues: %v", broken, issues)
+	}
+}
+
+func TestQuickLinkCheck_BrokenLink(t *testing.T) {
+	dir := t.TempDir()
+	content := "# Skill\n[missing](nonexistent.txt)\n"
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+
+	broken, issues := quickLinkCheck(dir)
+	if broken != 1 {
+		t.Errorf("broken = %d, want 1; issues: %v", broken, issues)
+	}
+	if len(issues) != 1 || !strings.Contains(issues[0], "nonexistent.txt") {
+		t.Errorf("issues = %v, want mention of nonexistent.txt", issues)
+	}
+}
+
+func TestQuickLinkCheck_SkipsProtocols(t *testing.T) {
+	dir := t.TempDir()
+	content := `# Skill
+[http](http://example.com)
+[https](https://example.com)
+[mailto](mailto:test@example.com)
+[mdc](mdc:something)
+[anchor](#section)
+`
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+
+	broken, _ := quickLinkCheck(dir)
+	if broken != 0 {
+		t.Errorf("broken = %d, want 0 (all protocols should be skipped)", broken)
+	}
+}
+
+func TestQuickLinkCheck_LinkWithAnchor(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "guide.md"), []byte("# Guide"), 0o644)
+	content := "# Skill\n[guide section](guide.md#section)\n"
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+
+	broken, _ := quickLinkCheck(dir)
+	if broken != 0 {
+		t.Errorf("broken = %d, want 0 (file part of link exists)", broken)
+	}
+}
+
+func TestQuickLinkCheck_NoSkillMD(t *testing.T) {
+	dir := t.TempDir()
+	broken, issues := quickLinkCheck(dir)
+	if broken != 0 || issues != nil {
+		t.Errorf("expected 0 broken and nil issues for missing SKILL.md")
+	}
+}
+
+// ========================================
+// resolveDir
+// ========================================
+
+func TestResolveDir_NonEmpty(t *testing.T) {
+	got := resolveDir("/some/dir")
+	if got != "/some/dir" {
+		t.Errorf("resolveDir(/some/dir) = %q", got)
+	}
+}
+
+func TestResolveDir_Empty(t *testing.T) {
+	got := resolveDir("")
+	if got == "" {
+		t.Error("resolveDir(\"\") returned empty")
+	}
+	// Should return CWD or ".".
+	wd, _ := os.Getwd()
+	if got != wd && got != "." {
+		t.Errorf("resolveDir(\"\") = %q, want CWD or \".\"", got)
+	}
+}
+
+// ========================================
+// version
+// ========================================
+
+func TestVersion_Fallback(t *testing.T) {
+	v := version()
+	// Should return a non-empty string. If no version.txt found, returns "0.0.0-dev".
+	if v == "" {
+		t.Error("version() returned empty string")
+	}
+}
+
+// ========================================
+// stdio.go — additional coverage
+// ========================================
+
+func TestServeStdio_ParseError(t *testing.T) {
+	// Send invalid JSON — should get parse error response then exit.
+	input := strings.NewReader("this is not json\n")
+	var output bytes.Buffer
+
+	ServeStdio(context.Background(), input, &output, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	out := output.String()
+	if out == "" {
+		t.Fatal("expected parse error response, got empty")
+	}
+	var resp jsonrpc.Response
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error in response")
+	}
+	if resp.Error.Code != jsonrpc.CodeParseError {
+		t.Errorf("error code = %d, want %d (parse error)", resp.Error.Code, jsonrpc.CodeParseError)
+	}
+}
+
+func TestServeStdio_EmptyInput(t *testing.T) {
+	input := strings.NewReader("")
+	var output bytes.Buffer
+
+	ServeStdio(context.Background(), input, &output, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if output.Len() != 0 {
+		t.Errorf("expected no output for empty input (EOF), got: %s", output.String())
+	}
+}
+
+func TestServeStdio_MultipleRequests(t *testing.T) {
+	// Send initialize, notification, tools/list, then EOF.
+	lines := []string{
+		`{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`,
+		`{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}`,
+		`{"jsonrpc":"2.0","method":"unknown/method","params":{},"id":3}`,
+	}
+	input := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var output bytes.Buffer
+
+	ServeStdio(context.Background(), input, &output, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Should have 3 responses: initialize, tools/list, unknown/method.
+	// Notification produces no response.
+	respLines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(respLines) != 3 {
+		t.Fatalf("expected 3 response lines, got %d: %s", len(respLines), output.String())
+	}
+}
+
+func TestHasIDField(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"with id", `{"jsonrpc":"2.0","method":"test","id":1}`, true},
+		{"without id", `{"jsonrpc":"2.0","method":"test"}`, false},
+		{"null id", `{"jsonrpc":"2.0","method":"test","id":null}`, true},
+		{"string id", `{"jsonrpc":"2.0","method":"test","id":"abc"}`, true},
+		{"invalid json", `not json`, false},
+		{"empty object", `{}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasIDField([]byte(tt.raw))
+			if got != tt.want {
+				t.Errorf("hasIDField(%s) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// ========================================
+// Initialize response structure validation
+// ========================================
+
+func TestInitialize_ResponseStructure(t *testing.T) {
+	srv := NewServer(slog.Default())
+	req := &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		Params:  json.RawMessage(`{}`),
+		ID:      json.RawMessage(`99`),
+	}
+
+	resp := srv.HandleRequest(context.Background(), req)
+	if resp.JSONRPC != "2.0" {
+		t.Errorf("JSONRPC = %q, want 2.0", resp.JSONRPC)
+	}
+
+	// Verify ID is preserved.
+	if string(resp.ID) != "99" {
+		t.Errorf("ID = %s, want 99", string(resp.ID))
+	}
+
+	data, _ := json.Marshal(resp.Result)
+	var result initializeResult
+	_ = json.Unmarshal(data, &result)
+
+	if result.ProtocolVersion != "2024-11-05" {
+		t.Errorf("protocolVersion = %q", result.ProtocolVersion)
+	}
+	if result.ServerInfo.Name != "waza" {
+		t.Errorf("serverInfo.name = %q", result.ServerInfo.Name)
+	}
+}

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -266,8 +266,8 @@ func TestSkillCheck_WithBothFiles(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create SKILL.md and eval.yaml.
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Skill\n"), 0o644)
-	os.WriteFile(filepath.Join(dir, "eval.yaml"), []byte("name: test\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Skill\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "eval.yaml"), []byte("name: test\n"), 0o644)
 
 	args, _ := json.Marshal(map[string]string{"skill_path": dir})
 	params, _ := json.Marshal(toolsCallParams{Name: "waza_skill_check", Arguments: args})
@@ -303,7 +303,7 @@ func TestSkillCheck_WithEvalYml(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create eval.yml (not .yaml) — should still be detected.
-	os.WriteFile(filepath.Join(dir, "eval.yml"), []byte("name: test\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "eval.yml"), []byte("name: test\n"), 0o644)
 
 	args, _ := json.Marshal(map[string]string{"skill_path": dir})
 	params, _ := json.Marshal(toolsCallParams{Name: "waza_skill_check", Arguments: args})
@@ -356,9 +356,9 @@ func TestSkillCheck_EmptySkillPath(t *testing.T) {
 func TestQuickLinkCheck_NoBrokenLinks(t *testing.T) {
 	dir := t.TempDir()
 	// Create SKILL.md with links that exist.
-	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hi"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hi"), 0o644)
 	content := "# Skill\n[readme](readme.txt)\n[external](https://example.com)\n"
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
 
 	broken, issues := quickLinkCheck(dir)
 	if broken != 0 {
@@ -369,7 +369,7 @@ func TestQuickLinkCheck_NoBrokenLinks(t *testing.T) {
 func TestQuickLinkCheck_BrokenLink(t *testing.T) {
 	dir := t.TempDir()
 	content := "# Skill\n[missing](nonexistent.txt)\n"
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
 
 	broken, issues := quickLinkCheck(dir)
 	if broken != 1 {
@@ -389,7 +389,7 @@ func TestQuickLinkCheck_SkipsProtocols(t *testing.T) {
 [mdc](mdc:something)
 [anchor](#section)
 `
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
 
 	broken, _ := quickLinkCheck(dir)
 	if broken != 0 {
@@ -399,9 +399,9 @@ func TestQuickLinkCheck_SkipsProtocols(t *testing.T) {
 
 func TestQuickLinkCheck_LinkWithAnchor(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "guide.md"), []byte("# Guide"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "guide.md"), []byte("# Guide"), 0o644)
 	content := "# Skill\n[guide section](guide.md#section)\n"
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
 
 	broken, _ := quickLinkCheck(dir)
 	if broken != 0 {

--- a/internal/storage/azure_blob_test.go
+++ b/internal/storage/azure_blob_test.go
@@ -1,378 +1,274 @@
 package storage
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/microsoft/waza/internal/models"
 )
 
-// ========================================
-// MOCK BLOB CLIENT INTERFACE
-// ========================================
-
-// These tests use a mock blob client to avoid Azure dependencies.
-// Once azure_blob.go is implemented, update the implementation to use these mocks.
-
-type mockBlobClient struct {
-	blobs       map[string][]byte            // blob path -> content
-	metadata    map[string]map[string]string // blob path -> metadata
-	uploadErr   error
-	downloadErr error
-	listErr     error
+// stubAzureBlobStore creates a stub store for testing methods that don't call Azure.
+func stubAzureBlobStore() *AzureBlobStore {
+	return &AzureBlobStore{client: nil, containerName: "test-container"}
 }
 
-func newMockBlobClient() *mockBlobClient {
-	return &mockBlobClient{
-		blobs:    make(map[string][]byte),
-		metadata: make(map[string]map[string]string),
-	}
-}
+// --- sanitizePathSegment ---
 
-func (m *mockBlobClient) Upload(ctx context.Context, path string, data []byte, metadata map[string]string) error {
-	if m.uploadErr != nil {
-		return m.uploadErr
-	}
-	m.blobs[path] = data
-	m.metadata[path] = metadata
-	return nil
-}
-
-func (m *mockBlobClient) Download(ctx context.Context, path string) ([]byte, error) {
-	if m.downloadErr != nil {
-		return nil, m.downloadErr
-	}
-	data, ok := m.blobs[path]
-	if !ok {
-		return nil, ErrNotFound
-	}
-	return data, nil
-}
-
-func (m *mockBlobClient) List(ctx context.Context, prefix string) ([]blobItem, error) {
-	if m.listErr != nil {
-		return nil, m.listErr
-	}
-	var items []blobItem
-	for path, meta := range m.metadata {
-		items = append(items, blobItem{
-			Path:     path,
-			Metadata: meta,
-		})
-	}
-	return items, nil
-}
-
-type blobItem struct {
-	Path     string
-	Metadata map[string]string
-}
-
-// ========================================
-// AZURE BLOB STORE TESTS
-// ========================================
-
-// Note: These tests assume AzureBlobStore will be implemented with a similar interface.
-// Adjust once the actual implementation exists.
-
-func makeAzureOutcome(runID, skill, model string, passed, total int) *models.EvaluationOutcome {
-	return &models.EvaluationOutcome{
-		RunID:       runID,
-		SkillTested: skill,
-		BenchName:   "test-bench",
-		Timestamp:   time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC),
-		Setup:       models.OutcomeSetup{ModelID: model},
-		Digest: models.OutcomeDigest{
-			TotalTests:     total,
-			Succeeded:      passed,
-			Failed:         total - passed,
-			AggregateScore: 0.85,
-		},
-		Measures: map[string]models.MeasureResult{
-			"accuracy": {Value: 0.9},
-		},
-	}
-}
-
-func TestAzureBlobStore_Upload_Serialization(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
-
-	mock := newMockBlobClient()
-	outcome := makeAzureOutcome("azure-run-1", "skill-x", "gpt-4o", 8, 10)
-
-	// Expected blob path construction: {skill}/{timestamp}/{runID}.json
-	expectedPath := fmt.Sprintf("skill-x/2026-02-27/%s.json", outcome.RunID)
-
-	// Simulate Upload logic
-	data, err := json.Marshal(outcome)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	metadata := map[string]string{
-		"skill":     outcome.SkillTested,
-		"model":     outcome.Setup.ModelID,
-		"timestamp": outcome.Timestamp.Format(time.RFC3339),
-	}
-
-	if err := mock.Upload(context.Background(), expectedPath, data, metadata); err != nil {
-		t.Fatalf("Upload() error: %v", err)
-	}
-
-	// Verify blob was stored with correct metadata
-	if _, ok := mock.blobs[expectedPath]; !ok {
-		t.Errorf("expected blob at path %s", expectedPath)
-	}
-
-	if mock.metadata[expectedPath]["skill"] != "skill-x" {
-		t.Errorf("metadata skill = %q, want skill-x", mock.metadata[expectedPath]["skill"])
-	}
-}
-
-func TestAzureBlobStore_Download_Deserialization(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
-
-	mock := newMockBlobClient()
-	outcome := makeAzureOutcome("azure-run-2", "skill-y", "claude-sonnet", 9, 10)
-
-	data, _ := json.Marshal(outcome)
-	path := "skill-y/2026-02-27/azure-run-2.json"
-	_ = mock.Upload(context.Background(), path, data, nil)
-
-	// Download and deserialize
-	downloaded, err := mock.Download(context.Background(), path)
-	if err != nil {
-		t.Fatalf("Download() error: %v", err)
-	}
-
-	var got models.EvaluationOutcome
-	if err := json.Unmarshal(downloaded, &got); err != nil {
-		t.Fatalf("Unmarshal error: %v", err)
-	}
-
-	if got.RunID != "azure-run-2" {
-		t.Errorf("RunID = %q, want azure-run-2", got.RunID)
-	}
-	if got.SkillTested != "skill-y" {
-		t.Errorf("SkillTested = %q, want skill-y", got.SkillTested)
-	}
-}
-
-func TestAzureBlobStore_List_MetadataFiltering(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
-
-	mock := newMockBlobClient()
-	ctx := context.Background()
-
-	// Upload multiple outcomes with different metadata
-	outcomes := []*models.EvaluationOutcome{
-		makeAzureOutcome("run-1", "skill-a", "gpt-4o", 5, 10),
-		makeAzureOutcome("run-2", "skill-a", "claude-sonnet", 8, 10),
-		makeAzureOutcome("run-3", "skill-b", "gpt-4o", 9, 10),
-	}
-
-	for i, o := range outcomes {
-		data, _ := json.Marshal(o)
-		path := fmt.Sprintf("%s/2026-02-27/run-%d.json", o.SkillTested, i+1)
-		metadata := map[string]string{
-			"skill": o.SkillTested,
-			"model": o.Setup.ModelID,
-		}
-		_ = mock.Upload(ctx, path, data, metadata)
-	}
-
-	// List all
-	items, err := mock.List(ctx, "")
-	if err != nil {
-		t.Fatalf("List() error: %v", err)
-	}
-	if len(items) != 3 {
-		t.Errorf("List() returned %d items, want 3", len(items))
-	}
-
-	// Filter by skill (would need to be implemented in actual AzureBlobStore)
-	skillACount := 0
-	for _, item := range items {
-		if item.Metadata["skill"] == "skill-a" {
-			skillACount++
-		}
-	}
-	if skillACount != 2 {
-		t.Errorf("skill-a count = %d, want 2", skillACount)
-	}
-}
-
-func TestAzureBlobStore_Compare_DeltaCalculation(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
-
-	mock := newMockBlobClient()
-	ctx := context.Background()
-
-	o1 := makeAzureOutcome("run-1", "skill-x", "gpt-4o", 6, 10)
-	o1.Digest.AggregateScore = 0.6
-	o2 := makeAzureOutcome("run-2", "skill-x", "gpt-4o", 9, 10)
-	o2.Digest.AggregateScore = 0.9
-
-	for i, o := range []*models.EvaluationOutcome{o1, o2} {
-		data, _ := json.Marshal(o)
-		path := fmt.Sprintf("skill-x/2026-02-27/run-%d.json", i+1)
-		_ = mock.Upload(ctx, path, data, nil)
-	}
-
-	// Compare logic (would be implemented in AzureBlobStore.Compare)
-	data1, _ := mock.Download(ctx, "skill-x/2026-02-27/run-1.json")
-	data2, _ := mock.Download(ctx, "skill-x/2026-02-27/run-2.json")
-
-	var downloaded1, downloaded2 models.EvaluationOutcome
-	_ = json.Unmarshal(data1, &downloaded1)
-	_ = json.Unmarshal(data2, &downloaded2)
-
-	scoreDelta := downloaded2.Digest.AggregateScore - downloaded1.Digest.AggregateScore
-	if scoreDelta != 0.3 {
-		t.Errorf("score delta = %v, want 0.3", scoreDelta)
-	}
-}
-
-func TestAzureBlobStore_AuthFailure_AzLoginRetry(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
-
-	mock := newMockBlobClient()
-
-	// Simulate auth error
-	mock.uploadErr = errors.New("authentication failed: No valid credentials")
-
-	outcome := makeAzureOutcome("run-1", "skill-x", "gpt-4o", 5, 10)
-	data, _ := json.Marshal(outcome)
-
-	err := mock.Upload(context.Background(), "test-path.json", data, nil)
-	if err == nil {
-		t.Fatal("Upload() should error on auth failure")
-	}
-
-	// In actual implementation, this should trigger `az login` retry flow
-	// and potentially switch to local storage as fallback
-	if !errors.Is(err, mock.uploadErr) {
-		t.Errorf("expected auth error, got: %v", err)
-	}
-}
-
-func TestAzureBlobStore_NetworkError_Handling(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
-
-	mock := newMockBlobClient()
-
-	// Simulate network error
-	mock.downloadErr = errors.New("network timeout")
-
-	_, err := mock.Download(context.Background(), "some-path.json")
-	if err == nil {
-		t.Fatal("Download() should error on network failure")
-	}
-
-	// Should handle gracefully, possibly with retry logic
-	if !errors.Is(err, mock.downloadErr) {
-		t.Errorf("expected network error, got: %v", err)
-	}
-}
-
-func TestAzureBlobStore_GracefulDegradation(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
-
-	// Test that when Azure storage is unavailable, system falls back to local storage
-	// This would be tested in the actual NewStore factory function
-
-	mock := newMockBlobClient()
-	mock.listErr = errors.New("service unavailable")
-
-	_, err := mock.List(context.Background(), "")
-	if err == nil {
-		t.Fatal("List() should error when service unavailable")
-	}
-
-	// Implementation should detect this and potentially:
-	// 1. Fall back to local storage
-	// 2. Log the error
-	// 3. Continue execution without crashing
-}
-
-func TestAzureBlobStore_BlobPathConstruction(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
-
-	// Test various blob path construction scenarios
+func TestSanitizePathSegment(t *testing.T) {
 	tests := []struct {
-		skill     string
-		timestamp time.Time
-		runID     string
-		want      string
+		in, want string
 	}{
-		{
-			skill:     "code-explainer",
-			timestamp: time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC),
-			runID:     "run-123",
-			want:      "code-explainer/2026-03-15/run-123.json",
-		},
-		{
-			skill:     "skill-with-dashes",
-			timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-			runID:     "run-abc-def",
-			want:      "skill-with-dashes/2026-01-01/run-abc-def.json",
-		},
+		{"simple", "simple"},
+		{"has/slash", "has_slash"},
+		{"back\\slash", "back_slash"},
+		{"with:colon", "with_colon"},
+		{"has space", "has_space"},
+		{"a/b\\c:d e", "a_b_c_d_e"},
+		{"", ""},
 	}
-
 	for _, tt := range tests {
-		// This would be the actual path construction logic in AzureBlobStore
-		got := fmt.Sprintf("%s/%s/%s.json",
-			tt.skill,
-			tt.timestamp.Format("2006-01-02"),
-			tt.runID,
-		)
-		if got != tt.want {
-			t.Errorf("path = %q, want %q", got, tt.want)
+		if got := sanitizePathSegment(tt.in); got != tt.want {
+			t.Errorf("sanitizePathSegment(%q) = %q, want %q", tt.in, got, tt.want)
 		}
 	}
 }
 
-func TestAzureBlobStore_SpecialCharactersInSkillName(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
+// --- stringPtr ---
 
-	mock := newMockBlobClient()
-
-	// Skill names with special characters should be sanitized for blob paths
-	outcome := makeAzureOutcome("run-1", "skill/with:special\\chars", "gpt-4o", 5, 10)
-
-	// Expected: special characters should be URL-encoded or sanitized
-	// Actual implementation will determine the encoding strategy
-	data, _ := json.Marshal(outcome)
-
-	// This test verifies the implementation handles special characters
-	// The exact path format will depend on the implementation
-	err := mock.Upload(context.Background(), "skill-with-special-chars/2026-02-27/run-1.json", data, nil)
-	if err != nil {
-		t.Fatalf("Upload() error: %v", err)
+func TestStringPtr(t *testing.T) {
+	p := stringPtr("hello")
+	if p == nil || *p != "hello" {
+		t.Errorf("stringPtr(\"hello\") = %v, want pointer to \"hello\"", p)
+	}
+	p2 := stringPtr("")
+	if p2 == nil || *p2 != "" {
+		t.Error("stringPtr(\"\") should return pointer to empty string")
 	}
 }
 
-func TestAzureBlobStore_ContextCancellation(t *testing.T) {
-	t.Skip("Skip until azure_blob.go is implemented")
+// --- getMetadata ---
 
-	mock := newMockBlobClient()
+func TestGetMetadata(t *testing.T) {
+	val := "myval"
+	meta := map[string]*string{"key": &val}
 
-	// Create a canceled context
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	if got := getMetadata(meta, "key"); got != "myval" {
+		t.Errorf("getMetadata present key = %q, want myval", got)
+	}
+	if got := getMetadata(meta, "missing"); got != "" {
+		t.Errorf("getMetadata missing key = %q, want empty", got)
+	}
+	if got := getMetadata(nil, "key"); got != "" {
+		t.Errorf("getMetadata nil map = %q, want empty", got)
+	}
+	meta["nilval"] = nil
+	if got := getMetadata(meta, "nilval"); got != "" {
+		t.Errorf("getMetadata nil value = %q, want empty", got)
+	}
+}
 
-	outcome := makeAzureOutcome("run-1", "skill-x", "gpt-4o", 5, 10)
-	data, _ := json.Marshal(outcome)
+// --- isCI ---
 
-	// Upload should respect context cancellation
-	// The actual implementation should check ctx.Err() before operations
-	err := mock.Upload(ctx, "test-path.json", data, nil)
+func TestIsCI(t *testing.T) {
+	// Save and clear all CI env vars.
+	saved := make(map[string]string)
+	for _, v := range ciEnvVars {
+		saved[v] = os.Getenv(v)
+		os.Unsetenv(v)
+	}
+	t.Cleanup(func() {
+		for k, v := range saved {
+			if v != "" {
+				os.Setenv(k, v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	})
 
-	// In a real implementation with context checking, this would return context.Canceled
-	// For now, the mock doesn't check context, so we just verify it handles it gracefully
-	_ = err
+	if isCI() {
+		t.Error("isCI() = true when all CI vars unset")
+	}
+
+	// Setting any single var should return true.
+	for _, v := range ciEnvVars {
+		os.Setenv(v, "1")
+		if !isCI() {
+			t.Errorf("isCI() = false with %s set", v)
+		}
+		os.Unsetenv(v)
+	}
+}
+
+// --- blobToResultSummary ---
+
+func TestBlobToResultSummary(t *testing.T) {
+	abs := stubAzureBlobStore()
+	ts := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	blob := &container.BlobItem{
+		Name: stringPtr("skill-x/run-1.json"),
+		Metadata: map[string]*string{
+			"runid":     stringPtr("run-1"),
+			"skill":     stringPtr("skill-x"),
+			"model":     stringPtr("gpt-4o"),
+			"passrate":  stringPtr("80.0"),
+			"timestamp": stringPtr(ts.Format(time.RFC3339)),
+		},
+	}
+
+	rs, err := abs.blobToResultSummary(blob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rs.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", rs.RunID)
+	}
+	if rs.Skill != "skill-x" {
+		t.Errorf("Skill = %q, want skill-x", rs.Skill)
+	}
+	if rs.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want gpt-4o", rs.Model)
+	}
+	if rs.PassRate != 80.0 {
+		t.Errorf("PassRate = %v, want 80.0", rs.PassRate)
+	}
+	if rs.BlobPath != "skill-x/run-1.json" {
+		t.Errorf("BlobPath = %q, want skill-x/run-1.json", rs.BlobPath)
+	}
+}
+
+func TestBlobToResultSummary_NilMetadata(t *testing.T) {
+	abs := stubAzureBlobStore()
+	blob := &container.BlobItem{Name: stringPtr("test.json"), Metadata: nil}
+
+	_, err := abs.blobToResultSummary(blob)
+	if err == nil {
+		t.Error("expected error for nil metadata")
+	}
+}
+
+func TestBlobToResultSummary_MissingRequiredFields(t *testing.T) {
+	abs := stubAzureBlobStore()
+	// Missing timestamp
+	blob := &container.BlobItem{
+		Name: stringPtr("test.json"),
+		Metadata: map[string]*string{
+			"runid": stringPtr("r1"),
+		},
+	}
+	_, err := abs.blobToResultSummary(blob)
+	if err == nil {
+		t.Error("expected error for missing timestamp")
+	}
+}
+
+func TestBlobToResultSummary_BadTimestamp(t *testing.T) {
+	abs := stubAzureBlobStore()
+	blob := &container.BlobItem{
+		Name: stringPtr("test.json"),
+		Metadata: map[string]*string{
+			"runid":     stringPtr("r1"),
+			"timestamp": stringPtr("not-a-time"),
+		},
+	}
+	_, err := abs.blobToResultSummary(blob)
+	if err == nil {
+		t.Error("expected error for bad timestamp")
+	}
+}
+
+func TestBlobToResultSummary_NoPassRate(t *testing.T) {
+	abs := stubAzureBlobStore()
+	ts := time.Now().Format(time.RFC3339)
+	blob := &container.BlobItem{
+		Name: stringPtr("test.json"),
+		Metadata: map[string]*string{
+			"runid":     stringPtr("r1"),
+			"timestamp": stringPtr(ts),
+		},
+	}
+	rs, err := abs.blobToResultSummary(blob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rs.PassRate != 0.0 {
+		t.Errorf("PassRate = %v, want 0.0 for missing passrate", rs.PassRate)
+	}
+}
+
+func TestBlobToResultSummary_NilBlobName(t *testing.T) {
+	abs := stubAzureBlobStore()
+	ts := time.Now().Format(time.RFC3339)
+	blob := &container.BlobItem{
+		Name: nil,
+		Metadata: map[string]*string{
+			"runid":     stringPtr("r1"),
+			"timestamp": stringPtr(ts),
+		},
+	}
+	rs, err := abs.blobToResultSummary(blob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rs.BlobPath != "" {
+		t.Errorf("BlobPath = %q, want empty for nil Name", rs.BlobPath)
+	}
+}
+
+// --- AzureBlobStore.outcomeToResultSummary ---
+
+func TestAzureBlobStore_OutcomeToResultSummary(t *testing.T) {
+	abs := stubAzureBlobStore()
+	o := &models.EvaluationOutcome{
+		RunID:       "run-42",
+		SkillTested: "my/skill",
+		Timestamp:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		Setup:       models.OutcomeSetup{ModelID: "gpt-4o"},
+		Digest:      models.OutcomeDigest{TotalTests: 10, Succeeded: 7},
+	}
+
+	rs := abs.outcomeToResultSummary(o)
+	if rs.RunID != "run-42" {
+		t.Errorf("RunID = %q", rs.RunID)
+	}
+	if rs.PassRate != 70.0 {
+		t.Errorf("PassRate = %v, want 70.0", rs.PassRate)
+	}
+	// Skill contains a slash which gets sanitized in the blob path.
+	want := "my_skill/run-42.json"
+	if rs.BlobPath != want {
+		t.Errorf("BlobPath = %q, want %q", rs.BlobPath, want)
+	}
+}
+
+func TestAzureBlobStore_OutcomeToResultSummary_ZeroTests(t *testing.T) {
+	abs := stubAzureBlobStore()
+	o := &models.EvaluationOutcome{
+		RunID:       "empty-run",
+		SkillTested: "s",
+		Digest:      models.OutcomeDigest{TotalTests: 0, Succeeded: 0},
+	}
+	rs := abs.outcomeToResultSummary(o)
+	if rs.PassRate != 0.0 {
+		t.Errorf("PassRate = %v, want 0.0 for zero tests", rs.PassRate)
+	}
+}
+
+// --- NewAzureBlobStore validation ---
+
+func TestNewAzureBlobStore_MissingAccountName(t *testing.T) {
+	_, err := NewAzureBlobStore(t.Context(), "", "container")
+	if err == nil {
+		t.Error("expected error for empty account name")
+	}
+}
+
+func TestNewAzureBlobStore_MissingContainerName(t *testing.T) {
+	_, err := NewAzureBlobStore(t.Context(), "account", "")
+	if err == nil {
+		t.Error("expected error for empty container name")
+	}
 }

--- a/internal/storage/azure_blob_test.go
+++ b/internal/storage/azure_blob_test.go
@@ -76,14 +76,17 @@ func TestIsCI(t *testing.T) {
 	saved := make(map[string]string)
 	for _, v := range ciEnvVars {
 		saved[v] = os.Getenv(v)
-		os.Unsetenv(v)
+		t.Setenv(v, "")
+		if err := os.Unsetenv(v); err != nil {
+			t.Fatalf("Unsetenv(%s): %v", v, err)
+		}
 	}
 	t.Cleanup(func() {
 		for k, v := range saved {
 			if v != "" {
-				os.Setenv(k, v)
+				_ = os.Setenv(k, v)
 			} else {
-				os.Unsetenv(k)
+				_ = os.Unsetenv(k)
 			}
 		}
 	})
@@ -94,11 +97,14 @@ func TestIsCI(t *testing.T) {
 
 	// Setting any single var should return true.
 	for _, v := range ciEnvVars {
-		os.Setenv(v, "1")
+		t.Setenv(v, "1")
 		if !isCI() {
 			t.Errorf("isCI() = false with %s set", v)
 		}
-		os.Unsetenv(v)
+		t.Setenv(v, "")
+		if err := os.Unsetenv(v); err != nil {
+			t.Fatalf("Unsetenv(%s): %v", v, err)
+		}
 	}
 }
 

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -250,7 +250,7 @@ func TestMatchesFilter_AllMatch(t *testing.T) {
 func TestLocalStore_LoadSkipsNonJSON(t *testing.T) {
 	dir := t.TempDir()
 	// Write a non-JSON file — load should skip it.
-	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hello"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hello"), 0o644)
 	ls := NewLocalStore(dir)
 	results, err := ls.List(t.Context(), ListOptions{})
 	if err != nil {
@@ -263,7 +263,7 @@ func TestLocalStore_LoadSkipsNonJSON(t *testing.T) {
 
 func TestLocalStore_LoadSkipsInvalidJSON(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{not valid json}"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{not valid json}"), 0o644)
 	ls := NewLocalStore(dir)
 	results, err := ls.List(t.Context(), ListOptions{})
 	if err != nil {
@@ -277,7 +277,7 @@ func TestLocalStore_LoadSkipsInvalidJSON(t *testing.T) {
 func TestLocalStore_LoadSkipsNonOutcomeJSON(t *testing.T) {
 	dir := t.TempDir()
 	// Valid JSON but not an EvaluationOutcome (no BenchName, TotalTests==0).
-	os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"key":"value"}`), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"key":"value"}`), 0o644)
 	ls := NewLocalStore(dir)
 	results, err := ls.List(t.Context(), ListOptions{})
 	if err != nil {
@@ -295,7 +295,7 @@ func TestLocalStore_LoadGeneratesRunIDFromPath(t *testing.T) {
 		BenchName: "bench",
 		Digest:    models.OutcomeDigest{TotalTests: 1, Succeeded: 1},
 	})
-	os.WriteFile(filepath.Join(dir, "derived-run.json"), data, 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "derived-run.json"), data, 0o644)
 
 	ls := NewLocalStore(dir)
 	results, err := ls.List(t.Context(), ListOptions{})
@@ -317,7 +317,7 @@ func TestLocalStore_ListWithLimit(t *testing.T) {
 		o := makeOutcome(fmt.Sprintf("run-%d", i), "s", "m", i, 10)
 		o.Timestamp = time.Date(2026, time.Month(i), 1, 0, 0, 0, 0, time.UTC)
 		data, _ := json.Marshal(o)
-		os.WriteFile(filepath.Join(dir, fmt.Sprintf("run-%d.json", i)), data, 0o644)
+		_ = os.WriteFile(filepath.Join(dir, fmt.Sprintf("run-%d.json", i)), data, 0o644)
 	}
 
 	ls := NewLocalStore(dir)
@@ -343,7 +343,7 @@ func TestLocalStore_CompareSecondDownloadError(t *testing.T) {
 	dir := t.TempDir()
 	o1 := makeOutcome("exists", "s", "m", 5, 10)
 	data, _ := json.Marshal(o1)
-	os.WriteFile(filepath.Join(dir, "exists.json"), data, 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "exists.json"), data, 0o644)
 
 	ls := NewLocalStore(dir)
 	_, err := ls.Compare(t.Context(), "exists", "nonexistent")

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1,0 +1,361 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/microsoft/waza/internal/projectconfig"
+)
+
+// --- buildMetricDeltas ---
+
+func TestBuildMetricDeltas_Basic(t *testing.T) {
+	o1 := &models.EvaluationOutcome{
+		Measures: map[string]models.MeasureResult{
+			"accuracy": {Value: 0.6},
+			"speed":    {Value: 100},
+		},
+	}
+	o2 := &models.EvaluationOutcome{
+		Measures: map[string]models.MeasureResult{
+			"accuracy": {Value: 0.9},
+			"speed":    {Value: 80},
+		},
+	}
+
+	deltas := buildMetricDeltas(o1, o2)
+	if len(deltas) != 2 {
+		t.Fatalf("expected 2 deltas, got %d", len(deltas))
+	}
+	if deltas["accuracy"].Delta != 0.3 {
+		t.Errorf("accuracy delta = %v, want 0.3", deltas["accuracy"].Delta)
+	}
+	if deltas["speed"].Delta != -20.0 {
+		t.Errorf("speed delta = %v, want -20", deltas["speed"].Delta)
+	}
+}
+
+func TestBuildMetricDeltas_DisjointMetrics(t *testing.T) {
+	o1 := &models.EvaluationOutcome{
+		Measures: map[string]models.MeasureResult{
+			"only_in_o1": {Value: 5},
+		},
+	}
+	o2 := &models.EvaluationOutcome{
+		Measures: map[string]models.MeasureResult{
+			"only_in_o2": {Value: 10},
+		},
+	}
+
+	deltas := buildMetricDeltas(o1, o2)
+	if len(deltas) != 2 {
+		t.Fatalf("expected 2 deltas, got %d", len(deltas))
+	}
+	// only_in_o1: o1=5, o2=0 → delta = -5
+	if deltas["only_in_o1"].Value1 != 5 || deltas["only_in_o1"].Value2 != 0 {
+		t.Errorf("only_in_o1: got v1=%v v2=%v", deltas["only_in_o1"].Value1, deltas["only_in_o1"].Value2)
+	}
+	// only_in_o2: o1=0, o2=10 → delta = 10
+	if deltas["only_in_o2"].Value1 != 0 || deltas["only_in_o2"].Value2 != 10 {
+		t.Errorf("only_in_o2: got v1=%v v2=%v", deltas["only_in_o2"].Value1, deltas["only_in_o2"].Value2)
+	}
+}
+
+func TestBuildMetricDeltas_Empty(t *testing.T) {
+	o1 := &models.EvaluationOutcome{Measures: map[string]models.MeasureResult{}}
+	o2 := &models.EvaluationOutcome{Measures: map[string]models.MeasureResult{}}
+
+	deltas := buildMetricDeltas(o1, o2)
+	if len(deltas) != 0 {
+		t.Errorf("expected 0 deltas, got %d", len(deltas))
+	}
+}
+
+func TestBuildMetricDeltas_Rounding(t *testing.T) {
+	// Ensure rounding to 3 decimal places works.
+	o1 := &models.EvaluationOutcome{
+		Measures: map[string]models.MeasureResult{
+			"x": {Value: 0.1},
+		},
+	}
+	o2 := &models.EvaluationOutcome{
+		Measures: map[string]models.MeasureResult{
+			"x": {Value: 0.3},
+		},
+	}
+
+	deltas := buildMetricDeltas(o1, o2)
+	// 0.3 - 0.1 = 0.19999... should round to 0.2
+	if deltas["x"].Delta != 0.2 {
+		t.Errorf("delta = %v, want 0.2 (rounded)", deltas["x"].Delta)
+	}
+}
+
+// --- NewStore edge cases ---
+
+func TestNewStore_NilConfig(t *testing.T) {
+	store, err := NewStore(nil, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore(nil) error: %v", err)
+	}
+	if _, ok := store.(*LocalStore); !ok {
+		t.Error("expected *LocalStore for nil config")
+	}
+}
+
+func TestNewStore_EmptyProvider(t *testing.T) {
+	cfg := &projectconfig.StorageConfig{
+		Provider: "",
+		Enabled:  true,
+	}
+	store, err := NewStore(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore(empty provider) error: %v", err)
+	}
+	if _, ok := store.(*LocalStore); !ok {
+		t.Error("expected *LocalStore for empty provider")
+	}
+}
+
+func TestNewStore_AzureBlobMissingAccountName(t *testing.T) {
+	cfg := &projectconfig.StorageConfig{
+		Provider:      "azure-blob",
+		Enabled:       true,
+		AccountName:   "",
+		ContainerName: "test-container",
+	}
+	_, err := NewStore(cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for azure-blob with empty accountName")
+	}
+}
+
+func TestNewStore_AzureBlobMissingContainerName(t *testing.T) {
+	cfg := &projectconfig.StorageConfig{
+		Provider:      "azure-blob",
+		Enabled:       true,
+		AccountName:   "myaccount",
+		ContainerName: "",
+	}
+	_, err := NewStore(cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for azure-blob with empty containerName")
+	}
+}
+
+func TestNewStore_UnknownProvider(t *testing.T) {
+	cfg := &projectconfig.StorageConfig{
+		Provider: "unknown-provider",
+		Enabled:  true,
+	}
+	store, err := NewStore(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore(unknown) error: %v", err)
+	}
+	// Unknown provider with enabled=true but not "azure-blob" falls through to local.
+	if _, ok := store.(*LocalStore); !ok {
+		t.Error("expected *LocalStore for unknown provider")
+	}
+}
+
+// --- outcomeToResultSummary ---
+
+func TestOutcomeToResultSummary_ZeroTests(t *testing.T) {
+	o := &models.EvaluationOutcome{
+		RunID:       "run-zero",
+		SkillTested: "skill-x",
+		Setup:       models.OutcomeSetup{ModelID: "model-y"},
+		Timestamp:   time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		Digest:      models.OutcomeDigest{TotalTests: 0, Succeeded: 0},
+	}
+	s := outcomeToResultSummary(o, "/results")
+	if s.PassRate != 0.0 {
+		t.Errorf("PassRate = %v, want 0.0 for zero tests", s.PassRate)
+	}
+	if s.RunID != "run-zero" {
+		t.Errorf("RunID = %q, want run-zero", s.RunID)
+	}
+}
+
+func TestOutcomeToResultSummary_PassRate(t *testing.T) {
+	o := &models.EvaluationOutcome{
+		RunID:       "run-pass",
+		SkillTested: "s",
+		Setup:       models.OutcomeSetup{ModelID: "m"},
+		Digest:      models.OutcomeDigest{TotalTests: 4, Succeeded: 3},
+	}
+	s := outcomeToResultSummary(o, "/dir")
+	want := 75.0
+	if s.PassRate != want {
+		t.Errorf("PassRate = %v, want %v", s.PassRate, want)
+	}
+}
+
+// --- matchesFilter ---
+
+func TestMatchesFilter_AllEmpty(t *testing.T) {
+	o := &models.EvaluationOutcome{}
+	if !matchesFilter(o, ListOptions{}) {
+		t.Error("empty options should match any outcome")
+	}
+}
+
+func TestMatchesFilter_SkillMismatch(t *testing.T) {
+	o := &models.EvaluationOutcome{SkillTested: "skill-a"}
+	if matchesFilter(o, ListOptions{Skill: "skill-b"}) {
+		t.Error("should not match different skill")
+	}
+}
+
+func TestMatchesFilter_ModelMismatch(t *testing.T) {
+	o := &models.EvaluationOutcome{Setup: models.OutcomeSetup{ModelID: "gpt-4o"}}
+	if matchesFilter(o, ListOptions{Model: "claude-sonnet"}) {
+		t.Error("should not match different model")
+	}
+}
+
+func TestMatchesFilter_SinceFilter(t *testing.T) {
+	o := &models.EvaluationOutcome{
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if matchesFilter(o, ListOptions{Since: since}) {
+		t.Error("should not match outcome before Since")
+	}
+}
+
+func TestMatchesFilter_AllMatch(t *testing.T) {
+	o := &models.EvaluationOutcome{
+		SkillTested: "skill-a",
+		Timestamp:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		Setup:       models.OutcomeSetup{ModelID: "gpt-4o"},
+	}
+	opts := ListOptions{
+		Skill: "skill-a",
+		Model: "gpt-4o",
+		Since: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if !matchesFilter(o, opts) {
+		t.Error("should match when all filters satisfy")
+	}
+}
+
+// --- load() edge cases ---
+
+func TestLocalStore_LoadSkipsNonJSON(t *testing.T) {
+	dir := t.TempDir()
+	// Write a non-JSON file — load should skip it.
+	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hello"), 0o644)
+	ls := NewLocalStore(dir)
+	results, err := ls.List(t.Context(), ListOptions{})
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestLocalStore_LoadSkipsInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{not valid json}"), 0o644)
+	ls := NewLocalStore(dir)
+	results, err := ls.List(t.Context(), ListOptions{})
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for invalid JSON, got %d", len(results))
+	}
+}
+
+func TestLocalStore_LoadSkipsNonOutcomeJSON(t *testing.T) {
+	dir := t.TempDir()
+	// Valid JSON but not an EvaluationOutcome (no BenchName, TotalTests==0).
+	os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"key":"value"}`), 0o644)
+	ls := NewLocalStore(dir)
+	results, err := ls.List(t.Context(), ListOptions{})
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for non-outcome JSON, got %d", len(results))
+	}
+}
+
+func TestLocalStore_LoadGeneratesRunIDFromPath(t *testing.T) {
+	dir := t.TempDir()
+	// Outcome without RunID — load should derive RunID from file path.
+	data, _ := json.Marshal(models.EvaluationOutcome{
+		BenchName: "bench",
+		Digest:    models.OutcomeDigest{TotalTests: 1, Succeeded: 1},
+	})
+	os.WriteFile(filepath.Join(dir, "derived-run.json"), data, 0o644)
+
+	ls := NewLocalStore(dir)
+	results, err := ls.List(t.Context(), ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].RunID != "derived-run" {
+		t.Errorf("RunID = %q, want derived-run", results[0].RunID)
+	}
+}
+
+func TestLocalStore_ListWithLimit(t *testing.T) {
+	dir := t.TempDir()
+	// Create 3 outcomes.
+	for i := 1; i <= 3; i++ {
+		o := makeOutcome(fmt.Sprintf("run-%d", i), "s", "m", i, 10)
+		o.Timestamp = time.Date(2026, time.Month(i), 1, 0, 0, 0, 0, time.UTC)
+		data, _ := json.Marshal(o)
+		os.WriteFile(filepath.Join(dir, fmt.Sprintf("run-%d.json", i)), data, 0o644)
+	}
+
+	ls := NewLocalStore(dir)
+	results, err := ls.List(t.Context(), ListOptions{Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results with Limit=2, got %d", len(results))
+	}
+}
+
+func TestLocalStore_CompareFirstDownloadError(t *testing.T) {
+	dir := t.TempDir()
+	ls := NewLocalStore(dir)
+	_, err := ls.Compare(t.Context(), "nonexistent-1", "nonexistent-2")
+	if err == nil {
+		t.Error("expected error when first download fails")
+	}
+}
+
+func TestLocalStore_CompareSecondDownloadError(t *testing.T) {
+	dir := t.TempDir()
+	o1 := makeOutcome("exists", "s", "m", 5, 10)
+	data, _ := json.Marshal(o1)
+	os.WriteFile(filepath.Join(dir, "exists.json"), data, 0o644)
+
+	ls := NewLocalStore(dir)
+	_, err := ls.Compare(t.Context(), "exists", "nonexistent")
+	if err == nil {
+		t.Error("expected error when second download fails")
+	}
+}
+
+// --- ErrNotFound sentinel ---
+
+func TestErrNotFound_Message(t *testing.T) {
+	if ErrNotFound.Error() != "result not found" {
+		t.Errorf("ErrNotFound = %q, want %q", ErrNotFound.Error(), "result not found")
+	}
+}

--- a/internal/suggest/grader_docs_test.go
+++ b/internal/suggest/grader_docs_test.go
@@ -1,0 +1,114 @@
+package suggest
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraderSummaries_ContainsAllKnownTypes(t *testing.T) {
+	summaries := GraderSummaries()
+	for _, gtype := range AvailableGraderTypes() {
+		assert.Contains(t, summaries, gtype+":", "missing summary for %s", gtype)
+	}
+}
+
+func TestGraderSummaries_NoDescriptionFallback(t *testing.T) {
+	// The graderSummary map may not cover a future grader type.
+	// Test the fallback by temporarily adding a type to the list and
+	// verifying the function output format.
+	summaries := GraderSummaries()
+	// All current types should have descriptions (no "(no description)").
+	assert.NotContains(t, summaries, "(no description)")
+}
+
+func TestGraderSummaries_Format(t *testing.T) {
+	summaries := GraderSummaries()
+	// Each line should start with "- "
+	for _, line := range splitNonEmpty(summaries) {
+		assert.True(t, len(line) > 2 && line[:2] == "- ", "unexpected format: %q", line)
+	}
+}
+
+func TestLoadGraderDocs_NilFS(t *testing.T) {
+	result := LoadGraderDocs(nil, []string{"code", "text"})
+	assert.Equal(t, "", result)
+}
+
+func TestLoadGraderDocs_EmptyTypes(t *testing.T) {
+	fsys := fstest.MapFS{}
+	result := LoadGraderDocs(fsys, nil)
+	assert.Equal(t, "", result)
+}
+
+func TestLoadGraderDocs_UnknownTypesSkipped(t *testing.T) {
+	fsys := fstest.MapFS{
+		"docs/graders/code.md": &fstest.MapFile{Data: []byte("# Code Grader\nAssertions.")},
+	}
+	result := LoadGraderDocs(fsys, []string{"nonexistent_type"})
+	assert.Equal(t, "", result)
+}
+
+func TestLoadGraderDocs_LoadsSingleDoc(t *testing.T) {
+	fsys := fstest.MapFS{
+		"docs/graders/code.md": &fstest.MapFile{Data: []byte("# Code Grader\nAssertions.")},
+	}
+	result := LoadGraderDocs(fsys, []string{"code"})
+	require.Contains(t, result, "Code Grader")
+	require.Contains(t, result, "Assertions")
+}
+
+func TestLoadGraderDocs_MultipleTypes(t *testing.T) {
+	fsys := fstest.MapFS{
+		"docs/graders/code.md": &fstest.MapFile{Data: []byte("# Code Grader")},
+		"docs/graders/text.md": &fstest.MapFile{Data: []byte("# Text Grader")},
+	}
+	result := LoadGraderDocs(fsys, []string{"code", "text"})
+	assert.Contains(t, result, "Code Grader")
+	assert.Contains(t, result, "Text Grader")
+}
+
+func TestLoadGraderDocs_TrimsWhitespace(t *testing.T) {
+	fsys := fstest.MapFS{
+		"docs/graders/code.md": &fstest.MapFile{Data: []byte("  \n# Code Grader\n  \n")},
+	}
+	result := LoadGraderDocs(fsys, []string{"code"})
+	assert.Equal(t, "# Code Grader", result)
+}
+
+func TestLoadGraderDocs_MixedValidAndInvalid(t *testing.T) {
+	fsys := fstest.MapFS{
+		"docs/graders/text.md": &fstest.MapFile{Data: []byte("# Text Grader docs")},
+	}
+	// "bogus" has no file, "text" does
+	result := LoadGraderDocs(fsys, []string{"bogus", "text"})
+	assert.Contains(t, result, "Text Grader docs")
+	assert.NotContains(t, result, "bogus")
+}
+
+func splitNonEmpty(s string) []string {
+	var result []string
+	for _, line := range split(s) {
+		if line != "" {
+			result = append(result, line)
+		}
+	}
+	return result
+}
+
+func split(s string) []string {
+	var result []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			result = append(result, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		result = append(result, s[start:])
+	}
+	return result
+}

--- a/internal/suggest/helpers_test.go
+++ b/internal/suggest/helpers_test.go
@@ -1,0 +1,237 @@
+package suggest
+
+import (
+	"testing"
+
+	"github.com/microsoft/waza/internal/scaffold"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- orDefault ---
+
+func TestOrDefault_NonEmpty(t *testing.T) {
+	assert.Equal(t, "value", orDefault("value", "fallback"))
+}
+
+func TestOrDefault_Empty(t *testing.T) {
+	assert.Equal(t, "fallback", orDefault("", "fallback"))
+}
+
+func TestOrDefault_Whitespace(t *testing.T) {
+	assert.Equal(t, "fallback", orDefault("   ", "fallback"))
+}
+
+func TestOrDefault_BothEmpty(t *testing.T) {
+	assert.Equal(t, "", orDefault("", ""))
+}
+
+// --- phrasesToText ---
+
+func TestPhrasesToText_Empty(t *testing.T) {
+	assert.Equal(t, "none", phrasesToText(nil))
+}
+
+func TestPhrasesToText_EmptySlice(t *testing.T) {
+	assert.Equal(t, "none", phrasesToText([]scaffold.TriggerPhrase{}))
+}
+
+func TestPhrasesToText_SinglePhrase(t *testing.T) {
+	phrases := []scaffold.TriggerPhrase{{Prompt: "summarize"}}
+	assert.Equal(t, "summarize", phrasesToText(phrases))
+}
+
+func TestPhrasesToText_MultiplePhrases(t *testing.T) {
+	phrases := []scaffold.TriggerPhrase{
+		{Prompt: "summarize"},
+		{Prompt: "explain"},
+		{Prompt: "translate"},
+	}
+	assert.Equal(t, "summarize, explain, translate", phrasesToText(phrases))
+}
+
+func TestPhrasesToText_WhitespaceOnlyPrompts(t *testing.T) {
+	phrases := []scaffold.TriggerPhrase{
+		{Prompt: "   "},
+		{Prompt: ""},
+	}
+	assert.Equal(t, "none", phrasesToText(phrases))
+}
+
+func TestPhrasesToText_MixedEmptyAndValid(t *testing.T) {
+	phrases := []scaffold.TriggerPhrase{
+		{Prompt: ""},
+		{Prompt: "valid"},
+		{Prompt: "  "},
+	}
+	assert.Equal(t, "valid", phrasesToText(phrases))
+}
+
+// --- summarizeBody ---
+
+func TestSummarizeBody_Empty(t *testing.T) {
+	assert.Equal(t, "No body content", summarizeBody(""))
+}
+
+func TestSummarizeBody_WhitespaceOnly(t *testing.T) {
+	assert.Equal(t, "No body content", summarizeBody("  \n  \n  "))
+}
+
+func TestSummarizeBody_SingleHeading(t *testing.T) {
+	result := summarizeBody("# Overview")
+	assert.Equal(t, "# Overview", result)
+}
+
+func TestSummarizeBody_HeadingsAndText(t *testing.T) {
+	body := "# Overview\nThis does things.\n## Details\nMore info here."
+	result := summarizeBody(body)
+	assert.Contains(t, result, "# Overview")
+	assert.Contains(t, result, "This does things.")
+	assert.Contains(t, result, "## Details")
+	assert.Contains(t, result, "More info here.")
+}
+
+func TestSummarizeBody_MaxLines(t *testing.T) {
+	// 10+ content lines — should cap at 8
+	body := "# H1\nLine1\nLine2\nLine3\nLine4\nLine5\nLine6\nLine7\nLine8\nLine9\nLine10"
+	result := summarizeBody(body)
+	// Headings always included, plus lines up to 8 total
+	assert.NotContains(t, result, "Line9")
+	assert.NotContains(t, result, "Line10")
+}
+
+func TestSummarizeBody_SkipsBlankLines(t *testing.T) {
+	body := "# Title\n\n\nSome content\n\nMore content"
+	result := summarizeBody(body)
+	assert.Contains(t, result, "# Title")
+	assert.Contains(t, result, "Some content")
+	assert.Contains(t, result, "More content")
+}
+
+// --- extractYAML ---
+
+func TestExtractYAML_Empty(t *testing.T) {
+	assert.Equal(t, "", extractYAML(""))
+}
+
+func TestExtractYAML_WhitespaceOnly(t *testing.T) {
+	assert.Equal(t, "", extractYAML("   \n  \n  "))
+}
+
+func TestExtractYAML_NoCodeFence(t *testing.T) {
+	input := "name: test\nvalue: 42"
+	assert.Equal(t, input, extractYAML(input))
+}
+
+func TestExtractYAML_WithCodeFence(t *testing.T) {
+	input := "```yaml\nname: test\nvalue: 42\n```"
+	assert.Equal(t, "name: test\nvalue: 42", extractYAML(input))
+}
+
+func TestExtractYAML_CodeFenceNoClosing(t *testing.T) {
+	// No closing ```, should return the original
+	input := "```yaml\nname: test\nvalue: 42"
+	result := extractYAML(input)
+	assert.Equal(t, input, result)
+}
+
+func TestExtractYAML_SurroundingText(t *testing.T) {
+	input := "Here is the YAML:\n```yaml\nname: extracted\n```\nDone."
+	assert.Equal(t, "name: extracted", extractYAML(input))
+}
+
+// --- normalizeGeneratedPath ---
+
+func TestNormalizeGeneratedPath_ValidRelative(t *testing.T) {
+	path, err := normalizeGeneratedPath("tasks/basic.yaml", "fallback.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "tasks/basic.yaml", path)
+}
+
+func TestNormalizeGeneratedPath_EmptyUsesFallback(t *testing.T) {
+	path, err := normalizeGeneratedPath("", "tasks/task-01.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "tasks/task-01.yaml", path)
+}
+
+func TestNormalizeGeneratedPath_WhitespaceUsesFallback(t *testing.T) {
+	path, err := normalizeGeneratedPath("   ", "fallback.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "fallback.yaml", path)
+}
+
+func TestNormalizeGeneratedPath_AbsolutePathRejected(t *testing.T) {
+	_, err := normalizeGeneratedPath("/etc/passwd", "fallback.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid generated path")
+}
+
+func TestNormalizeGeneratedPath_ParentTraversalRejected(t *testing.T) {
+	_, err := normalizeGeneratedPath("../../etc/passwd", "fallback.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid generated path")
+}
+
+func TestNormalizeGeneratedPath_DotSlash(t *testing.T) {
+	path, err := normalizeGeneratedPath("./tasks/basic.yaml", "fallback.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "tasks/basic.yaml", path)
+}
+
+// --- filterValidGraderTypes ---
+
+func TestFilterValidGraderTypes_AllValid(t *testing.T) {
+	result := filterValidGraderTypes([]string{"code", "text", "file"})
+	assert.Equal(t, []string{"code", "text", "file"}, result)
+}
+
+func TestFilterValidGraderTypes_MixedValidInvalid(t *testing.T) {
+	result := filterValidGraderTypes([]string{"code", "not_a_grader", "text"})
+	assert.Equal(t, []string{"code", "text"}, result)
+}
+
+func TestFilterValidGraderTypes_AllInvalid(t *testing.T) {
+	result := filterValidGraderTypes([]string{"bogus", "fake"})
+	assert.Nil(t, result)
+}
+
+func TestFilterValidGraderTypes_Empty(t *testing.T) {
+	result := filterValidGraderTypes(nil)
+	assert.Nil(t, result)
+}
+
+func TestFilterValidGraderTypes_WhitespaceTrimmed(t *testing.T) {
+	result := filterValidGraderTypes([]string{"  code  ", " text "})
+	assert.Equal(t, []string{"code", "text"}, result)
+}
+
+// --- AvailableGraderTypes ---
+
+func TestAvailableGraderTypes_NonEmpty(t *testing.T) {
+	types := AvailableGraderTypes()
+	assert.True(t, len(types) > 0, "should have at least one grader type")
+}
+
+func TestAvailableGraderTypes_ContainsExpected(t *testing.T) {
+	types := AvailableGraderTypes()
+	expected := []string{"code", "prompt", "text", "file", "json_schema", "program", "behavior", "action_sequence", "skill_invocation", "trigger", "diff", "tool_constraint"}
+	for _, exp := range expected {
+		assert.Contains(t, types, exp, "missing expected grader type %q", exp)
+	}
+}
+
+// --- parseGraderSelection ---
+
+func TestParseGraderSelection_PlainLines(t *testing.T) {
+	result := parseGraderSelection("code\ntext\nfile")
+	assert.Equal(t, []string{"code", "text", "file"}, result)
+}
+
+func TestParseGraderSelection_WhitespaceAround(t *testing.T) {
+	result := parseGraderSelection("  \n  code  \n  text  \n  ")
+	assert.Equal(t, []string{"code", "text"}, result)
+}
+
+func TestParseGraderSelection_OnlyInvalid(t *testing.T) {
+	result := parseGraderSelection("bogus\nfake\nnope")
+	assert.Nil(t, result)
+}

--- a/internal/suggest/helpers_test.go
+++ b/internal/suggest/helpers_test.go
@@ -1,6 +1,8 @@
 package suggest
 
 import (
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/microsoft/waza/internal/scaffold"
@@ -144,13 +146,13 @@ func TestExtractYAML_SurroundingText(t *testing.T) {
 func TestNormalizeGeneratedPath_ValidRelative(t *testing.T) {
 	path, err := normalizeGeneratedPath("tasks/basic.yaml", "fallback.yaml")
 	assert.NoError(t, err)
-	assert.Equal(t, "tasks/basic.yaml", path)
+	assert.Equal(t, filepath.FromSlash("tasks/basic.yaml"), path)
 }
 
 func TestNormalizeGeneratedPath_EmptyUsesFallback(t *testing.T) {
 	path, err := normalizeGeneratedPath("", "tasks/task-01.yaml")
 	assert.NoError(t, err)
-	assert.Equal(t, "tasks/task-01.yaml", path)
+	assert.Equal(t, filepath.FromSlash("tasks/task-01.yaml"), path)
 }
 
 func TestNormalizeGeneratedPath_WhitespaceUsesFallback(t *testing.T) {
@@ -160,7 +162,11 @@ func TestNormalizeGeneratedPath_WhitespaceUsesFallback(t *testing.T) {
 }
 
 func TestNormalizeGeneratedPath_AbsolutePathRejected(t *testing.T) {
-	_, err := normalizeGeneratedPath("/etc/passwd", "fallback.yaml")
+	absPath := "/etc/passwd"
+	if runtime.GOOS == "windows" {
+		absPath = `C:\etc\passwd`
+	}
+	_, err := normalizeGeneratedPath(absPath, "fallback.yaml")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid generated path")
 }
@@ -174,7 +180,7 @@ func TestNormalizeGeneratedPath_ParentTraversalRejected(t *testing.T) {
 func TestNormalizeGeneratedPath_DotSlash(t *testing.T) {
 	path, err := normalizeGeneratedPath("./tasks/basic.yaml", "fallback.yaml")
 	assert.NoError(t, err)
-	assert.Equal(t, "tasks/basic.yaml", path)
+	assert.Equal(t, filepath.FromSlash("tasks/basic.yaml"), path)
 }
 
 // --- filterValidGraderTypes ---

--- a/internal/suggest/prompt_test.go
+++ b/internal/suggest/prompt_test.go
@@ -1,0 +1,141 @@
+package suggest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderSelectionPrompt_Structure(t *testing.T) {
+	data := promptData{
+		SkillName:      "my-skill",
+		Description:    "A skill that does things",
+		Triggers:       "do things, make stuff",
+		AntiTriggers:   "break things",
+		ContentSummary: "## Overview | Does things",
+	}
+
+	prompt := renderSelectionPrompt(data)
+	assert.Contains(t, prompt, "selecting grader types")
+	assert.Contains(t, prompt, "Name: my-skill")
+	assert.Contains(t, prompt, "Description: A skill that does things")
+	assert.Contains(t, prompt, "Triggers (USE FOR): do things, make stuff")
+	assert.Contains(t, prompt, "Anti-triggers (DO NOT USE FOR): break things")
+	assert.Contains(t, prompt, "Content summary: ## Overview | Does things")
+	assert.Contains(t, prompt, "YAML list of grader type names")
+}
+
+func TestRenderSelectionPrompt_IncludesGraderSummaries(t *testing.T) {
+	data := promptData{SkillName: "test"}
+	prompt := renderSelectionPrompt(data)
+	// Should include the grader summaries inline
+	for _, gtype := range AvailableGraderTypes() {
+		assert.Contains(t, prompt, gtype)
+	}
+}
+
+func TestRenderImplementationPrompt_WithGraderDocs(t *testing.T) {
+	data := promptData{
+		SkillName:    "test-skill",
+		Description:  "A test skill",
+		SkillContent: "# Test Skill\nDoes testing.",
+	}
+	graderDocs := "### `code` - Assertion-Based\nRun assertions against output."
+
+	prompt := renderImplementationPrompt(data, graderDocs)
+	assert.Contains(t, prompt, "generating a waza evaluation suite")
+	assert.Contains(t, prompt, "Name: test-skill")
+	assert.Contains(t, prompt, "Grader documentation for the types you should use")
+	assert.Contains(t, prompt, "Assertion-Based")
+	assert.Contains(t, prompt, evalYAMLSchemaSummary)
+	assert.Contains(t, prompt, exampleEvalYAML)
+	assert.Contains(t, prompt, "Skill content (SKILL.md)")
+	assert.Contains(t, prompt, "Does testing.")
+}
+
+func TestRenderImplementationPrompt_WithoutGraderDocs(t *testing.T) {
+	data := promptData{
+		SkillName:    "test-skill",
+		Description:  "A test skill",
+		SkillContent: "# Test",
+	}
+
+	prompt := renderImplementationPrompt(data, "")
+	assert.Contains(t, prompt, "Name: test-skill")
+	assert.NotContains(t, prompt, "Grader documentation for the types you should use")
+}
+
+func TestRenderImplementationPrompt_ContainsRequirements(t *testing.T) {
+	data := promptData{SkillName: "x"}
+	prompt := renderImplementationPrompt(data, "")
+	// Key requirements that must be in the prompt
+	assert.Contains(t, prompt, "NEVER use bare strings")
+	assert.Contains(t, prompt, "required_skills")
+	assert.Contains(t, prompt, "Task YAML must use inputs")
+	assert.Contains(t, prompt, "at least 3 diverse tasks")
+	assert.Contains(t, prompt, "at least 1 negative/anti-trigger task")
+}
+
+func TestRenderPrompt_IsSinglePassFallback(t *testing.T) {
+	data := promptData{
+		SkillName:    "single-pass-skill",
+		Description:  "Does stuff",
+		SkillContent: "# Content",
+	}
+	prompt := renderPrompt(data)
+	// renderPrompt should call renderImplementationPrompt with empty graderDocs
+	assert.Contains(t, prompt, "Name: single-pass-skill")
+	assert.NotContains(t, prompt, "Grader documentation for the types you should use")
+	assert.Contains(t, prompt, "generating a waza evaluation suite")
+}
+
+func TestRenderSelectionPrompt_EmptyFields(t *testing.T) {
+	data := promptData{
+		SkillName:      "",
+		Description:    "",
+		Triggers:       "",
+		AntiTriggers:   "",
+		ContentSummary: "",
+	}
+	prompt := renderSelectionPrompt(data)
+	require.NotEmpty(t, prompt)
+	assert.Contains(t, prompt, "Name: ")
+	assert.Contains(t, prompt, "selecting grader types")
+}
+
+func TestRenderImplementationPrompt_EmptySkillContent(t *testing.T) {
+	data := promptData{
+		SkillName:    "empty-skill",
+		SkillContent: "",
+	}
+	prompt := renderImplementationPrompt(data, "")
+	assert.Contains(t, prompt, "Skill content (SKILL.md)")
+	assert.Contains(t, prompt, "Name: empty-skill")
+}
+
+func TestPromptDataStruct_AllFieldsUsed(t *testing.T) {
+	data := promptData{
+		SkillName:      "skill-name",
+		Description:    "desc-value",
+		Triggers:       "trigger-value",
+		AntiTriggers:   "anti-trigger-value",
+		ContentSummary: "summary-value",
+		GraderTypes:    "- code\n- text",
+		SkillContent:   "content-value",
+	}
+
+	// Selection prompt uses SkillName, Description, Triggers, AntiTriggers, ContentSummary
+	sel := renderSelectionPrompt(data)
+	assert.Contains(t, sel, "skill-name")
+	assert.Contains(t, sel, "desc-value")
+	assert.Contains(t, sel, "trigger-value")
+	assert.Contains(t, sel, "anti-trigger-value")
+	assert.Contains(t, sel, "summary-value")
+
+	// Implementation prompt uses all fields
+	impl := renderImplementationPrompt(data, "docs-here")
+	assert.Contains(t, impl, "skill-name")
+	assert.Contains(t, impl, "content-value")
+	assert.Contains(t, impl, "docs-here")
+}

--- a/internal/suggest/resolve_test.go
+++ b/internal/suggest/resolve_test.go
@@ -1,0 +1,244 @@
+package suggest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- resolveSkillFile ---
+
+func TestResolveSkillFile_EmptyPath(t *testing.T) {
+	_, err := resolveSkillFile("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skill path is required")
+}
+
+func TestResolveSkillFile_WhitespacePath(t *testing.T) {
+	_, err := resolveSkillFile("   ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skill path is required")
+}
+
+func TestResolveSkillFile_NonexistentPath(t *testing.T) {
+	_, err := resolveSkillFile("/nonexistent/path/to/skill")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestResolveSkillFile_DirectoryWithSKILLMD(t *testing.T) {
+	dir := t.TempDir()
+	skillPath := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillPath, []byte("---\nname: test\n---\n# Test"), 0644))
+
+	resolved, err := resolveSkillFile(dir)
+	require.NoError(t, err)
+	assert.Equal(t, skillPath, resolved)
+}
+
+func TestResolveSkillFile_DirectFileReference(t *testing.T) {
+	dir := t.TempDir()
+	skillPath := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillPath, []byte("---\nname: test\n---\n# Test"), 0644))
+
+	resolved, err := resolveSkillFile(skillPath)
+	require.NoError(t, err)
+	assert.Equal(t, skillPath, resolved)
+}
+
+func TestResolveSkillFile_DirectoryMissingSKILLMD(t *testing.T) {
+	dir := t.TempDir()
+	_, err := resolveSkillFile(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SKILL.md found")
+}
+
+func TestResolveSkillFile_WrongFilename(t *testing.T) {
+	dir := t.TempDir()
+	wrongPath := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(wrongPath, []byte("# README"), 0644))
+
+	_, err := resolveSkillFile(wrongPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected SKILL.md")
+}
+
+// --- loadSkill ---
+
+func TestLoadSkill_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nname: test-skill\ndescription: \"A test skill.\"\n---\n# Test Skill\n\nDoes things.\n"
+	skillPath := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillPath, []byte(content), 0644))
+
+	rawContent, sk, err := loadSkill(skillPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, rawContent)
+	assert.Equal(t, "test-skill", sk.Frontmatter.Name)
+	assert.Equal(t, skillPath, sk.Path)
+}
+
+func TestLoadSkill_NonexistentFile(t *testing.T) {
+	_, _, err := loadSkill("/nonexistent/SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading SKILL.md")
+}
+
+func TestLoadSkill_InvalidFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	// Missing closing ---
+	content := "---\nname: test\n# no closing delimiter"
+	skillPath := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillPath, []byte(content), 0644))
+
+	_, _, err := loadSkill(skillPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing SKILL.md")
+}
+
+// --- buildPromptData ---
+
+func TestBuildPromptData_ExtractsFields(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nname: build-prompt-skill\ndescription: \"A useful skill. USE FOR: summarize, explain. DO NOT USE FOR: coding, deploy.\"\n---\n# Overview\nThis skill summarizes docs.\n"
+	skillPath := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillPath, []byte(content), 0644))
+
+	rawContent, sk, err := loadSkill(skillPath)
+	require.NoError(t, err)
+
+	data := buildPromptData(sk, rawContent)
+	assert.Equal(t, "build-prompt-skill", data.SkillName)
+	assert.NotEmpty(t, data.Description)
+	assert.Contains(t, data.Triggers, "summarize")
+	assert.Contains(t, data.AntiTriggers, "coding")
+	assert.NotEmpty(t, data.ContentSummary)
+	assert.Contains(t, data.GraderTypes, "code")
+	assert.Equal(t, rawContent, data.SkillContent)
+}
+
+func TestBuildPromptData_FallbackSkillName(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "my-cool-skill")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+	content := "---\ndescription: \"Some skill.\"\n---\n# Content\n"
+	skillPath := filepath.Join(subDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillPath, []byte(content), 0644))
+
+	rawContent, sk, err := loadSkill(skillPath)
+	require.NoError(t, err)
+
+	data := buildPromptData(sk, rawContent)
+	// Name not set in frontmatter, should fall back to parent dir name
+	assert.Equal(t, "my-cool-skill", data.SkillName)
+}
+
+func TestBuildPromptData_NoTriggers(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nname: simple-skill\ndescription: \"A plain skill with no trigger phrases.\"\n---\n# Simple\n"
+	skillPath := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillPath, []byte(content), 0644))
+
+	rawContent, sk, err := loadSkill(skillPath)
+	require.NoError(t, err)
+
+	data := buildPromptData(sk, rawContent)
+	assert.Equal(t, "none", data.Triggers)
+	assert.Equal(t, "none", data.AntiTriggers)
+}
+
+// --- WriteToDir edge cases ---
+
+func TestWriteToDir_EmptyTaskPath(t *testing.T) {
+	s := &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Tasks: []GeneratedFile{
+			{Path: "", Content: "id: auto\nname: Auto\ninputs:\n  prompt: hi"},
+		},
+	}
+
+	dir := t.TempDir()
+	written, err := s.WriteToDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, written, 2) // eval.yaml + auto-named task
+}
+
+func TestWriteToDir_EmptyFixturePath(t *testing.T) {
+	s := &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Fixtures: []GeneratedFile{
+			{Path: "", Content: "fixture content"},
+		},
+	}
+
+	dir := t.TempDir()
+	written, err := s.WriteToDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, written, 2) // eval.yaml + auto-named fixture
+}
+
+func TestWriteToDir_AbsolutePathRejected(t *testing.T) {
+	s := &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Tasks: []GeneratedFile{
+			{Path: "/etc/evil.yaml", Content: "id: x\nname: X\ninputs:\n  prompt: hi"},
+		},
+	}
+
+	dir := t.TempDir()
+	_, err := s.WriteToDir(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid generated path")
+}
+
+func TestWriteToDir_TraversalPathRejected(t *testing.T) {
+	s := &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Fixtures: []GeneratedFile{
+			{Path: "../../etc/passwd", Content: "evil"},
+		},
+	}
+
+	dir := t.TempDir()
+	_, err := s.WriteToDir(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid generated path")
+}
+
+func TestWriteToDir_InvalidEvalYAML(t *testing.T) {
+	s := &Suggestion{
+		EvalYAML: "this is not valid eval yaml",
+	}
+
+	dir := t.TempDir()
+	_, err := s.WriteToDir(dir)
+	require.Error(t, err)
+}
+
+func validEvalYAML() string {
+	return `name: test-eval
+description: test
+skill: sample
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 120
+  parallel: false
+  executor: mock
+  model: test
+graders:
+  - type: code
+    name: has_output
+    config:
+      assertions:
+        - "len(output) > 0"
+metrics:
+  - name: completion
+    weight: 1.0
+    threshold: 0.8
+tasks:
+  - "tasks/*.yaml"`
+}

--- a/internal/suggest/resolve_test.go
+++ b/internal/suggest/resolve_test.go
@@ -24,7 +24,8 @@ func TestResolveSkillFile_WhitespacePath(t *testing.T) {
 }
 
 func TestResolveSkillFile_NonexistentPath(t *testing.T) {
-	_, err := resolveSkillFile("/nonexistent/path/to/skill")
+	nonexistent := filepath.Join(t.TempDir(), "does-not-exist", "skill")
+	_, err := resolveSkillFile(nonexistent)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not exist")
 }


### PR DESCRIPTION
## Summary

Boost test coverage for two packages that were below 80%:

| Package | Before | After | Target |
|---------|--------|-------|--------|
| `internal/suggest` | 68.4% | **83.1%** | 80%+ ✅ |
| `internal/jsonrpc` | 69.3% | **90.8%** | 80%+ ✅ |

## New test files

### suggest package (+6 files)
- **grader_docs_test.go** — `GraderSummaries` format, `LoadGraderDocs` with `fstest.MapFS` (nil, empty, mixed valid/invalid, whitespace trimming)
- **prompt_test.go** — `renderSelectionPrompt`, `renderImplementationPrompt`, `renderPrompt` with various data shapes and empty fields
- **helpers_test.go** — `orDefault`, `phrasesToText`, `summarizeBody`, `extractYAML`, `normalizeGeneratedPath`, `filterValidGraderTypes`, `parseGraderSelection` edge cases
- **resolve_test.go** — `resolveSkillFile`, `loadSkill`, `buildPromptData`, `WriteToDir` edge cases (empty paths, traversal, invalid YAML)

### jsonrpc package (+2 files)
- **methods_test.go** — `MethodRegistry` CRUD, overwrite, empty name, handler error/params, `RegisterHandlers` verification
- **handlers_extra_test.go** — `task.list`/`task.get` success paths, `run.cancel` success/already-completed, `eval.*` edge cases, TCP listener lifecycle, malformed YAML validation

## Verification
- All tests pass: `go test -mod=readonly -count=1 ./internal/suggest/... ./internal/jsonrpc/...`
- `go vet` clean on both packages
- No changes to production code