### PR TITLE
fix: audit YAML validation and add TestCase unknown field test (#132)

### DIFF
--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -78,6 +79,30 @@ inputs:
 	}
 }
 
+func TestLoadTestCase_UnknownFieldRejected(t *testing.T) {
+	yamlData := `id: tc-bogus
+name: has bogus field
+bogus_field: true
+inputs:
+  prompt: do something
+expected:
+  output_contains:
+    - "hello"
+`
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tc.yaml")
+	if err := os.WriteFile(p, []byte(yamlData), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	_, err := LoadTestCase(p)
+	if err == nil {
+		t.Fatal("expected error for unknown field 'bogus_field', got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus_field") {
+		t.Errorf("error should mention bogus_field, got: %v", err)
+	}
+}
+
 func TestLoadTestCase_OutputContainsAny(t *testing.T) {
 	yamlData := `id: tc-may
 name: test may-include
@@ -104,3 +129,7 @@ expected:
 		t.Errorf("expected first entry 'option_a', got %q", tc.Expectation.MayInclude[0])
 	}
 }
+
+// TestLoadTestCase_FollowUpPrompts was removed: it referenced
+// TestStimulus.FollowUps which does not exist. Re-add when that
+// field is implemented.


### PR DESCRIPTION
## Summary

Closes #132

### Audit Results

Audited all `yaml.Unmarshal` and `yaml.NewDecoder` calls across the Go codebase. **Finding: all user-facing config loaders already use strict parsing.**

**Already strict (`KnownFields(true)`):**
| Loader | File | Status |
|---|---|---|
| `LoadBenchmarkSpec` | `internal/models/spec.go:226` | ✅ strict |
| `GraderConfig.UnmarshalYAML` | `internal/models/spec.go:79` | ✅ strict |
| `LoadTestCase` | `internal/models/testcase.go:227` | ✅ strict |
| `ValidatorInline.UnmarshalYAML` | `internal/models/testcase.go:103` | ✅ strict |
| `DecodeGraderParams` | `internal/models/grader_params.go:252` | ✅ strict |
| `trigger.ParseSpec` | `internal/trigger/spec.go:27` | ✅ strict |
| `ProjectConfig.Load` | `internal/projectconfig/config.go:203` | ✅ strict |
| `jsonrpc eval validate` | `internal/jsonrpc/handlers.go:223` | ✅ strict |
| `suggest.validateEvalYAML` | `internal/suggest/suggest.go:336` | ✅ strict |
| `suggest.parseSuggestion` | `internal/suggest/suggest.go:202` | ✅ strict |

**Intentionally non-strict (correct):**
- `cmd_coverage.go` / `cmd_check.go` — partial struct parses that only read subset of eval.yaml fields
- `internal/generate` — skill frontmatter (documented: allows extra fields for other tools)
- `internal/skill` — frontmatter generic/node parse
- `internal/validation/schema.go` — schema probing into `any`
- `internal/suggest` — grader type probing

### Changes
- **Added** `TestLoadTestCase_UnknownFieldRejected` — proves that a task YAML with `bogus_field: true` is rejected
- **Removed** broken `TestLoadTestCase_FollowUpPrompts` — referenced non-existent `TestStimulus.FollowUps` field, prevented package compilation on main

### Testing
```
go test -mod=readonly ./internal/models/ — PASS
```