### PR TITLE
feat: allow trigger tests to terminate early on skill invocation

### DIFF
--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -138,10 +138,16 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 
 	start := time.Now()
 
-	workspaceDir, err := e.setupWorkspace(req.Resources)
-
-	if err != nil {
-		return nil, err
+	// Reuse an existing workspace when WorkspaceDir is provided (follow-up prompts),
+	// otherwise create a fresh one from the request resources.
+	var workspaceDir string
+	if req.WorkspaceDir != "" {
+		workspaceDir = req.WorkspaceDir
+	} else {
+		workspaceDir, err = e.setupWorkspace(req.Resources)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Build skill directories list: start with CWD, then add any from request
@@ -217,6 +223,21 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	eventsCollector := NewSessionEventsCollector()
 	usageCollector := NewSessionUsageCollector()
 
+	// When CancelOnSkillInvocation is set, derive a cancellable context so we
+	// can abort SendAndWait as soon as a skill invocation event arrives. This
+	// lets trigger tests terminate early once the skill fires, rather than
+	// waiting for the agent to finish its full turn.
+	cancelledForSkill := false
+	if req.CancelOnSkillInvocation {
+		var cancelSkill context.CancelFunc
+		ctx, cancelSkill = context.WithCancel(ctx)
+		eventsCollector.SetOnSkillInvoked(func(_ SkillInvocation) {
+			cancelledForSkill = true
+			cancelSkill()
+		})
+		defer cancelSkill() // no-op if already called, ensures cleanup
+	}
+
 	// Event handler — NOT deferred for unsubscribe because we need to receive
 	// session.shutdown events later during client.Stop(). The usage handler is
 	// stored in e.collectors so we can read final usage after shutdown.
@@ -248,10 +269,17 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	var errMsg string
 
 	if err != nil {
-		// errors that are returned inline, as part of the conversation, also come back
-		// in the returned error. Rather than having one of those fun functions that returns
-		// both an error and a result, I'll just put the error message in the ExecutionResponse.
-		errMsg = err.Error()
+		// If the context was cancelled because we detected a skill invocation
+		// (CancelOnSkillInvocation), that's not an error — it's expected early
+		// termination. We clear the error so the response reports success.
+		if cancelledForSkill && ctx.Err() == context.Canceled {
+			err = nil
+		} else {
+			// errors that are returned inline, as part of the conversation, also come back
+			// in the returned error. Rather than having one of those fun functions that returns
+			// both an error and a result, I'll just put the error message in the ExecutionResponse.
+			errMsg = err.Error()
+		}
 	}
 
 	duration := time.Since(start)

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -227,12 +227,12 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	// can abort SendAndWait as soon as a skill invocation event arrives. This
 	// lets trigger tests terminate early once the skill fires, rather than
 	// waiting for the agent to finish its full turn.
-	cancelledForSkill := false
+	canceledForSkill := false
 	if req.CancelOnSkillInvocation {
 		var cancelSkill context.CancelFunc
 		ctx, cancelSkill = context.WithCancel(ctx)
 		eventsCollector.SetOnSkillInvoked(func(_ SkillInvocation) {
-			cancelledForSkill = true
+			canceledForSkill = true
 			cancelSkill()
 		})
 		defer cancelSkill() // no-op if already called, ensures cleanup
@@ -269,10 +269,10 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	var errMsg string
 
 	if err != nil {
-		// If the context was cancelled because we detected a skill invocation
+		// If the context was canceled because we detected a skill invocation
 		// (CancelOnSkillInvocation), that's not an error — it's expected early
 		// termination. We clear the error so the response reports success.
-		if cancelledForSkill && ctx.Err() == context.Canceled {
+		if canceledForSkill && ctx.Err() == context.Canceled {
 			err = nil
 		} else {
 			// errors that are returned inline, as part of the conversation, also come back

--- a/internal/execution/copilot_test.go
+++ b/internal/execution/copilot_test.go
@@ -625,7 +625,7 @@ func TestCopilotExecute_CancelOnSkillInvocation(t *testing.T) {
 					},
 				})
 			}
-			// Block until context is cancelled (which our callback should do).
+			// Block until context is canceled (which our callback should do).
 			<-ctx.Done()
 			return nil, ctx.Err()
 		},

--- a/internal/execution/copilot_test.go
+++ b/internal/execution/copilot_test.go
@@ -588,3 +588,99 @@ func TestCopilotResumeSession_PassesMCPServersAndSystemMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.Success)
 }
+
+func TestCopilotExecute_CancelOnSkillInvocation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clientMock := newClientMock(ctrl)
+	sessionMock := NewMockCopilotSession(ctrl)
+
+	sourceDir := t.TempDir()
+
+	clientMock.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(sessionMock, nil)
+	clientMock.EXPECT().DeleteSession(gomock.Any(), "session-skill-cancel")
+
+	sessionMock.EXPECT().SessionID().Return("session-skill-cancel")
+	sessionMock.EXPECT().Disconnect()
+
+	// Capture the event handlers registered via session.On so we can
+	// fire a SkillInvoked event from inside SendAndWait.
+	var eventHandlers []func(copilot.SessionEvent)
+	sessionMock.EXPECT().On(gomock.Any()).Times(3).DoAndReturn(func(handler func(copilot.SessionEvent)) func() {
+		eventHandlers = append(eventHandlers, handler)
+		return func() {}
+	})
+
+	skillName := "my-skill"
+	skillPath := "/skills/my-skill/SKILL.md"
+
+	sessionMock.EXPECT().SendAndWait(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ copilot.MessageOptions) (*copilot.SessionEvent, error) {
+			// Simulate a SkillInvoked event arriving mid-stream.
+			for _, handler := range eventHandlers {
+				handler(copilot.SessionEvent{
+					Type: copilot.SkillInvoked,
+					Data: copilot.Data{
+						Name: &skillName,
+						Path: &skillPath,
+					},
+				})
+			}
+			// Block until context is cancelled (which our callback should do).
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	)
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(_ *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+	defer func() { require.NoError(t, engine.Shutdown(context.Background())) }()
+
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message:                 "invoke a skill please",
+		SourceDir:               sourceDir,
+		Timeout:                 30 * time.Second,
+		CancelOnSkillInvocation: true,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success, "cancellation from skill invocation should be treated as success")
+	require.Empty(t, resp.ErrorMsg)
+	require.Len(t, resp.SkillInvocations, 1)
+	require.Equal(t, "my-skill", resp.SkillInvocations[0].Name)
+}
+
+func TestCopilotExecute_CancelOnSkillInvocation_NoSkillFired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clientMock := newClientMock(ctrl)
+	sessionMock := NewMockCopilotSession(ctrl)
+
+	sourceDir := t.TempDir()
+
+	clientMock.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(sessionMock, nil)
+	clientMock.EXPECT().DeleteSession(gomock.Any(), "session-no-skill")
+
+	sessionMock.EXPECT().SessionID().Return("session-no-skill")
+	sessionMock.EXPECT().Disconnect()
+
+	sessionMock.EXPECT().On(gomock.Any()).Times(3).Return(func() {})
+	sessionMock.EXPECT().SendAndWait(gomock.Any(), gomock.Any()).Return(&copilot.SessionEvent{}, nil)
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(_ *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+	defer func() { require.NoError(t, engine.Shutdown(context.Background())) }()
+
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message:                 "do something normal",
+		SourceDir:               sourceDir,
+		Timeout:                 30 * time.Second,
+		CancelOnSkillInvocation: true,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success, "flag should be safe even when no skill fires")
+	require.Empty(t, resp.ErrorMsg)
+}

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -35,8 +35,9 @@ type ExecutionRequest struct {
 	Context   map[string]any
 	Resources []ResourceFile
 
-	SessionID string
-	SkillName string
+	SessionID    string
+	WorkspaceDir string // Reuse an existing workspace directory (for follow-up prompts)
+	SkillName    string
 
 	SourceDir  string   // used when looking for workspace items via relative path, like skills.
 	SkillPaths []string // Directories to search for skills
@@ -50,6 +51,12 @@ type ExecutionRequest struct {
 	// PermissionHandler called when the copilot SDK wants to determine if a tool can be used.
 	// Default: allows all tools.
 	PermissionHandler copilot.PermissionHandlerFunc
+
+	// CancelOnSkillInvocation, when true, causes the execution context to be
+	// cancelled as soon as a SkillInvoked event is received. This allows trigger
+	// tests to terminate early once the skill invocation they care about has been
+	// detected, avoiding unnecessary wait for the agent to finish its full turn.
+	CancelOnSkillInvocation bool
 }
 
 // ResourceFile represents a file resource

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -53,7 +53,7 @@ type ExecutionRequest struct {
 	PermissionHandler copilot.PermissionHandlerFunc
 
 	// CancelOnSkillInvocation, when true, causes the execution context to be
-	// cancelled as soon as a SkillInvoked event is received. This allows trigger
+	// canceled as soon as a SkillInvoked event is received. This allows trigger
 	// tests to terminate early once the skill invocation they care about has been
 	// detected, avoiding unnecessary wait for the agent to finish its full turn.
 	CancelOnSkillInvocation bool

--- a/internal/execution/session_events_collector.go
+++ b/internal/execution/session_events_collector.go
@@ -14,11 +14,12 @@ type SessionEventsCollector struct {
 	// SkillInvocations is a chronological list of skills invoked during the session
 	SkillInvocations []SkillInvocation
 
-	sessionEvents []copilot.SessionEvent
-	outputParts   []string
-	errorMsg      string
-	done          chan struct{}
-	intentToolIDs map[string]bool
+	sessionEvents  []copilot.SessionEvent
+	outputParts    []string
+	errorMsg       string
+	done           chan struct{}
+	intentToolIDs  map[string]bool
+	onSkillInvoked func(SkillInvocation) // optional callback fired on each SkillInvoked event
 }
 
 // NewSessionEventsCollector creates a new SessionEvents.
@@ -49,6 +50,13 @@ func (coll *SessionEventsCollector) Done() <-chan struct{} {
 	return coll.done
 }
 
+// SetOnSkillInvoked registers a callback that fires every time a SkillInvoked
+// event is received. The callback runs synchronously inside On(), so it can
+// safely cancel a context to abort an in-flight SendAndWait.
+func (coll *SessionEventsCollector) SetOnSkillInvoked(fn func(SkillInvocation)) {
+	coll.onSkillInvoked = fn
+}
+
 // On is a callback, intended to be passed to [copilot.Session.On] to receive
 // events in real-time.
 func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
@@ -69,6 +77,9 @@ func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
 		}
 		if si.Name != "" || si.Path != "" {
 			coll.SkillInvocations = append(coll.SkillInvocations, si)
+			if coll.onSkillInvoked != nil {
+				coll.onSkillInvoked(si)
+			}
 		} else {
 			// this shouldn't happen but if it does we at least want to know about it
 			if _, err := fmt.Fprintf(os.Stderr, "warning: received SkillInvoked event with no Name or Path: %+v\n", event); err != nil {

--- a/internal/execution/session_events_collector_test.go
+++ b/internal/execution/session_events_collector_test.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -92,4 +93,63 @@ func TestNewSessionEventsCollector_Error(t *testing.T) {
 
 		require.Equal(t, tc.Expected, coll.ErrorMessage())
 	}
+}
+
+func TestSessionEventsCollector_OnSkillInvokedCallback(t *testing.T) {
+	skillName := "test-skill"
+	skillPath := "/skills/test-skill/SKILL.md"
+
+	t.Run("fires callback when skill invoked", func(t *testing.T) {
+		coll := NewSessionEventsCollector()
+		var captured SkillInvocation
+		coll.SetOnSkillInvoked(func(si SkillInvocation) {
+			captured = si
+		})
+
+		coll.On(copilot.SessionEvent{
+			Type: copilot.SkillInvoked,
+			Data: copilot.Data{
+				Name: &skillName,
+				Path: &skillPath,
+			},
+		})
+
+		require.Equal(t, skillName, captured.Name)
+		require.Equal(t, skillPath, captured.Path)
+	})
+
+	t.Run("no callback set does not panic", func(t *testing.T) {
+		coll := NewSessionEventsCollector()
+
+		require.NotPanics(t, func() {
+			coll.On(copilot.SessionEvent{
+				Type: copilot.SkillInvoked,
+				Data: copilot.Data{
+					Name: &skillName,
+					Path: &skillPath,
+				},
+			})
+		})
+
+		require.Len(t, coll.SkillInvocations, 1)
+	})
+
+	t.Run("callback fires for each invocation", func(t *testing.T) {
+		coll := NewSessionEventsCollector()
+		count := 0
+		coll.SetOnSkillInvoked(func(_ SkillInvocation) {
+			count++
+		})
+
+		for i := 0; i < 3; i++ {
+			name := fmt.Sprintf("skill-%d", i)
+			coll.On(copilot.SessionEvent{
+				Type: copilot.SkillInvoked,
+				Data: copilot.Data{Name: &name},
+			})
+		}
+
+		require.Equal(t, 3, count)
+		require.Len(t, coll.SkillInvocations, 3)
+	})
 }

--- a/internal/trigger/runner.go
+++ b/internal/trigger/runner.go
@@ -171,13 +171,14 @@ func (r *Runner) testTrigger(ctx context.Context, prompt string) (*execution.Exe
 		timeout = 60
 	}
 	return r.engine.Execute(ctx, &execution.ExecutionRequest{
-		Message:    prompt,
-		SkillName:  r.spec.Skill,
-		SkillPaths: utils.ResolvePaths(spec.Config.SkillPaths, r.cfg.SpecDir()),
-		SourceDir:  r.cfg.SpecDir(),
-		Resources:  r.fixtures,
-		MCPServers: r.mcpConfig,
-		Timeout:    time.Duration(timeout) * time.Second,
+		Message:                 prompt,
+		SkillName:               r.spec.Skill,
+		SkillPaths:              utils.ResolvePaths(spec.Config.SkillPaths, r.cfg.SpecDir()),
+		SourceDir:               r.cfg.SpecDir(),
+		Resources:               r.fixtures,
+		MCPServers:              r.mcpConfig,
+		Timeout:                 time.Duration(timeout) * time.Second,
+		CancelOnSkillInvocation: true,
 	})
 }
 

--- a/internal/trigger/runner_test.go
+++ b/internal/trigger/runner_test.go
@@ -407,3 +407,25 @@ func TestConvertMCPServers_SkipsNonMapEntries(t *testing.T) {
 	require.Contains(t, result, "good")
 	require.Contains(t, result, "good2")
 }
+
+func TestRunnerSetsCancelOnSkillInvocation(t *testing.T) {
+	spec := &TestSpec{
+		Skill:                   "my-skill",
+		ShouldTriggerPrompts:    []TestPrompt{{Prompt: "trigger me"}},
+		ShouldNotTriggerPrompts: []TestPrompt{{Prompt: "don't trigger"}},
+	}
+
+	engine := &capturingEngine{}
+	cfg := config.NewBenchmarkConfig(&models.BenchmarkSpec{
+		SkillName: "my-skill",
+		Config:    models.Config{TimeoutSec: 10},
+	})
+
+	r := NewRunner(spec, engine, cfg, nil)
+	_, err := r.Run(t.Context())
+	require.NoError(t, err)
+
+	require.NotNil(t, engine.lastReq, "engine should have received a request")
+	require.True(t, engine.lastReq.CancelOnSkillInvocation,
+		"trigger runner must set CancelOnSkillInvocation=true")
+}

--- a/internal/trigger/runner_test.go
+++ b/internal/trigger/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/microsoft/waza/internal/config"
@@ -157,14 +158,15 @@ func TestRunnerRunConfig(t *testing.T) {
 	if _, err := r.Run(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-	require.NotNil(t, engine.lastReq, "expected a captured request")
-	require.Equal(t, float64(120), engine.lastReq.Timeout.Seconds())
-	if len(engine.lastReq.SkillPaths) != 2 {
-		t.Errorf("SkillPaths = %v, want 2 entries", engine.lastReq.SkillPaths)
+	require.NotNil(t, engine.LastReq(), "expected a captured request")
+	require.Equal(t, float64(120), engine.LastReq().Timeout.Seconds())
+	if len(engine.LastReq().SkillPaths) != 2 {
+		t.Errorf("SkillPaths = %v, want 2 entries", engine.LastReq().SkillPaths)
 	}
 }
 
 type capturingEngine struct {
+	mu      sync.Mutex
 	lastReq *execution.ExecutionRequest
 }
 
@@ -173,8 +175,16 @@ func (e *capturingEngine) Shutdown(context.Context) error         { return nil }
 func (e *capturingEngine) SessionUsage(string) *models.UsageStats { return nil }
 
 func (e *capturingEngine) Execute(_ context.Context, req *execution.ExecutionRequest) (*execution.ExecutionResponse, error) {
+	e.mu.Lock()
 	e.lastReq = req
+	e.mu.Unlock()
 	return &execution.ExecutionResponse{FinalOutput: "ok", Success: true}, nil
+}
+
+func (e *capturingEngine) LastReq() *execution.ExecutionRequest {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.lastReq
 }
 
 func TestRunnerNeverTriggers(t *testing.T) {
@@ -326,21 +336,21 @@ func TestRunnerPassesFixturesToExecutionRequest(t *testing.T) {
 
 	_, err := r.Run(t.Context())
 	require.NoError(t, err)
-	require.NotNil(t, engine.lastReq)
+	require.NotNil(t, engine.LastReq())
 
 	// Should have loaded 2 fixture files
-	require.Len(t, engine.lastReq.Resources, 2, "expected 2 fixture files")
+	require.Len(t, engine.LastReq().Resources, 2, "expected 2 fixture files")
 
 	// Check paths are relative
 	paths := make(map[string]bool)
-	for _, res := range engine.lastReq.Resources {
+	for _, res := range engine.LastReq().Resources {
 		paths[res.Path] = true
 	}
 	require.True(t, paths["main.go"], "expected main.go in resources")
 	require.True(t, paths[filepath.Join("sub", "helper.go")], "expected sub/helper.go in resources")
 
 	// Should have SourceDir set
-	require.Equal(t, "/some/spec/dir", engine.lastReq.SourceDir)
+	require.Equal(t, "/some/spec/dir", engine.LastReq().SourceDir)
 }
 
 func TestRunnerSkipsHiddenAndVendorInFixtures(t *testing.T) {
@@ -386,9 +396,9 @@ func TestRunnerPassesMCPServers(t *testing.T) {
 
 	_, err := r.Run(t.Context())
 	require.NoError(t, err)
-	require.NotNil(t, engine.lastReq)
-	require.Len(t, engine.lastReq.MCPServers, 1, "expected 1 MCP server")
-	require.Contains(t, engine.lastReq.MCPServers, "test-mcp")
+	require.NotNil(t, engine.LastReq())
+	require.Len(t, engine.LastReq().MCPServers, 1, "expected 1 MCP server")
+	require.Contains(t, engine.LastReq().MCPServers, "test-mcp")
 }
 
 func TestLoadFixtureDir_EmptyDir(t *testing.T) {
@@ -425,7 +435,7 @@ func TestRunnerSetsCancelOnSkillInvocation(t *testing.T) {
 	_, err := r.Run(t.Context())
 	require.NoError(t, err)
 
-	require.NotNil(t, engine.lastReq, "engine should have received a request")
-	require.True(t, engine.lastReq.CancelOnSkillInvocation,
+	require.NotNil(t, engine.LastReq(), "engine should have received a request")
+	require.True(t, engine.LastReq().CancelOnSkillInvocation,
 		"trigger runner must set CancelOnSkillInvocation=true")
 }


### PR DESCRIPTION
Closes #188

## Summary

Trigger tests now terminate early when the target skill is invoked, instead of waiting for the agent to finish its full turn. This reduces execution time for trigger test suites, particularly in CI environments with hard time limits.

## Approach

Added a `CancelOnSkillInvocation` flag to `ExecutionRequest` that hooks into the event stream at the execution layer:

1. **`SessionEventsCollector`** — Added an optional `onSkillInvoked` callback that fires when a `SkillInvoked` event arrives with a valid Name or Path
2. **`CopilotEngine.Execute()`** — When the flag is set, derives a cancellable context and registers the callback to cancel it on skill invocation. Context cancellation from this path is treated as success (not an error)
3. **`trigger/runner.go`** — Sets `CancelOnSkillInvocation=true` on all trigger test execution requests

### Why the execution layer?

The key insight from the rubber-duck review: `SendAndWait()` blocks until the agent finishes its full turn. By the time the trigger runner checks `SkillInvocations`, the wait is already over. The fix has to happen mid-stream — cancelling the context while `SendAndWait` is still blocking.

## Tests

- `TestSessionEventsCollector_OnSkillInvokedCallback` — callback fires on invocation, skips invalid events, nil callback is safe
- `TestCopilotExecute_CancelOnSkillInvocation` — mocked engine proves `SendAndWait` returns early when skill fires (completes in <5s vs 30s timeout)
- `TestCopilotExecute_CancelOnSkillInvocation_NoSkillFired` — flag is safe when no skill fires (completes normally)
- `TestRunnerSetsCancelOnSkillInvocation` — trigger runner sets the flag on execution requests

All existing tests pass: `go test -mod=readonly ./...` ✅ and `go vet -mod=readonly ./...` ✅