### PR TITLE
fix: CI integration test allows eval failures with mock executor

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -100,7 +100,17 @@ jobs:
       - name: Integration Test
         if: matrix.os == 'ubuntu-latest'
         run: |
+          # Verify waza can load and execute an eval end-to-end with the
+          # mock executor. Exit code 1 = eval tasks failed (expected with
+          # mock output). Exit code >1 or signal = real crash — fail CI.
+          set +e
           ./waza run ./examples/code-explainer/eval.yaml --verbose
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -gt 1 ]; then
+            echo "::error::waza crashed with exit code $EXIT_CODE"
+            exit $EXIT_CODE
+          fi
+          echo "Integration test completed (exit code: $EXIT_CODE)"
 
   lint:
     name: Lint


### PR DESCRIPTION
**Root cause:** PR #203 (v0.27.0) wired up `evaluateExpectations()` which made `output_contains` checks actually execute. Before that, these fields were defined but never evaluated — the integration test passed because expectations were silently skipped.

The mock executor outputs `Mock response for: {prompt}` which doesn't contain keywords like `recursive`, `factorial`, `async`, etc. that the example tasks expect. This is correct behavior — the test validates waza runs without crashing, not that mock evals pass.

**Fix:** Exit code 1 (eval failures) is now allowed. Exit codes >1 (crashes, panics) still fail CI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>