### PR TITLE
fix: webserver test skips when frontend assets not built

### DIFF
--- a/internal/suggest/resolve_test.go
+++ b/internal/suggest/resolve_test.go
@@ -3,6 +3,7 @@ package suggest
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -182,10 +183,14 @@ func TestWriteToDir_EmptyFixturePath(t *testing.T) {
 }
 
 func TestWriteToDir_AbsolutePathRejected(t *testing.T) {
+	absPath := "/etc/evil.yaml"
+	if runtime.GOOS == "windows" {
+		absPath = `C:\evil.yaml`
+	}
 	s := &Suggestion{
 		EvalYAML: validEvalYAML(),
 		Tasks: []GeneratedFile{
-			{Path: "/etc/evil.yaml", Content: "id: x\nname: X\ninputs:\n  prompt: hi"},
+			{Path: absPath, Content: "id: x\nname: X\ninputs:\n  prompt: hi"},
 		},
 	}
 

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -177,7 +177,7 @@ func TestIndexHTMLReferencesExistingAssets(t *testing.T) {
 	require.NoError(t, err, "unexpected error reading dist/assets")
 
 	// Verify assets/ actually contains JS or CSS bundles.  The directory
-	// may exist but be empty (e.g., partial build or cache artefact).
+	// may exist but be empty (e.g., partial build or cache artifact).
 	var hasBundles bool
 	for _, e := range entries {
 		if !e.IsDir() {

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -170,10 +170,26 @@ func TestIndexHTMLReferencesExistingAssets(t *testing.T) {
 	distFS, err := fs.Sub(web.Assets, "dist")
 	require.NoError(t, err)
 
-	if _, err := fs.ReadDir(distFS, "assets"); errors.Is(err, fs.ErrNotExist) {
+	entries, err := fs.ReadDir(distFS, "assets")
+	if errors.Is(err, fs.ErrNotExist) {
 		t.Skip("skipping: web/dist/assets not built (run 'cd web && npm run build' or 'make build-web')")
-	} else if err != nil {
-		require.NoError(t, err, "unexpected error reading dist/assets")
+	}
+	require.NoError(t, err, "unexpected error reading dist/assets")
+
+	// Verify assets/ actually contains JS or CSS bundles.  The directory
+	// may exist but be empty (e.g., partial build or cache artefact).
+	var hasBundles bool
+	for _, e := range entries {
+		if !e.IsDir() {
+			ext := filepath.Ext(e.Name())
+			if ext == ".js" || ext == ".css" {
+				hasBundles = true
+				break
+			}
+		}
+	}
+	if !hasBundles {
+		t.Skip("skipping: web/dist/assets contains no JS/CSS bundles (run 'cd web && npm run build' or 'make build-web')")
 	}
 
 	indexBytes, err := fs.ReadFile(distFS, "index.html")


### PR DESCRIPTION
## Problem

`TestIndexHTMLReferencesExistingAssets` fails on Windows CI because `npm run build` only runs on the ubuntu-latest matrix. The test's skip guard only checked whether the `assets/` directory existed — not whether it contained actual JS/CSS bundles. If the directory exists but is empty (cache artefact, partial build), the test proceeds and fails when the SPA fallback serves `index.html` instead of the expected asset content types.

## Fix

After confirming `assets/` exists, the test now also verifies it contains at least one `.js` or `.css` file. If not, it skips with a descriptive message pointing at `npm run build`.

## Verification

- `go test -count=1 -v ./internal/webserver/...` — all pass
- `go test ./...` — full suite green
- `go vet ./...` — clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>