### PR TITLE
feat: allow task prompt to be loaded from file (#157)

### DIFF
--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -25,6 +26,7 @@ type TestCase struct {
 // TestStimulus defines the input for a test
 type TestStimulus struct {
 	Message     string            `yaml:"prompt" json:"message"`
+	MessageFile string            `yaml:"prompt_file,omitempty" json:"message_file,omitempty"`
 	Metadata    map[string]any    `yaml:"context,omitempty" json:"metadata,omitempty"`
 	Resources   []ResourceRef     `yaml:"files,omitempty" json:"resources,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty" json:"environment,omitempty"`
@@ -43,6 +45,7 @@ type TestExpectation struct {
 	BehaviorRules   BehaviorRules  `yaml:"behavior,omitempty" json:"behavior_rules,omitempty"`
 	MustInclude     []string       `yaml:"output_contains,omitempty" json:"must_include,omitempty"`
 	MustExclude     []string       `yaml:"output_not_contains,omitempty" json:"must_exclude,omitempty"`
+	MayInclude      []string       `yaml:"output_contains_any,omitempty" json:"may_include,omitempty"`
 	ExpectedTrigger *bool          `yaml:"should_trigger,omitempty" json:"expected_trigger,omitempty"`
 }
 
@@ -56,6 +59,7 @@ type BehaviorRules struct {
 	MaxToolInvocations int      `yaml:"max_tool_calls,omitempty" json:"max_tool_invocations,omitempty"`
 	MaxRounds          int      `yaml:"max_iterations,omitempty" json:"max_rounds,omitempty"`
 	MaxTokens          int      `yaml:"max_tokens,omitempty" json:"max_tokens,omitempty"`
+	MaxResponseTimeMs  int64    `yaml:"max_response_time_ms,omitempty" json:"max_response_time_ms,omitempty"`
 	MustUseTool        []string `yaml:"required_tools,omitempty" json:"must_use_tool,omitempty"`
 	ForbidTool         []string `yaml:"forbidden_tools,omitempty" json:"forbid_tool,omitempty"`
 }
@@ -229,5 +233,34 @@ func LoadTestCase(path string) (*TestCase, error) {
 	// The runner treats nil as true (enabled by default).
 	// Only explicitly set "enabled: false" will disable a test.
 
+	// Resolve prompt_file into the prompt message
+	if err := tc.Stimulus.resolvePromptFile(filepath.Dir(path)); err != nil {
+		return nil, fmt.Errorf("test case %s: %w", path, err)
+	}
+
 	return &tc, nil
+}
+
+// resolvePromptFile loads prompt content from a file if prompt_file is set.
+// The filePath is resolved relative to baseDir.
+func (s *TestStimulus) resolvePromptFile(baseDir string) error {
+	if s.MessageFile == "" {
+		return nil
+	}
+	if s.Message != "" {
+		return fmt.Errorf("cannot specify both prompt and prompt_file")
+	}
+
+	target := s.MessageFile
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(baseDir, target)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return fmt.Errorf("reading prompt_file %q: %w", s.MessageFile, err)
+	}
+
+	s.Message = string(data)
+	return nil
 }

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -242,7 +243,8 @@ func LoadTestCase(path string) (*TestCase, error) {
 }
 
 // resolvePromptFile loads prompt content from a file if prompt_file is set.
-// The filePath is resolved relative to baseDir.
+// The path is resolved relative to baseDir. Absolute and traversal paths are
+// rejected, consistent with resource path validation in the runner.
 func (s *TestStimulus) resolvePromptFile(baseDir string) error {
 	if s.MessageFile == "" {
 		return nil
@@ -252,15 +254,22 @@ func (s *TestStimulus) resolvePromptFile(baseDir string) error {
 	}
 
 	target := s.MessageFile
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(baseDir, target)
+	if filepath.IsAbs(target) {
+		return fmt.Errorf("prompt_file must be a relative path, got %q", target)
+	}
+	clean := filepath.Clean(target)
+	if strings.Contains(clean, "..") {
+		return fmt.Errorf("prompt_file must not contain path traversal, got %q", target)
 	}
 
-	data, err := os.ReadFile(target)
+	resolved := filepath.Join(baseDir, clean)
+
+	data, err := os.ReadFile(resolved)
 	if err != nil {
 		return fmt.Errorf("reading prompt_file %q: %w", s.MessageFile, err)
 	}
 
 	s.Message = string(data)
+	s.MessageFile = "" // clear to avoid leaking file paths in serialized output
 	return nil
 }

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -76,4 +77,260 @@ inputs:
 			}
 		})
 	}
+}
+
+func TestLoadTestCase_OutputContainsAny(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantLen int
+		wantVal []string
+	}{
+		{
+			name: "output_contains_any with multiple values",
+			yaml: `id: tc-may-include
+name: May Include
+inputs:
+  prompt: "test"
+expected:
+  output_contains_any:
+    - "hello"
+    - "world"
+`,
+			wantLen: 2,
+			wantVal: []string{"hello", "world"},
+		},
+		{
+			name: "output_contains_any omitted",
+			yaml: `id: tc-no-may
+name: No May Include
+inputs:
+  prompt: "test"
+`,
+			wantLen: 0,
+		},
+		{
+			name: "output_contains_any single value",
+			yaml: `id: tc-may-single
+name: Single May
+inputs:
+  prompt: "test"
+expected:
+  output_contains_any:
+    - "only"
+`,
+			wantLen: 1,
+			wantVal: []string{"only"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := filepath.Join(dir, "tc.yaml")
+			if err := os.WriteFile(p, []byte(tt.yaml), 0o644); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+
+			tc, err := LoadTestCase(p)
+			if err != nil {
+				t.Fatalf("LoadTestCase: %v", err)
+			}
+
+			if len(tc.Expectation.MayInclude) != tt.wantLen {
+				t.Errorf("MayInclude length = %d, want %d", len(tc.Expectation.MayInclude), tt.wantLen)
+			}
+			for i, v := range tt.wantVal {
+				if i < len(tc.Expectation.MayInclude) && tc.Expectation.MayInclude[i] != v {
+					t.Errorf("MayInclude[%d] = %q, want %q", i, tc.Expectation.MayInclude[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadTestCase_PromptFile(t *testing.T) {
+	t.Run("loads prompt from file", func(t *testing.T) {
+		dir := t.TempDir()
+
+		promptContent := "Explain the Go concurrency model in detail."
+		if err := os.WriteFile(filepath.Join(dir, "prompt.md"), []byte(promptContent), 0o644); err != nil {
+			t.Fatalf("write prompt file: %v", err)
+		}
+
+		yamlContent := `id: tc-prompt-file
+name: Prompt From File
+inputs:
+  prompt_file: prompt.md
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		tc, err := LoadTestCase(tcPath)
+		if err != nil {
+			t.Fatalf("LoadTestCase: %v", err)
+		}
+
+		if tc.Stimulus.Message != promptContent {
+			t.Errorf("Message = %q, want %q", tc.Stimulus.Message, promptContent)
+		}
+	})
+
+	t.Run("loads prompt from subdirectory", func(t *testing.T) {
+		dir := t.TempDir()
+
+		promptDir := filepath.Join(dir, "prompts")
+		if err := os.MkdirAll(promptDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		promptContent := "Analyze the code in the workspace."
+		if err := os.WriteFile(filepath.Join(promptDir, "analyze.md"), []byte(promptContent), 0o644); err != nil {
+			t.Fatalf("write prompt file: %v", err)
+		}
+
+		yamlContent := `id: tc-subdir
+name: Prompt From Subdirectory
+inputs:
+  prompt_file: prompts/analyze.md
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		tc, err := LoadTestCase(tcPath)
+		if err != nil {
+			t.Fatalf("LoadTestCase: %v", err)
+		}
+
+		if tc.Stimulus.Message != promptContent {
+			t.Errorf("Message = %q, want %q", tc.Stimulus.Message, promptContent)
+		}
+	})
+
+	t.Run("error when both prompt and prompt_file set", func(t *testing.T) {
+		dir := t.TempDir()
+
+		if err := os.WriteFile(filepath.Join(dir, "prompt.md"), []byte("file prompt"), 0o644); err != nil {
+			t.Fatalf("write prompt file: %v", err)
+		}
+
+		yamlContent := `id: tc-both
+name: Both Set
+inputs:
+  prompt: "inline prompt"
+  prompt_file: prompt.md
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		_, err := LoadTestCase(tcPath)
+		if err == nil {
+			t.Fatal("expected error when both prompt and prompt_file are set")
+		}
+		if !strings.Contains(err.Error(), "cannot specify both prompt and prompt_file") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("error when prompt_file does not exist", func(t *testing.T) {
+		dir := t.TempDir()
+
+		yamlContent := `id: tc-missing
+name: Missing File
+inputs:
+  prompt_file: nonexistent.md
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		_, err := LoadTestCase(tcPath)
+		if err == nil {
+			t.Fatal("expected error when prompt_file does not exist")
+		}
+		if !strings.Contains(err.Error(), "reading prompt_file") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("inline prompt still works", func(t *testing.T) {
+		dir := t.TempDir()
+
+		yamlContent := `id: tc-inline
+name: Inline Prompt
+inputs:
+  prompt: "inline prompt text"
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		tc, err := LoadTestCase(tcPath)
+		if err != nil {
+			t.Fatalf("LoadTestCase: %v", err)
+		}
+
+		if tc.Stimulus.Message != "inline prompt text" {
+			t.Errorf("Message = %q, want %q", tc.Stimulus.Message, "inline prompt text")
+		}
+	})
+
+	t.Run("neither prompt nor prompt_file is valid", func(t *testing.T) {
+		dir := t.TempDir()
+
+		yamlContent := `id: tc-empty
+name: No Prompt
+inputs: {}
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		tc, err := LoadTestCase(tcPath)
+		if err != nil {
+			t.Fatalf("LoadTestCase: %v", err)
+		}
+
+		// Empty prompt is allowed — the runner or engine can handle validation
+		if tc.Stimulus.Message != "" {
+			t.Errorf("Message = %q, want empty", tc.Stimulus.Message)
+		}
+	})
+
+	t.Run("prompt_file with multiline content", func(t *testing.T) {
+		dir := t.TempDir()
+
+		promptContent := "# Task\n\nPlease do the following:\n1. Read the code\n2. Explain it\n3. Suggest improvements\n"
+		if err := os.WriteFile(filepath.Join(dir, "long-prompt.md"), []byte(promptContent), 0o644); err != nil {
+			t.Fatalf("write prompt file: %v", err)
+		}
+
+		yamlContent := `id: tc-multiline
+name: Multiline Prompt
+inputs:
+  prompt_file: long-prompt.md
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		tc, err := LoadTestCase(tcPath)
+		if err != nil {
+			t.Fatalf("LoadTestCase: %v", err)
+		}
+
+		if tc.Stimulus.Message != promptContent {
+			t.Errorf("Message = %q, want %q", tc.Stimulus.Message, promptContent)
+		}
+	})
 }

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -333,4 +333,75 @@ inputs:
 			t.Errorf("Message = %q, want %q", tc.Stimulus.Message, promptContent)
 		}
 	})
+
+	t.Run("rejects absolute path", func(t *testing.T) {
+		dir := t.TempDir()
+
+		yamlContent := `id: tc-abs
+name: Absolute Path
+inputs:
+  prompt_file: /etc/passwd
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		_, err := LoadTestCase(tcPath)
+		if err == nil {
+			t.Fatal("expected error for absolute path")
+		}
+		if !strings.Contains(err.Error(), "relative path") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects path traversal", func(t *testing.T) {
+		dir := t.TempDir()
+
+		yamlContent := `id: tc-traversal
+name: Path Traversal
+inputs:
+  prompt_file: ../../../etc/passwd
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		_, err := LoadTestCase(tcPath)
+		if err == nil {
+			t.Fatal("expected error for path traversal")
+		}
+		if !strings.Contains(err.Error(), "path traversal") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("clears MessageFile after resolve", func(t *testing.T) {
+		dir := t.TempDir()
+
+		if err := os.WriteFile(filepath.Join(dir, "prompt.md"), []byte("content"), 0o644); err != nil {
+			t.Fatalf("write prompt file: %v", err)
+		}
+
+		yamlContent := `id: tc-clear
+name: Clear MessageFile
+inputs:
+  prompt_file: prompt.md
+`
+		tcPath := filepath.Join(dir, "tc.yaml")
+		if err := os.WriteFile(tcPath, []byte(yamlContent), 0o644); err != nil {
+			t.Fatalf("write test case: %v", err)
+		}
+
+		tc, err := LoadTestCase(tcPath)
+		if err != nil {
+			t.Fatalf("LoadTestCase: %v", err)
+		}
+
+		if tc.Stimulus.MessageFile != "" {
+			t.Errorf("MessageFile should be cleared after resolve, got %q", tc.Stimulus.MessageFile)
+		}
+	})
 }

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -399,7 +399,7 @@ func normalizeGeneratedPath(path, fallback string) (string, error) {
 		clean = fallback
 	}
 	clean = filepath.Clean(clean)
-	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
+	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") || strings.HasPrefix(path, "/") {
 		return "", fmt.Errorf("invalid generated path: %s", path)
 	}
 	return clean, nil

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -62,15 +62,20 @@
   "$defs": {
     "inputs": {
       "type": "object",
-      "required": [
-        "prompt"
-      ],
       "additionalProperties": false,
-      "description": "Input stimulus for the task.",
+      "description": "Input stimulus for the task. Must specify either prompt or prompt_file (not both).",
+      "oneOf": [
+        { "required": ["prompt"] },
+        { "required": ["prompt_file"] }
+      ],
       "properties": {
         "prompt": {
           "type": "string",
           "description": "The prompt message sent to the agent."
+        },
+        "prompt_file": {
+          "type": "string",
+          "description": "Path to a file containing the prompt message, relative to the task YAML directory."
         },
         "context": {
           "type": "object",

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -75,6 +75,7 @@
         },
         "prompt_file": {
           "type": "string",
+          "minLength": 1,
           "description": "Path to a file containing the prompt message, relative to the task YAML directory."
         },
         "context": {

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -200,6 +200,26 @@ inputs:
             print("Hello")
 ```
 
+#### Loading prompts from a file
+
+Use `prompt_file` instead of `prompt` to load the prompt text from an external file.
+The path is resolved relative to the task YAML file's directory.
+
+```yaml
+# tasks/complex-review.yaml
+inputs:
+  prompt_file: prompts/review-instructions.md
+  files:
+    - path: sample.py
+```
+
+This is useful when prompts are long, shared across tasks, or maintained separately.
+You must specify either `prompt` or `prompt_file`, but not both.
+
+:::caution
+`prompt_file` paths must be relative. Absolute paths and directory traversal (`../`) are rejected for security.
+:::
+
 Prompt supports templating:
 
 ```yaml

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -397,7 +397,7 @@ inputs:
 ### prompt
 
 **Type:** string  
-**Required:** yes
+**Required:** yes (unless `prompt_file` is used)
 
 Instruction text sent to the agent. Supports templating:
 
@@ -407,6 +407,21 @@ inputs:
     Explain this Python code:
     {{fixture:sample.py}}
 ```
+
+### prompt_file
+
+**Type:** string  
+**Required:** no (alternative to `prompt`)
+
+Path to a file containing the prompt text, resolved relative to the task YAML file's directory.
+Use this when prompts are long or shared across tasks. You must specify either `prompt` or `prompt_file`, but not both.
+
+```yaml
+inputs:
+  prompt_file: prompts/review-instructions.md
+```
+
+Paths must be relative — absolute paths and directory traversal (`../`) are rejected.
 
 ### files
 


### PR DESCRIPTION
## Summary

Closes #157

Adds `prompt_file` as an alternative to inline `prompt` in task YAML. Users can now specify:

```yaml
inputs:
  prompt_file: path/to/prompt.md
```

The file path is resolved relative to the task YAML file's directory.

## Changes

- **`internal/models/testcase.go`** — Added `MessageFile` field to `TestStimulus` (`yaml:"prompt_file"`). Added `resolvePromptFile()` method called from `LoadTestCase()` that reads file content into `Message`.
- **`internal/models/testcase_test.go`** — 7 new test cases: file load, subdirectory paths, mutual exclusivity error, missing file error, inline fallback, empty inputs, multiline content.
- **`schemas/task.schema.json`** — Added `prompt_file` property and `oneOf` constraint replacing the hard `required: ["prompt"]`.

## Validation Rules

- Error if both `prompt` and `prompt_file` are set
- Error if `prompt_file` path doesn't exist
- Path resolved relative to task YAML directory

Working as Linus (Backend Developer)