### PR TITLE
feat: add tool_calls grader (#187)

### DIFF
--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -74,6 +74,8 @@ func Create(identifier string, params models.GraderParameters) (Grader, error) {
 		return NewSkillInvocationGrader(identifier, p)
 	case models.ToolConstraintGraderParameters:
 		return NewToolConstraintGrader(identifier, p)
+	case models.ToolCallsGraderParameters:
+		return NewToolCallsGrader(identifier, p)
 	case models.DiffGraderParameters:
 		return NewDiffGrader(identifier, p)
 	case models.PromptGraderParameters:

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -1,0 +1,129 @@
+package graders
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/waza/internal/models"
+)
+
+// ToolCallsGrader validates which tools an agent called during execution.
+// It checks required tools, forbidden tools, minimum calls, and maximum calls.
+type ToolCallsGrader struct {
+	name   string
+	params models.ToolCallsGraderParameters
+}
+
+// NewToolCallsGrader creates a new ToolCallsGrader, returning an error if the
+// parameters are invalid (e.g. no constraints defined, negative bounds, or
+// min > max).
+func NewToolCallsGrader(name string, params models.ToolCallsGraderParameters) (*ToolCallsGrader, error) {
+	hasConstraint := len(params.RequiredTools) > 0 ||
+		len(params.ForbiddenTools) > 0 ||
+		params.MinCalls != nil ||
+		params.MaxCalls != nil
+
+	if !hasConstraint {
+		return nil, fmt.Errorf("tool_calls grader %q: at least one constraint (required_tools, forbidden_tools, min_calls, max_calls) must be specified", name)
+	}
+
+	if params.MinCalls != nil && *params.MinCalls < 0 {
+		return nil, fmt.Errorf("tool_calls grader %q: min_calls must be non-negative, got %d", name, *params.MinCalls)
+	}
+	if params.MaxCalls != nil && *params.MaxCalls < 0 {
+		return nil, fmt.Errorf("tool_calls grader %q: max_calls must be non-negative, got %d", name, *params.MaxCalls)
+	}
+	if params.MinCalls != nil && params.MaxCalls != nil && *params.MinCalls > *params.MaxCalls {
+		return nil, fmt.Errorf("tool_calls grader %q: min_calls (%d) must be <= max_calls (%d)", name, *params.MinCalls, *params.MaxCalls)
+	}
+
+	return &ToolCallsGrader{name: name, params: params}, nil
+}
+
+func (g *ToolCallsGrader) Name() string            { return g.name }
+func (g *ToolCallsGrader) Kind() models.GraderKind { return models.GraderKindToolCalls }
+
+func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.GraderResults, error) {
+	return measureTime(func() (*models.GraderResults, error) {
+		if gCtx.Session == nil {
+			return &models.GraderResults{
+				Name:     g.name,
+				Passed:   false,
+				Score:    0,
+				Feedback: "no session data available for tool_calls grading",
+			}, nil
+		}
+
+		calledSet := make(map[string]bool, len(gCtx.Session.ToolCalls))
+		for _, tc := range gCtx.Session.ToolCalls {
+			calledSet[tc.Name] = true
+		}
+		totalCalls := len(gCtx.Session.ToolCalls)
+
+		var totalChecks, passedChecks int
+		var failures []string
+
+		for _, tool := range g.params.RequiredTools {
+			totalChecks++
+			if calledSet[tool] {
+				passedChecks++
+			} else {
+				failures = append(failures, fmt.Sprintf("required tool %q was not called", tool))
+			}
+		}
+
+		for _, tool := range g.params.ForbiddenTools {
+			totalChecks++
+			if calledSet[tool] {
+				failures = append(failures, fmt.Sprintf("forbidden tool %q was called", tool))
+			} else {
+				passedChecks++
+			}
+		}
+
+		if g.params.MinCalls != nil {
+			totalChecks++
+			if totalCalls >= *g.params.MinCalls {
+				passedChecks++
+			} else {
+				failures = append(failures, fmt.Sprintf("expected at least %d tool calls, got %d", *g.params.MinCalls, totalCalls))
+			}
+		}
+
+		if g.params.MaxCalls != nil {
+			totalChecks++
+			if totalCalls <= *g.params.MaxCalls {
+				passedChecks++
+			} else {
+				failures = append(failures, fmt.Sprintf("expected at most %d tool calls, got %d", *g.params.MaxCalls, totalCalls))
+			}
+		}
+
+		score := float64(passedChecks) / float64(totalChecks)
+		passed := passedChecks == totalChecks
+
+		feedback := "all tool_calls checks passed"
+		if !passed {
+			feedback = strings.Join(failures, "; ")
+		}
+
+		calledNames := make([]string, 0, len(calledSet))
+		for name := range calledSet {
+			calledNames = append(calledNames, name)
+		}
+
+		return &models.GraderResults{
+			Name:     g.name,
+			Passed:   passed,
+			Score:    score,
+			Feedback: feedback,
+			Details: map[string]any{
+				"total_calls":   totalCalls,
+				"unique_tools":  calledNames,
+				"passed_checks": passedChecks,
+				"total_checks":  totalChecks,
+			},
+		}, nil
+	})
+}

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -1,0 +1,354 @@
+package graders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func intPtr(v int) *int { return &v }
+
+func TestToolCallsGrader_NoConstraints(t *testing.T) {
+	_, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one constraint")
+}
+
+func TestToolCallsGrader_NegativeMinCalls(t *testing.T) {
+	_, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{MinCalls: intPtr(-1)})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "min_calls must be non-negative")
+}
+
+func TestToolCallsGrader_NegativeMaxCalls(t *testing.T) {
+	_, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{MaxCalls: intPtr(-1)})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max_calls must be non-negative")
+}
+
+func TestToolCallsGrader_MinGreaterThanMax(t *testing.T) {
+	_, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		MinCalls: intPtr(5),
+		MaxCalls: intPtr(2),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "min_calls (5) must be <= max_calls (2)")
+}
+
+func TestToolCallsGrader_ValidMinEqualsMax(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		MinCalls: intPtr(3),
+		MaxCalls: intPtr(3),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, g)
+}
+
+func TestToolCallsGrader_NameAndKind(t *testing.T) {
+	g, err := NewToolCallsGrader("my-grader", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"bash"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "my-grader", g.Name())
+	require.Equal(t, models.GraderKindToolCalls, g.Kind())
+}
+
+func TestToolCallsGrader_NilSession(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"bash"},
+	})
+	res, err := g.Grade(context.Background(), &Context{})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.Equal(t, float64(0), res.Score)
+	require.Contains(t, res.Feedback, "no session data")
+}
+
+func TestToolCallsGrader_RequiredTools_AllPresent(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"bash", "view"},
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+				{Name: "view"},
+				{Name: "edit"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed)
+	require.Equal(t, 1.0, res.Score)
+}
+
+func TestToolCallsGrader_RequiredTools_SomeMissing(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"bash", "view", "grep"},
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.InDelta(t, 1.0/3.0, res.Score, 0.01)
+	require.Contains(t, res.Feedback, "view")
+	require.Contains(t, res.Feedback, "grep")
+}
+
+func TestToolCallsGrader_ForbiddenTools_NoneUsed(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		ForbiddenTools: []string{"rm", "sudo"},
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed)
+	require.Equal(t, 1.0, res.Score)
+}
+
+func TestToolCallsGrader_ForbiddenTools_SomeUsed(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		ForbiddenTools: []string{"rm", "sudo"},
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "rm"},
+				{Name: "bash"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.Equal(t, 0.5, res.Score)
+	require.Contains(t, res.Feedback, `forbidden tool "rm" was called`)
+}
+
+func TestToolCallsGrader_MinCalls_Pass(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		MinCalls: intPtr(2),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+				{Name: "view"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed)
+}
+
+func TestToolCallsGrader_MinCalls_Fail(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		MinCalls: intPtr(5),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.Contains(t, res.Feedback, "at least 5 tool calls")
+}
+
+func TestToolCallsGrader_MaxCalls_Pass(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		MaxCalls: intPtr(3),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+				{Name: "view"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed)
+}
+
+func TestToolCallsGrader_MaxCalls_Fail(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		MaxCalls: intPtr(1),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+				{Name: "view"},
+				{Name: "edit"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.Contains(t, res.Feedback, "at most 1 tool calls")
+}
+
+func TestToolCallsGrader_Combined_AllPass(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools:  []string{"bash"},
+		ForbiddenTools: []string{"rm"},
+		MinCalls:       intPtr(1),
+		MaxCalls:       intPtr(5),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+				{Name: "view"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed)
+	require.Equal(t, 1.0, res.Score)
+	require.Contains(t, res.Feedback, "all tool_calls checks passed")
+}
+
+func TestToolCallsGrader_Combined_PartialFailure(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools:  []string{"bash", "grep"},
+		ForbiddenTools: []string{"rm"},
+		MinCalls:       intPtr(1),
+		MaxCalls:       intPtr(10),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+				{Name: "view"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.InDelta(t, 4.0/5.0, res.Score, 0.01)
+	require.Contains(t, res.Feedback, `required tool "grep" was not called`)
+}
+
+func TestToolCallsGrader_AllChecksFail(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools:  []string{"bash"},
+		ForbiddenTools: []string{"rm"},
+		MinCalls:       intPtr(10),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "rm"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.Equal(t, 0.0, res.Score)
+}
+
+func TestToolCallsGrader_Details(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"bash"},
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+				{Name: "bash"},
+				{Name: "view"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, res.Details["total_calls"])
+	require.Equal(t, 1, res.Details["passed_checks"])
+	require.Equal(t, 1, res.Details["total_checks"])
+	unique := res.Details["unique_tools"].([]string)
+	require.ElementsMatch(t, []string{"bash", "view"}, unique)
+}
+
+func TestToolCallsGrader_EmptyToolCalls(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"bash"},
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.Equal(t, 0.0, res.Score)
+}
+
+func TestToolCallsGrader_DuplicateToolCalls(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"bash"},
+		MaxCalls:      intPtr(5),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+				{Name: "bash"},
+				{Name: "bash"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed)
+	require.Equal(t, 3, res.Details["total_calls"])
+}
+
+func TestToolCallsGrader_MinCallsZero(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		MinCalls: intPtr(0),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed)
+}
+
+func TestToolCallsGrader_MaxCallsZero(t *testing.T) {
+	g, _ := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		MaxCalls: intPtr(0),
+	})
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+}
+
+func TestToolCallsGrader_Factory(t *testing.T) {
+	g, err := Create("check-tools", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"bash"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "check-tools", g.Name())
+	require.Equal(t, models.GraderKindToolCalls, g.Kind())
+}

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -279,7 +279,8 @@ func TestToolCallsGrader_Details(t *testing.T) {
 	require.Equal(t, 3, res.Details["total_calls"])
 	require.Equal(t, 1, res.Details["passed_checks"])
 	require.Equal(t, 1, res.Details["total_checks"])
-	unique := res.Details["unique_tools"].([]string)
+	unique, ok := res.Details["unique_tools"].([]string)
+	require.True(t, ok)
 	require.ElementsMatch(t, []string{"bash", "view"}, unique)
 }
 

--- a/internal/models/grader_params.go
+++ b/internal/models/grader_params.go
@@ -150,6 +150,16 @@ type DiffGraderParameters struct {
 
 func (DiffGraderParameters) isGraderParameters() {}
 
+// ToolCallsGraderParameters validates which tools were called during a session.
+type ToolCallsGraderParameters struct {
+	RequiredTools  []string `yaml:"required_tools,omitempty" json:"required_tools,omitempty"`
+	ForbiddenTools []string `yaml:"forbidden_tools,omitempty" json:"forbidden_tools,omitempty"`
+	MinCalls       *int     `yaml:"min_calls,omitempty" json:"min_calls,omitempty"`
+	MaxCalls       *int     `yaml:"max_calls,omitempty" json:"max_calls,omitempty"`
+}
+
+func (ToolCallsGraderParameters) isGraderParameters() {}
+
 type PromptGraderMode string
 
 const (
@@ -210,6 +220,8 @@ func decodeGraderParameters(kind GraderKind, configNode *yaml.Node) (GraderParam
 		return decodeYAMLNode[SkillInvocationGraderParameters](configNode)
 	case GraderKindToolConstraint:
 		return decodeYAMLNode[ToolConstraintGraderParameters](configNode)
+	case GraderKindToolCalls:
+		return decodeYAMLNode[ToolCallsGraderParameters](configNode)
 	case GraderKindDiff:
 		return decodeYAMLNode[DiffGraderParameters](configNode)
 	case GraderKindPrompt:

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -38,6 +38,7 @@ const (
 	GraderKindTrigger         GraderKind = "trigger"
 	GraderKindDiff            GraderKind = "diff"
 	GraderKindToolConstraint  GraderKind = "tool_constraint"
+	GraderKindToolCalls       GraderKind = "tool_calls"
 )
 
 func AllGraderKinds() []string {
@@ -54,6 +55,7 @@ func AllGraderKinds() []string {
 		string(GraderKindTrigger),
 		string(GraderKindDiff),
 		string(GraderKindToolConstraint),
+		string(GraderKindToolCalls),
 	}
 
 	sort.Strings(names)

--- a/site/src/content/docs/guides/graders.mdx
+++ b/site/src/content/docs/guides/graders.mdx
@@ -43,6 +43,7 @@ waza ships with **several built-in grader types**. Pick the right one for the jo
 | [Skill Invocation](#skill-invocation-skill_invocation) | `skill_invocation` | Which skills were invoked and in what order          |
 | [Program](#program)                                    | `program`          | External command (any language) grades via exit code |
 | [Tool Constraint](#tool-constraint)                    | `tool_constraint`  | Validate tool usage constraints (expect/reject lists and argument patterns) |
+| [Tool Calls](#tool-calls-tool_calls)                   | `tool_calls`       | Validate required/forbidden tools and call count bounds                    |
 | [Trigger](#trigger)                                    | `trigger`          | Heuristic grader for validating whether a prompt should activate a skill   |
 
 ---
@@ -515,6 +516,68 @@ At least one constraint must be configured. Each configured rule counts as one c
       - bash
       - edit
       - grep
+```
+
+---
+
+## Tool Calls (`tool_calls`)
+
+Validates which tools an agent called during execution. Supports required tools, forbidden tools, and call-count bounds — all in one grader. Each configured constraint counts as one check; partial credit is awarded.
+
+```yaml
+- type: tool_calls
+  name: tool_usage
+  config:
+    required_tools:
+      - bash
+      - edit
+    forbidden_tools:
+      - rm
+      - sudo
+    min_calls: 2
+    max_calls: 20
+```
+
+| Option            | Type        | Default | Description                                     |
+| ----------------- | ----------- | ------- | ----------------------------------------------- |
+| `required_tools`  | `list[str]` | `[]`    | Tool names that **must** appear in the session  |
+| `forbidden_tools` | `list[str]` | `[]`    | Tool names that **must not** appear             |
+| `min_calls`       | `int`       | `0`     | Minimum total tool calls required (0 = no min)  |
+| `max_calls`       | `int`       | `0`     | Maximum total tool calls allowed (0 = no limit) |
+
+At least one constraint must be configured. When both `min_calls` and `max_calls` are set, `min_calls` must be ≤ `max_calls`.
+
+**Scoring:** `passed_checks / total_checks`
+
+<Aside type="tip" title="tool_calls vs. tool_constraint vs. behavior">
+  Use `tool_calls` for simple required/forbidden tool lists with call-count
+  bounds. Use `tool_constraint` when you also need turn and token budgets.
+  Use `behavior` when you need `max_duration_ms` or a single
+  `max_tool_calls` cap without tool-name validation.
+</Aside>
+
+### Example: enforce safe tool usage
+
+```yaml
+- type: tool_calls
+  name: safety_check
+  config:
+    forbidden_tools:
+      - rm
+      - sudo
+    max_calls: 30
+```
+
+### Example: verify minimum workflow
+
+```yaml
+- type: tool_calls
+  name: workflow_check
+  config:
+    required_tools:
+      - bash
+      - edit
+    min_calls: 3
 ```
 
 ---

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -273,7 +273,7 @@ graders:
 
 | Field    | Type   | Description                                                                                                                                                      |
 | -------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`   | string | Grader type: `code`, `prompt`, `text`, `file`, `json_schema`, `program`, `behavior`, `action_sequence`, `skill_invocation`, `trigger`, `diff`, `tool_constraint` |
+| `type`   | string | Grader type: `code`, `prompt`, `text`, `file`, `json_schema`, `program`, `behavior`, `action_sequence`, `skill_invocation`, `trigger`, `diff`, `tool_constraint`, `tool_calls` |
 | `name`   | string | Unique grader name (used to reference in tasks)                                                                                                                  |
 | `weight` | float  | Relative importance in composite scoring (default: `1.0`)                                                                                                        |
 | `config` | object | Type-specific configuration                                                                                                                                      |


### PR DESCRIPTION
## Summary

Adds a new `tool_calls` grader that validates which tools an agent called during execution, without caring about order.

**Closes #187**

## Constraints Supported

| Parameter | Type | Description |
|-----------|------|-------------|
| `required_tools` | `[]string` | Tools that must appear in the session |
| `forbidden_tools` | `[]string` | Tools that must not appear |
| `min_calls` | `*int` | Minimum total tool call count |
| `max_calls` | `*int` | Maximum total tool call count |

## Scoring

Partial credit: `score = passed_checks / total_checks`. Each constraint counts as one check. Constructor validates parameters at creation time (non-negative bounds, min ≤ max, at least one constraint).

## Example YAML

```yaml
graders:
  - kind: tool_calls
    name: verify-tools
    params:
      required_tools: [bash, view]
      forbidden_tools: [rm]
      min_calls: 2
      max_calls: 20
```

## Changes

- **`internal/models/outcome.go`**: Added `GraderKindToolCalls` constant + `AllGraderKinds()` registration
- **`internal/models/grader_params.go`**: Added `ToolCallsGraderParameters` struct + YAML decoder case
- **`internal/graders/grader.go`**: Added factory case
- **`internal/graders/tool_calls_grader.go`**: Full grader implementation (~120 lines)
- **`internal/graders/tool_calls_grader_test.go`**: 25 tests covering constructor validation, required/forbidden tools, call count bounds, combined checks, partial scoring, details output, edge cases, and factory integration

## Testing

All 25 new tests pass. Existing model and grader tests unaffected.