### PR TITLE
feat: support pre-written follow-up prompts in eval YAML

### DIFF
--- a/internal/execution/mock.go
+++ b/internal/execution/mock.go
@@ -43,25 +43,30 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 
 	start := time.Now()
 
-	// Clean up any previous workspace before creating a new one
-	if m.workspace != "" {
-		if err := os.RemoveAll(m.workspace); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove old mock workspace %s: %v\n", m.workspace, err)
+	// Reuse workspace if provided (follow-up prompts), otherwise create fresh
+	if req.WorkspaceDir != "" {
+		m.workspace = req.WorkspaceDir
+	} else {
+		// Clean up any previous workspace before creating a new one
+		if m.workspace != "" {
+			if err := os.RemoveAll(m.workspace); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to remove old mock workspace %s: %v\n", m.workspace, err)
+			}
+			m.workspace = ""
 		}
-		m.workspace = ""
-	}
 
-	// Create a temp workspace so graders that inspect files (e.g. FileGrader) have
-	// a directory to work with, mirroring CopilotEngine behavior.
-	tmpDir, err := os.MkdirTemp("", "waza-mock-*")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create mock workspace: %w", err)
-	}
-	m.workspace = tmpDir
+		// Create a temp workspace so graders that inspect files (e.g. FileGrader) have
+		// a directory to work with, mirroring CopilotEngine behavior.
+		tmpDir, err := os.MkdirTemp("", "waza-mock-*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create mock workspace: %w", err)
+		}
+		m.workspace = tmpDir
 
-	// Write request resources into the workspace
-	if err := setupWorkspaceResources(m.workspace, req.Resources); err != nil {
-		return nil, fmt.Errorf("failed to setup mock workspace resources: %w", err)
+		// Write request resources into the workspace
+		if err := setupWorkspaceResources(m.workspace, req.Resources); err != nil {
+			return nil, fmt.Errorf("failed to setup mock workspace resources: %w", err)
+		}
 	}
 
 	// Simple mock response
@@ -72,6 +77,12 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 		output += fmt.Sprintf("\nAnalyzed %d file(s)", len(req.Resources))
 	}
 
+	// Pass through session ID for follow-up continuity
+	sessionID := req.SessionID
+	if sessionID == "" {
+		sessionID = fmt.Sprintf("mock-session-%d", time.Now().UnixNano())
+	}
+
 	resp := &ExecutionResponse{
 		FinalOutput:    output,
 		Events:         []copilot.SessionEvent{},
@@ -79,6 +90,7 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 		DurationMs:     time.Since(start).Milliseconds(),
 		ToolCalls:      []models.ToolCall{},
 		Success:        true,
+		SessionID:      sessionID,
 		WorkspaceDir:   m.workspace,
 		WorkspaceFiles: captureWorkspaceFiles(m.workspace),
 	}

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -31,6 +31,7 @@ type TestStimulus struct {
 	Metadata    map[string]any    `yaml:"context,omitempty" json:"metadata,omitempty"`
 	Resources   []ResourceRef     `yaml:"files,omitempty" json:"resources,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty" json:"environment,omitempty"`
+	FollowUps   []string          `yaml:"follow_up_prompts,omitempty" json:"follow_ups,omitempty"`
 }
 
 // ResourceRef points to a file or inline content

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1041,6 +1041,11 @@ func (r *TestRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		})
 	}
 
+	// Execute follow-up prompts if defined
+	if len(tc.Stimulus.FollowUps) > 0 {
+		r.executeFollowUps(ctx, tc, resp)
+	}
+
 	// Build validation context
 	vCtx := r.buildGraderContext(tc, resp)
 
@@ -1140,6 +1145,51 @@ func (r *TestRunner) buildExecutionRequest(tc *models.TestCase) *execution.Execu
 		SkillPaths: resolvedSkillPaths,
 		Timeout:    time.Duration(timeout) * time.Second,
 		MCPServers: convertMCPServers(spec.Config.ServerConfigs),
+	}
+}
+
+// executeFollowUps sends follow-up prompts using the same workspace and session,
+// aggregating results into the original response.
+func (r *TestRunner) executeFollowUps(ctx context.Context, tc *models.TestCase, resp *execution.ExecutionResponse) {
+	for i, prompt := range tc.Stimulus.FollowUps {
+		followReq := r.buildExecutionRequest(tc)
+		followReq.Message = prompt
+		followReq.SessionID = resp.SessionID
+		followReq.WorkspaceDir = resp.WorkspaceDir
+
+		if r.verbose {
+			r.notifyProgress(ProgressEvent{
+				EventType: EventAgentPrompt,
+				TestName:  tc.DisplayName,
+				Details:   map[string]any{"message": prompt, "follow_up": i + 1, "total": len(tc.Stimulus.FollowUps)},
+			})
+		}
+
+		followResp, err := r.engine.Execute(ctx, followReq)
+		if err != nil {
+			resp.ErrorMsg = fmt.Sprintf("follow-up %d/%d failed: %v", i+1, len(tc.Stimulus.FollowUps), err)
+			break
+		}
+
+		if followResp.ErrorMsg != "" {
+			resp.ErrorMsg = fmt.Sprintf("follow-up %d/%d: %s", i+1, len(tc.Stimulus.FollowUps), followResp.ErrorMsg)
+			break
+		}
+
+		// Aggregate results
+		resp.Events = append(resp.Events, followResp.Events...)
+		resp.ToolCalls = append(resp.ToolCalls, followResp.ToolCalls...)
+		resp.SkillInvocations = append(resp.SkillInvocations, followResp.SkillInvocations...)
+		resp.DurationMs += followResp.DurationMs
+		resp.FinalOutput = followResp.FinalOutput
+		resp.WorkspaceFiles = followResp.WorkspaceFiles
+		if followResp.Usage != nil {
+			if resp.Usage == nil {
+				resp.Usage = followResp.Usage
+			} else {
+				resp.Usage = models.AggregateUsageStats([]*models.UsageStats{resp.Usage, followResp.Usage})
+			}
+		}
 	}
 }
 

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -2,8 +2,10 @@ package orchestration
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -500,4 +502,221 @@ func TestRunTest_CacheHitAndTranscriptWrite(t *testing.T) {
 	assert.True(t, wasCached)
 	assert.Equal(t, outcome.TestID, cachedOutcome.TestID)
 	assert.Equal(t, outcome.Status, cachedOutcome.Status)
+}
+
+
+// --- Follow-up prompt test helpers ---
+
+type trackingCall struct {
+	Message      string
+	SessionID    string
+	WorkspaceDir string
+}
+
+type trackingEngine struct {
+	mu    sync.Mutex
+	calls []trackingCall
+}
+
+func (e *trackingEngine) Initialize(_ context.Context) error { return nil }
+func (e *trackingEngine) Shutdown(_ context.Context) error  { return nil }
+func (e *trackingEngine) SessionUsage(_ string) *models.UsageStats {
+	return nil
+}
+
+func (e *trackingEngine) Execute(_ context.Context, req *execution.ExecutionRequest) (*execution.ExecutionResponse, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.calls = append(e.calls, trackingCall{
+		Message:      req.Message,
+		SessionID:    req.SessionID,
+		WorkspaceDir: req.WorkspaceDir,
+	})
+	return &execution.ExecutionResponse{
+		FinalOutput:  fmt.Sprintf("response to: %s", req.Message),
+		SessionID:    "session-abc",
+		WorkspaceDir: "/workspace/abc",
+		DurationMs:   10,
+		Success:      true,
+	}, nil
+}
+
+type errorOnCallEngine struct {
+	mu        sync.Mutex
+	callCount int
+	errOnCall int // 1-based: fail on Nth call
+}
+
+func (e *errorOnCallEngine) Initialize(_ context.Context) error { return nil }
+func (e *errorOnCallEngine) Shutdown(_ context.Context) error  { return nil }
+func (e *errorOnCallEngine) SessionUsage(_ string) *models.UsageStats {
+	return nil
+}
+
+func (e *errorOnCallEngine) Execute(_ context.Context, req *execution.ExecutionRequest) (*execution.ExecutionResponse, error) {
+	e.mu.Lock()
+	e.callCount++
+	n := e.callCount
+	e.mu.Unlock()
+
+	if n == e.errOnCall {
+		return nil, fmt.Errorf("engine error on call %d", n)
+	}
+	return &execution.ExecutionResponse{
+		FinalOutput:  fmt.Sprintf("response %d", n),
+		SessionID:    "session-abc",
+		WorkspaceDir: "/workspace/abc",
+		DurationMs:   5,
+		Success:      true,
+	}, nil
+}
+
+// --- Follow-up prompt tests ---
+
+func TestExecuteRun_NoFollowUps(t *testing.T) {
+	eng := &trackingEngine{}
+	spec := &models.BenchmarkSpec{
+		SpecIdentity: models.SpecIdentity{Name: "no-followup-test"},
+		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
+	}
+	cfg := config.NewBenchmarkConfig(spec)
+	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+
+	tc := &models.TestCase{
+		TestID:      "t1",
+		DisplayName: "no followup",
+		Stimulus:    models.TestStimulus{Message: "initial prompt"},
+	}
+
+	result := runner.executeRun(context.Background(), tc, 1)
+	assert.Equal(t, models.StatusSkipped, result.Status)
+	assert.Equal(t, 1, len(eng.calls))
+	assert.Equal(t, "initial prompt", eng.calls[0].Message)
+}
+
+func TestExecuteRun_SingleFollowUp(t *testing.T) {
+	eng := &trackingEngine{}
+	spec := &models.BenchmarkSpec{
+		SpecIdentity: models.SpecIdentity{Name: "single-followup-test"},
+		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
+	}
+	cfg := config.NewBenchmarkConfig(spec)
+	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+
+	tc := &models.TestCase{
+		TestID:      "t2",
+		DisplayName: "single followup",
+		Stimulus: models.TestStimulus{
+			Message:   "initial prompt",
+			FollowUps: []string{"follow-up one"},
+		},
+	}
+
+	result := runner.executeRun(context.Background(), tc, 1)
+	assert.Equal(t, models.StatusSkipped, result.Status)
+	require.Equal(t, 2, len(eng.calls))
+	assert.Equal(t, "initial prompt", eng.calls[0].Message)
+	assert.Equal(t, "", eng.calls[0].SessionID)
+	assert.Equal(t, "follow-up one", eng.calls[1].Message)
+	assert.Equal(t, "session-abc", eng.calls[1].SessionID)
+	assert.Equal(t, "/workspace/abc", eng.calls[1].WorkspaceDir)
+	assert.Contains(t, result.FinalOutput, "response to: follow-up one")
+}
+
+func TestExecuteRun_MultipleFollowUps(t *testing.T) {
+	eng := &trackingEngine{}
+	spec := &models.BenchmarkSpec{
+		SpecIdentity: models.SpecIdentity{Name: "multi-followup-test"},
+		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
+	}
+	cfg := config.NewBenchmarkConfig(spec)
+	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+
+	tc := &models.TestCase{
+		TestID:      "t3",
+		DisplayName: "multi followup",
+		Stimulus: models.TestStimulus{
+			Message:   "initial",
+			FollowUps: []string{"follow-up 1", "follow-up 2", "follow-up 3"},
+		},
+	}
+
+	result := runner.executeRun(context.Background(), tc, 1)
+	assert.Equal(t, models.StatusSkipped, result.Status)
+	require.Equal(t, 4, len(eng.calls))
+	assert.Equal(t, "initial", eng.calls[0].Message)
+	for i, msg := range []string{"follow-up 1", "follow-up 2", "follow-up 3"} {
+		assert.Equal(t, msg, eng.calls[i+1].Message)
+		assert.Equal(t, "session-abc", eng.calls[i+1].SessionID)
+		assert.Equal(t, "/workspace/abc", eng.calls[i+1].WorkspaceDir)
+	}
+	// DurationMs should be sum of all calls (10ms each * 4 = 40ms)
+	assert.Equal(t, int64(40), result.DurationMs)
+}
+
+func TestExecuteRun_FollowUpErrorMidSequence(t *testing.T) {
+	eng := &errorOnCallEngine{errOnCall: 2} // fail on first follow-up
+	spec := &models.BenchmarkSpec{
+		SpecIdentity: models.SpecIdentity{Name: "error-followup-test"},
+		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
+	}
+	cfg := config.NewBenchmarkConfig(spec)
+	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+
+	tc := &models.TestCase{
+		TestID:      "t4",
+		DisplayName: "error followup",
+		Stimulus: models.TestStimulus{
+			Message:   "initial",
+			FollowUps: []string{"fail-here", "never-reached"},
+		},
+	}
+
+	result := runner.executeRun(context.Background(), tc, 1)
+	assert.Equal(t, models.StatusError, result.Status)
+	assert.Contains(t, result.ErrorMsg, "follow-up 1/2 failed")
+}
+
+func TestRunBenchmark_WithFollowUps(t *testing.T) {
+	eng := &trackingEngine{}
+
+	tmpDir := t.TempDir()
+	tasksDir := filepath.Join(tmpDir, "tasks")
+	require.NoError(t, os.MkdirAll(tasksDir, 0o755))
+
+	taskYAML := `id: bench-followup
+name: Benchmark Follow-up
+inputs:
+  prompt: "initial"
+  follow_up_prompts:
+    - "follow-up 1"
+    - "follow-up 2"
+expected:
+  output_contains:
+    - "response"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "t1.yaml"), []byte(taskYAML), 0o644))
+
+	spec := &models.BenchmarkSpec{
+		SpecIdentity: models.SpecIdentity{Name: "bench-with-followups"},
+		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
+		Tasks:        []string{"tasks/*.yaml"},
+	}
+	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
+	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+
+	outcome, err := runner.RunBenchmark(context.Background())
+	require.NoError(t, err)
+	require.Len(t, outcome.TestOutcomes, 1)
+
+	res := outcome.TestOutcomes[0]
+	assert.Equal(t, "bench-followup", res.TestID)
+	require.Len(t, res.Runs, 1)
+	assert.Equal(t, models.StatusSkipped, res.Runs[0].Status)
+
+	// Should have 3 calls: initial + 2 follow-ups
+	require.Equal(t, 3, len(eng.calls))
+	assert.Equal(t, "initial", eng.calls[0].Message)
+	assert.Equal(t, "follow-up 1", eng.calls[1].Message)
+	assert.Equal(t, "follow-up 2", eng.calls[2].Message)
 }

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -57,6 +57,13 @@
         "$ref": "#/$defs/validatorInline"
       },
       "description": "Task-level graders applied to this task's output."
+    },
+    "follow_up_prompts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Sequential follow-up prompts sent after the initial prompt, reusing the same session and workspace."
     }
   },
   "$defs": {
@@ -65,8 +72,16 @@
       "additionalProperties": false,
       "description": "Input stimulus for the task. Must specify either prompt or prompt_file (not both).",
       "oneOf": [
-        { "required": ["prompt"] },
-        { "required": ["prompt_file"] }
+        {
+          "required": [
+            "prompt"
+          ]
+        },
+        {
+          "required": [
+            "prompt_file"
+          ]
+        }
       ],
       "properties": {
         "prompt": {
@@ -319,7 +334,6 @@
             }
           }
         },
-
         {
           "if": {
             "properties": {

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -220,6 +220,20 @@ You must specify either `prompt` or `prompt_file`, but not both.
 `prompt_file` paths must be relative. Absolute paths and directory traversal (`../`) are rejected for security.
 :::
 
+### Follow-up Prompts
+
+Use `follow_up_prompts` to send additional messages after the initial prompt. Each follow-up reuses the same session and workspace, so file changes and conversation history persist across turns.
+
+```yaml
+inputs:
+  prompt: "Create a Python function that reads a CSV file"
+  follow_up_prompts:
+    - "Add error handling for missing files"
+    - "Write unit tests for the function"
+```
+
+This is useful for evaluating multi-turn conversations where each step builds on the previous one. Graders run only after all prompts (initial + follow-ups) have completed, so the final output reflects the full conversation.
+
 Prompt supports templating:
 
 ```yaml

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -421,7 +421,24 @@ inputs:
   prompt_file: prompts/review-instructions.md
 ```
 
-Paths must be relative — absolute paths and directory traversal (`../`) are rejected.
+
+
+### follow_up_prompts
+
+**Type:** array of strings  
+**Required:** no
+
+Sequential follow-up prompts sent after the initial prompt. Each follow-up reuses the same session and workspace directory, preserving conversation history and file changes across turns.
+
+```yaml
+inputs:
+  prompt: "Create a helper function"
+  follow_up_prompts:
+    - "Add error handling"
+    - "Write tests"
+```
+
+Graders evaluate only the final state after all prompts complete. If any follow-up fails, remaining prompts are skipped and the run is marked as an error.
 
 ### files
 


### PR DESCRIPTION
## Summary

Closes #189

Adds support for `follow_up_prompts` in eval YAML task definitions, enabling multi-turn evaluation scenarios where each follow-up reuses the same session and workspace.

Working as Linus (Backend Developer)

## Changes

### Core
- **`internal/models/testcase.go`**: Add `FollowUps []string` to `TestStimulus` (`yaml: follow_up_prompts`)
- **`internal/execution/engine.go`**: Add `WorkspaceDir` to `ExecutionRequest` for workspace reuse
- **`internal/execution/copilot.go`**: Skip `setupWorkspace` when `WorkspaceDir` is set
- **`internal/execution/mock.go`**: Support workspace reuse and `SessionID` passthrough
- **`internal/orchestration/runner.go`**: Add `executeFollowUps()` with result aggregation (events, tool calls, usage, duration)

### Tests
- 3 YAML parsing subtests (present, omitted, single)
- 5 orchestration tests (no follow-ups, single, multiple, error mid-sequence, full benchmark)

### Documentation
- `schemas/task.schema.json`: Add `follow_up_prompts` property
- `site/src/content/docs/guides/eval-yaml.mdx`: Add follow-up prompts guide section
- `site/src/content/docs/reference/schema.mdx`: Add schema reference entry

## Example

```yaml
inputs:
  prompt: "Create a Python function that reads a CSV file"
  follow_up_prompts:
    - "Add error handling for missing files"
    - "Write unit tests for the function"
```

## How it works

1. Initial prompt executes normally, creating a workspace and session
2. Each follow-up reuses the same `WorkspaceDir` and `SessionID`
3. Results are aggregated: events/tool calls appended, duration summed, last output wins
4. If any follow-up fails, remaining are skipped and the run is marked as error
5. Graders evaluate only the final state after all prompts complete