### PR TITLE
feat: add non-blocking version update check (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ azd waza init my-eval --interactive
 azd waza run examples/code-explainer/eval.yaml -v
 ```
 
+## Update Notifications
+
+Waza automatically checks for new versions in the background. If an update is available, a notice appears after command output:
+
+```
+A newer version of waza is available: v0.24.0 → v0.28.0. Run: curl -fsSL ... | bash
+```
+
+The check is non-blocking (never slows commands), cached for 24 hours, and can be disabled with `--no-update-check` or `WAZA_NO_UPDATE_CHECK=1`.
+
 ## Quick Start
 
 ### For New Users: Get Started in 5 Minutes

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"os"
 
 	"github.com/microsoft/waza/cmd/waza/dev"
 	"github.com/microsoft/waza/cmd/waza/tokens"
+	versionpkg "github.com/microsoft/waza/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -29,9 +31,21 @@ performance against predefined test cases.`,
 	slog.SetDefault(logger)
 
 	debugLogging := cmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
+	noUpdateCheck := cmd.PersistentFlags().Bool("no-update-check", false, "Disable automatic update check")
+
+	var checker *versionpkg.Checker
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if *debugLogging {
 			logLevel.Set(slog.LevelDebug)
+		}
+		if !*noUpdateCheck && os.Getenv("WAZA_NO_UPDATE_CHECK") == "" {
+			checker = versionpkg.NewChecker(version)
+			checker.Run(context.Background())
+		}
+	}
+	cmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
+		if checker != nil {
+			versionpkg.PrintNotice(checker.Result(), "")
 		}
 	}
 

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -1,0 +1,267 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// Package version provides non-blocking version checking against GitHub releases.
+package version
+
+import (
+"context"
+"encoding/json"
+"fmt"
+"io"
+"net/http"
+"os"
+"path/filepath"
+"strings"
+"sync"
+"time"
+
+"github.com/Masterminds/semver/v3"
+)
+
+const (
+defaultOwner = "microsoft"
+defaultRepo  = "waza"
+cacheTTL     = 24 * time.Hour
+cacheFile    = "version-check.json"
+httpTimeout  = 5 * time.Second
+)
+
+type releaseInfo struct {
+TagName string `json:"tag_name"`
+}
+
+type cacheEntry struct {
+LatestVersion string    `json:"latest_version"`
+CheckedAt     time.Time `json:"checked_at"`
+}
+
+// CheckResult holds the outcome of a version comparison.
+type CheckResult struct {
+CurrentVersion string
+LatestVersion  string
+UpdateAvail    bool
+}
+
+// Checker performs async version checks against GitHub releases.
+type Checker struct {
+currentVersion string
+owner          string
+repo           string
+cacheDir       string
+httpClient     *http.Client
+apiBaseURL     string
+
+mu     sync.Mutex
+result *CheckResult
+done   chan struct{}
+}
+
+// Option configures a Checker.
+type Option func(*Checker)
+
+// WithHTTPClient sets a custom HTTP client (useful for testing).
+func WithHTTPClient(c *http.Client) Option {
+return func(ch *Checker) { ch.httpClient = c }
+}
+
+// WithCacheDir overrides the default cache directory.
+func WithCacheDir(dir string) Option {
+return func(ch *Checker) { ch.cacheDir = dir }
+}
+
+// WithAPIBaseURL overrides the GitHub API base URL (for testing).
+func WithAPIBaseURL(url string) Option {
+return func(ch *Checker) { ch.apiBaseURL = url }
+}
+
+// WithRepo overrides the owner/repo for the release check.
+func WithRepo(owner, repo string) Option {
+return func(ch *Checker) {
+ch.owner = owner
+ch.repo = repo
+}
+}
+
+// NewChecker creates a version checker for the given current version.
+func NewChecker(currentVersion string, opts ...Option) *Checker {
+ch := &Checker{
+currentVersion: currentVersion,
+owner:          defaultOwner,
+repo:           defaultRepo,
+httpClient:     &http.Client{Timeout: httpTimeout},
+apiBaseURL:     "https://api.github.com",
+done:           make(chan struct{}),
+}
+for _, o := range opts {
+o(ch)
+}
+if ch.cacheDir == "" {
+home, err := os.UserHomeDir()
+if err == nil {
+ch.cacheDir = filepath.Join(home, ".waza")
+}
+}
+return ch
+}
+
+// Run starts the version check in a background goroutine. It is non-blocking.
+func (c *Checker) Run(ctx context.Context) {
+go func() {
+defer close(c.done)
+result := c.check(ctx)
+c.mu.Lock()
+c.result = result
+c.mu.Unlock()
+}()
+}
+
+// Result returns the check result. It blocks briefly (up to 100ms)
+// for the background check to complete. Returns nil if the check has not finished,
+// the current version is not parseable, or an error occurred.
+func (c *Checker) Result() *CheckResult {
+select {
+case <-c.done:
+case <-time.After(100 * time.Millisecond):
+return nil
+}
+c.mu.Lock()
+defer c.mu.Unlock()
+return c.result
+}
+
+func (c *Checker) check(ctx context.Context) *CheckResult {
+cur, err := parseSemver(c.currentVersion)
+if err != nil {
+return nil
+}
+
+if cached, ok := c.readCache(); ok {
+latest, err := semver.NewVersion(cached)
+if err == nil {
+return &CheckResult{
+CurrentVersion: cur.String(),
+LatestVersion:  latest.String(),
+UpdateAvail:    latest.GreaterThan(cur),
+}
+}
+}
+
+latest, err := c.fetchLatestVersion(ctx)
+if err != nil {
+return nil
+}
+
+c.writeCache(latest.String())
+
+return &CheckResult{
+CurrentVersion: cur.String(),
+LatestVersion:  latest.String(),
+UpdateAvail:    latest.GreaterThan(cur),
+}
+}
+
+func (c *Checker) fetchLatestVersion(ctx context.Context) (*semver.Version, error) {
+url := fmt.Sprintf("%s/repos/%s/%s/releases", c.apiBaseURL, c.owner, c.repo)
+req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+if err != nil {
+return nil, err
+}
+req.Header.Set("Accept", "application/vnd.github+json")
+req.Header.Set("User-Agent", "waza-version-check")
+
+resp, err := c.httpClient.Do(req)
+if err != nil {
+return nil, err
+}
+defer resp.Body.Close()
+
+if resp.StatusCode != http.StatusOK {
+return nil, fmt.Errorf("github api returned %d", resp.StatusCode)
+}
+
+body, err := io.ReadAll(resp.Body)
+if err != nil {
+return nil, err
+}
+
+var releases []releaseInfo
+if err := json.Unmarshal(body, &releases); err != nil {
+return nil, err
+}
+
+for _, r := range releases {
+if strings.HasPrefix(r.TagName, "v") {
+v, err := parseSemver(r.TagName)
+if err == nil {
+return v, nil
+}
+}
+}
+
+return nil, fmt.Errorf("no valid release found")
+}
+
+func (c *Checker) cachePath() string {
+if c.cacheDir == "" {
+return ""
+}
+return filepath.Join(c.cacheDir, cacheFile)
+}
+
+func (c *Checker) readCache() (string, bool) {
+path := c.cachePath()
+if path == "" {
+return "", false
+}
+data, err := os.ReadFile(path)
+if err != nil {
+return "", false
+}
+var entry cacheEntry
+if err := json.Unmarshal(data, &entry); err != nil {
+return "", false
+}
+if time.Since(entry.CheckedAt) > cacheTTL {
+return "", false
+}
+return entry.LatestVersion, true
+}
+
+func (c *Checker) writeCache(version string) {
+path := c.cachePath()
+if path == "" {
+return
+}
+if err := os.MkdirAll(c.cacheDir, 0o755); err != nil {
+return
+}
+entry := cacheEntry{
+LatestVersion: version,
+CheckedAt:     time.Now(),
+}
+data, err := json.Marshal(entry)
+if err != nil {
+return
+}
+_ = os.WriteFile(path, data, 0o644)
+}
+
+// PrintNotice prints an upgrade notice to stderr if a newer version is available.
+// Returns true if a notice was printed.
+func PrintNotice(result *CheckResult, installCmd string) bool {
+if result == nil || !result.UpdateAvail {
+return false
+}
+if installCmd == "" {
+installCmd = "curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash"
+}
+fmt.Fprintf(os.Stderr, "\nA newer version of waza is available: v%s \u2192 v%s. Run: %s\n",
+result.CurrentVersion, result.LatestVersion, installCmd)
+return true
+}
+
+func parseSemver(s string) (*semver.Version, error) {
+s = strings.TrimPrefix(s, "v")
+return semver.NewVersion(s)
+}

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -5,56 +5,56 @@
 package version
 
 import (
-"context"
-"encoding/json"
-"fmt"
-"io"
-"net/http"
-"os"
-"path/filepath"
-"strings"
-"sync"
-"time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
 
-"github.com/Masterminds/semver/v3"
+	"github.com/Masterminds/semver/v3"
 )
 
 const (
-defaultOwner = "microsoft"
-defaultRepo  = "waza"
-cacheTTL     = 24 * time.Hour
-cacheFile    = "version-check.json"
-httpTimeout  = 5 * time.Second
+	defaultOwner = "microsoft"
+	defaultRepo  = "waza"
+	cacheTTL     = 24 * time.Hour
+	cacheFile    = "version-check.json"
+	httpTimeout  = 5 * time.Second
 )
 
 type releaseInfo struct {
-TagName string `json:"tag_name"`
+	TagName string `json:"tag_name"`
 }
 
 type cacheEntry struct {
-LatestVersion string    `json:"latest_version"`
-CheckedAt     time.Time `json:"checked_at"`
+	LatestVersion string    `json:"latest_version"`
+	CheckedAt     time.Time `json:"checked_at"`
 }
 
 // CheckResult holds the outcome of a version comparison.
 type CheckResult struct {
-CurrentVersion string
-LatestVersion  string
-UpdateAvail    bool
+	CurrentVersion string
+	LatestVersion  string
+	UpdateAvail    bool
 }
 
 // Checker performs async version checks against GitHub releases.
 type Checker struct {
-currentVersion string
-owner          string
-repo           string
-cacheDir       string
-httpClient     *http.Client
-apiBaseURL     string
+	currentVersion string
+	owner          string
+	repo           string
+	cacheDir       string
+	httpClient     *http.Client
+	apiBaseURL     string
 
-mu     sync.Mutex
-result *CheckResult
-done   chan struct{}
+	mu     sync.Mutex
+	result *CheckResult
+	done   chan struct{}
 }
 
 // Option configures a Checker.
@@ -62,206 +62,206 @@ type Option func(*Checker)
 
 // WithHTTPClient sets a custom HTTP client (useful for testing).
 func WithHTTPClient(c *http.Client) Option {
-return func(ch *Checker) { ch.httpClient = c }
+	return func(ch *Checker) { ch.httpClient = c }
 }
 
 // WithCacheDir overrides the default cache directory.
 func WithCacheDir(dir string) Option {
-return func(ch *Checker) { ch.cacheDir = dir }
+	return func(ch *Checker) { ch.cacheDir = dir }
 }
 
 // WithAPIBaseURL overrides the GitHub API base URL (for testing).
 func WithAPIBaseURL(url string) Option {
-return func(ch *Checker) { ch.apiBaseURL = url }
+	return func(ch *Checker) { ch.apiBaseURL = url }
 }
 
 // WithRepo overrides the owner/repo for the release check.
 func WithRepo(owner, repo string) Option {
-return func(ch *Checker) {
-ch.owner = owner
-ch.repo = repo
-}
+	return func(ch *Checker) {
+		ch.owner = owner
+		ch.repo = repo
+	}
 }
 
 // NewChecker creates a version checker for the given current version.
 func NewChecker(currentVersion string, opts ...Option) *Checker {
-ch := &Checker{
-currentVersion: currentVersion,
-owner:          defaultOwner,
-repo:           defaultRepo,
-httpClient:     &http.Client{Timeout: httpTimeout},
-apiBaseURL:     "https://api.github.com",
-done:           make(chan struct{}),
-}
-for _, o := range opts {
-o(ch)
-}
-if ch.cacheDir == "" {
-home, err := os.UserHomeDir()
-if err == nil {
-ch.cacheDir = filepath.Join(home, ".waza")
-}
-}
-return ch
+	ch := &Checker{
+		currentVersion: currentVersion,
+		owner:          defaultOwner,
+		repo:           defaultRepo,
+		httpClient:     &http.Client{Timeout: httpTimeout},
+		apiBaseURL:     "https://api.github.com",
+		done:           make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(ch)
+	}
+	if ch.cacheDir == "" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			ch.cacheDir = filepath.Join(home, ".waza")
+		}
+	}
+	return ch
 }
 
 // Run starts the version check in a background goroutine. It is non-blocking.
 func (c *Checker) Run(ctx context.Context) {
-go func() {
-defer close(c.done)
-result := c.check(ctx)
-c.mu.Lock()
-c.result = result
-c.mu.Unlock()
-}()
+	go func() {
+		defer close(c.done)
+		result := c.check(ctx)
+		c.mu.Lock()
+		c.result = result
+		c.mu.Unlock()
+	}()
 }
 
 // Result returns the check result. It blocks briefly (up to 100ms)
 // for the background check to complete. Returns nil if the check has not finished,
 // the current version is not parseable, or an error occurred.
 func (c *Checker) Result() *CheckResult {
-select {
-case <-c.done:
-case <-time.After(100 * time.Millisecond):
-return nil
-}
-c.mu.Lock()
-defer c.mu.Unlock()
-return c.result
+	select {
+	case <-c.done:
+	case <-time.After(100 * time.Millisecond):
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.result
 }
 
 func (c *Checker) check(ctx context.Context) *CheckResult {
-cur, err := parseSemver(c.currentVersion)
-if err != nil {
-return nil
-}
+	cur, err := parseSemver(c.currentVersion)
+	if err != nil {
+		return nil
+	}
 
-if cached, ok := c.readCache(); ok {
-latest, err := semver.NewVersion(cached)
-if err == nil {
-return &CheckResult{
-CurrentVersion: cur.String(),
-LatestVersion:  latest.String(),
-UpdateAvail:    latest.GreaterThan(cur),
-}
-}
-}
+	if cached, ok := c.readCache(); ok {
+		latest, err := semver.NewVersion(cached)
+		if err == nil {
+			return &CheckResult{
+				CurrentVersion: cur.String(),
+				LatestVersion:  latest.String(),
+				UpdateAvail:    latest.GreaterThan(cur),
+			}
+		}
+	}
 
-latest, err := c.fetchLatestVersion(ctx)
-if err != nil {
-return nil
-}
+	latest, err := c.fetchLatestVersion(ctx)
+	if err != nil {
+		return nil
+	}
 
-c.writeCache(latest.String())
+	c.writeCache(latest.String())
 
-return &CheckResult{
-CurrentVersion: cur.String(),
-LatestVersion:  latest.String(),
-UpdateAvail:    latest.GreaterThan(cur),
-}
+	return &CheckResult{
+		CurrentVersion: cur.String(),
+		LatestVersion:  latest.String(),
+		UpdateAvail:    latest.GreaterThan(cur),
+	}
 }
 
 func (c *Checker) fetchLatestVersion(ctx context.Context) (*semver.Version, error) {
-url := fmt.Sprintf("%s/repos/%s/%s/releases", c.apiBaseURL, c.owner, c.repo)
-req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-if err != nil {
-return nil, err
-}
-req.Header.Set("Accept", "application/vnd.github+json")
-req.Header.Set("User-Agent", "waza-version-check")
+	url := fmt.Sprintf("%s/repos/%s/%s/releases", c.apiBaseURL, c.owner, c.repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "waza-version-check")
 
-resp, err := c.httpClient.Do(req)
-if err != nil {
-return nil, err
-}
-defer resp.Body.Close()
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
 
-if resp.StatusCode != http.StatusOK {
-return nil, fmt.Errorf("github api returned %d", resp.StatusCode)
-}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github api returned %d", resp.StatusCode)
+	}
 
-body, err := io.ReadAll(resp.Body)
-if err != nil {
-return nil, err
-}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 
-var releases []releaseInfo
-if err := json.Unmarshal(body, &releases); err != nil {
-return nil, err
-}
+	var releases []releaseInfo
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil, err
+	}
 
-for _, r := range releases {
-if strings.HasPrefix(r.TagName, "v") {
-v, err := parseSemver(r.TagName)
-if err == nil {
-return v, nil
-}
-}
-}
+	for _, r := range releases {
+		if strings.HasPrefix(r.TagName, "v") {
+			v, err := parseSemver(r.TagName)
+			if err == nil {
+				return v, nil
+			}
+		}
+	}
 
-return nil, fmt.Errorf("no valid release found")
+	return nil, fmt.Errorf("no valid release found")
 }
 
 func (c *Checker) cachePath() string {
-if c.cacheDir == "" {
-return ""
-}
-return filepath.Join(c.cacheDir, cacheFile)
+	if c.cacheDir == "" {
+		return ""
+	}
+	return filepath.Join(c.cacheDir, cacheFile)
 }
 
 func (c *Checker) readCache() (string, bool) {
-path := c.cachePath()
-if path == "" {
-return "", false
-}
-data, err := os.ReadFile(path)
-if err != nil {
-return "", false
-}
-var entry cacheEntry
-if err := json.Unmarshal(data, &entry); err != nil {
-return "", false
-}
-if time.Since(entry.CheckedAt) > cacheTTL {
-return "", false
-}
-return entry.LatestVersion, true
+	path := c.cachePath()
+	if path == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var entry cacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return "", false
+	}
+	if time.Since(entry.CheckedAt) > cacheTTL {
+		return "", false
+	}
+	return entry.LatestVersion, true
 }
 
 func (c *Checker) writeCache(version string) {
-path := c.cachePath()
-if path == "" {
-return
-}
-if err := os.MkdirAll(c.cacheDir, 0o755); err != nil {
-return
-}
-entry := cacheEntry{
-LatestVersion: version,
-CheckedAt:     time.Now(),
-}
-data, err := json.Marshal(entry)
-if err != nil {
-return
-}
-_ = os.WriteFile(path, data, 0o644)
+	path := c.cachePath()
+	if path == "" {
+		return
+	}
+	if err := os.MkdirAll(c.cacheDir, 0o755); err != nil {
+		return
+	}
+	entry := cacheEntry{
+		LatestVersion: version,
+		CheckedAt:     time.Now(),
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o644)
 }
 
 // PrintNotice prints an upgrade notice to stderr if a newer version is available.
 // Returns true if a notice was printed.
 func PrintNotice(result *CheckResult, installCmd string) bool {
-if result == nil || !result.UpdateAvail {
-return false
-}
-if installCmd == "" {
-installCmd = "curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash"
-}
-fmt.Fprintf(os.Stderr, "\nA newer version of waza is available: v%s \u2192 v%s. Run: %s\n",
-result.CurrentVersion, result.LatestVersion, installCmd)
-return true
+	if result == nil || !result.UpdateAvail {
+		return false
+	}
+	if installCmd == "" {
+		installCmd = "curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash"
+	}
+	fmt.Fprintf(os.Stderr, "\nA newer version of waza is available: v%s \u2192 v%s. Run: %s\n",
+		result.CurrentVersion, result.LatestVersion, installCmd)
+	return true
 }
 
 func parseSemver(s string) (*semver.Version, error) {
-s = strings.TrimPrefix(s, "v")
-return semver.NewVersion(s)
+	s = strings.TrimPrefix(s, "v")
+	return semver.NewVersion(s)
 }

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package version
+
+import (
+"context"
+"encoding/json"
+"net/http"
+"net/http/httptest"
+"os"
+"path/filepath"
+"testing"
+"time"
+
+"github.com/stretchr/testify/assert"
+"github.com/stretchr/testify/require"
+)
+
+func newTestServer(t *testing.T, releases []releaseInfo) *httptest.Server {
+t.Helper()
+return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+w.Header().Set("Content-Type", "application/json")
+err := json.NewEncoder(w).Encode(releases)
+require.NoError(t, err)
+}))
+}
+
+func TestCheck_NewerVersionAvailable(t *testing.T) {
+srv := newTestServer(t, []releaseInfo{{TagName: "v1.2.0"}, {TagName: "v1.1.0"}})
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+ch.Run(context.Background())
+result := ch.Result()
+require.NotNil(t, result)
+assert.True(t, result.UpdateAvail)
+assert.Equal(t, "1.0.0", result.CurrentVersion)
+assert.Equal(t, "1.2.0", result.LatestVersion)
+}
+
+func TestCheck_CurrentVersionIsCurrent(t *testing.T) {
+srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+ch.Run(context.Background())
+result := ch.Result()
+require.NotNil(t, result)
+assert.False(t, result.UpdateAvail)
+}
+
+func TestCheck_CurrentVersionIsNewer(t *testing.T) {
+srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
+defer srv.Close()
+ch := NewChecker("v2.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+ch.Run(context.Background())
+result := ch.Result()
+require.NotNil(t, result)
+assert.False(t, result.UpdateAvail)
+}
+
+func TestCheck_DevVersion(t *testing.T) {
+srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
+defer srv.Close()
+ch := NewChecker("dev", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+ch.Run(context.Background())
+assert.Nil(t, ch.Result(), "dev version should be skipped")
+}
+
+func TestCheck_CacheHit(t *testing.T) {
+cacheDir := t.TempDir()
+entry := cacheEntry{LatestVersion: "2.0.0", CheckedAt: time.Now()}
+data, err := json.Marshal(entry)
+require.NoError(t, err)
+require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), data, 0o644))
+srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+t.Fatal("server should not be called when cache is valid")
+}))
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
+ch.Run(context.Background())
+result := ch.Result()
+require.NotNil(t, result)
+assert.True(t, result.UpdateAvail)
+assert.Equal(t, "2.0.0", result.LatestVersion)
+}
+
+func TestCheck_CacheExpired(t *testing.T) {
+cacheDir := t.TempDir()
+entry := cacheEntry{LatestVersion: "1.5.0", CheckedAt: time.Now().Add(-25 * time.Hour)}
+data, err := json.Marshal(entry)
+require.NoError(t, err)
+require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), data, 0o644))
+srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
+ch.Run(context.Background())
+result := ch.Result()
+require.NotNil(t, result)
+assert.True(t, result.UpdateAvail)
+assert.Equal(t, "2.0.0", result.LatestVersion)
+cached, ok := ch.readCache()
+assert.True(t, ok)
+assert.Equal(t, "2.0.0", cached)
+}
+
+func TestCheck_APIFailure(t *testing.T) {
+srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+w.WriteHeader(http.StatusInternalServerError)
+}))
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+ch.Run(context.Background())
+assert.Nil(t, ch.Result(), "API failure should return nil")
+}
+
+func TestCheck_APITimeout(t *testing.T) {
+srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+time.Sleep(2 * time.Second)
+w.WriteHeader(http.StatusOK)
+}))
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()),
+WithHTTPClient(&http.Client{Timeout: 100 * time.Millisecond}))
+ch.Run(context.Background())
+assert.Nil(t, ch.Result(), "timeout should return nil gracefully")
+}
+
+func TestCheck_SkipsAzdExtTags(t *testing.T) {
+srv := newTestServer(t, []releaseInfo{
+{TagName: "azd-ext-microsoft-azd-waza_3.0.0"},
+{TagName: "v2.0.0"},
+})
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+ch.Run(context.Background())
+result := ch.Result()
+require.NotNil(t, result)
+assert.True(t, result.UpdateAvail)
+assert.Equal(t, "2.0.0", result.LatestVersion)
+}
+
+func TestCheck_NoReleases(t *testing.T) {
+srv := newTestServer(t, []releaseInfo{})
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+ch.Run(context.Background())
+assert.Nil(t, ch.Result(), "no releases should return nil")
+}
+
+func TestCheck_CacheDirCreated(t *testing.T) {
+srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
+defer srv.Close()
+cacheDir := filepath.Join(t.TempDir(), "nested", "dir")
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
+ch.Run(context.Background())
+result := ch.Result()
+require.NotNil(t, result)
+_, err := os.Stat(filepath.Join(cacheDir, cacheFile))
+assert.NoError(t, err)
+}
+
+func TestPrintNotice_NilResult(t *testing.T) {
+assert.False(t, PrintNotice(nil, ""))
+}
+
+func TestPrintNotice_NoUpdate(t *testing.T) {
+result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "1.0.0", UpdateAvail: false}
+assert.False(t, PrintNotice(result, ""))
+}
+
+func TestPrintNotice_UpdateAvailable(t *testing.T) {
+result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "2.0.0", UpdateAvail: true}
+r, w, _ := os.Pipe()
+oldStderr := os.Stderr
+os.Stderr = w
+printed := PrintNotice(result, "")
+w.Close()
+os.Stderr = oldStderr
+out := make([]byte, 1024)
+n, _ := r.Read(out)
+assert.True(t, printed)
+output := string(out[:n])
+assert.Contains(t, output, "v1.0.0")
+assert.Contains(t, output, "v2.0.0")
+assert.Contains(t, output, "install.sh")
+}
+
+func TestPrintNotice_CustomInstallCmd(t *testing.T) {
+result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "2.0.0", UpdateAvail: true}
+r, w, _ := os.Pipe()
+oldStderr := os.Stderr
+os.Stderr = w
+printed := PrintNotice(result, "brew upgrade waza")
+w.Close()
+os.Stderr = oldStderr
+out := make([]byte, 1024)
+n, _ := r.Read(out)
+assert.True(t, printed)
+assert.Contains(t, string(out[:n]), "brew upgrade waza")
+}
+
+func TestParseSemver(t *testing.T) {
+tests := []struct {
+input string
+want  string
+err   bool
+}{
+{"v1.2.3", "1.2.3", false},
+{"1.2.3", "1.2.3", false},
+{"v0.28.0", "0.28.0", false},
+{"dev", "", true},
+{"", "", true},
+{"not-a-version", "", true},
+}
+for _, tt := range tests {
+t.Run(tt.input, func(t *testing.T) {
+v, err := parseSemver(tt.input)
+if tt.err {
+assert.Error(t, err)
+} else {
+require.NoError(t, err)
+assert.Equal(t, tt.want, v.String())
+}
+})
+}
+}
+
+func TestCheck_ContextCancelled(t *testing.T) {
+srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+time.Sleep(5 * time.Second)
+}))
+defer srv.Close()
+ctx, cancel := context.WithCancel(context.Background())
+cancel()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+ch.Run(ctx)
+assert.Nil(t, ch.Result(), "cancelled context should return nil")
+}
+
+func TestCheck_InvalidCacheJSON(t *testing.T) {
+cacheDir := t.TempDir()
+require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), []byte("not json"), 0o644))
+srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
+defer srv.Close()
+ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
+ch.Run(context.Background())
+result := ch.Result()
+require.NotNil(t, result)
+assert.True(t, result.UpdateAvail)
+assert.Equal(t, "2.0.0", result.LatestVersion)
+}

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -4,248 +4,248 @@
 package version
 
 import (
-"context"
-"encoding/json"
-"net/http"
-"net/http/httptest"
-"os"
-"path/filepath"
-"testing"
-"time"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
 
-"github.com/stretchr/testify/assert"
-"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestServer(t *testing.T, releases []releaseInfo) *httptest.Server {
-t.Helper()
-return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-w.Header().Set("Content-Type", "application/json")
-err := json.NewEncoder(w).Encode(releases)
-require.NoError(t, err)
-}))
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(releases)
+		require.NoError(t, err)
+	}))
 }
 
 func TestCheck_NewerVersionAvailable(t *testing.T) {
-srv := newTestServer(t, []releaseInfo{{TagName: "v1.2.0"}, {TagName: "v1.1.0"}})
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
-ch.Run(context.Background())
-result := ch.Result()
-require.NotNil(t, result)
-assert.True(t, result.UpdateAvail)
-assert.Equal(t, "1.0.0", result.CurrentVersion)
-assert.Equal(t, "1.2.0", result.LatestVersion)
+	srv := newTestServer(t, []releaseInfo{{TagName: "v1.2.0"}, {TagName: "v1.1.0"}})
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	ch.Run(context.Background())
+	result := ch.Result()
+	require.NotNil(t, result)
+	assert.True(t, result.UpdateAvail)
+	assert.Equal(t, "1.0.0", result.CurrentVersion)
+	assert.Equal(t, "1.2.0", result.LatestVersion)
 }
 
 func TestCheck_CurrentVersionIsCurrent(t *testing.T) {
-srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
-ch.Run(context.Background())
-result := ch.Result()
-require.NotNil(t, result)
-assert.False(t, result.UpdateAvail)
+	srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	ch.Run(context.Background())
+	result := ch.Result()
+	require.NotNil(t, result)
+	assert.False(t, result.UpdateAvail)
 }
 
 func TestCheck_CurrentVersionIsNewer(t *testing.T) {
-srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
-defer srv.Close()
-ch := NewChecker("v2.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
-ch.Run(context.Background())
-result := ch.Result()
-require.NotNil(t, result)
-assert.False(t, result.UpdateAvail)
+	srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
+	defer srv.Close()
+	ch := NewChecker("v2.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	ch.Run(context.Background())
+	result := ch.Result()
+	require.NotNil(t, result)
+	assert.False(t, result.UpdateAvail)
 }
 
 func TestCheck_DevVersion(t *testing.T) {
-srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
-defer srv.Close()
-ch := NewChecker("dev", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
-ch.Run(context.Background())
-assert.Nil(t, ch.Result(), "dev version should be skipped")
+	srv := newTestServer(t, []releaseInfo{{TagName: "v1.0.0"}})
+	defer srv.Close()
+	ch := NewChecker("dev", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	ch.Run(context.Background())
+	assert.Nil(t, ch.Result(), "dev version should be skipped")
 }
 
 func TestCheck_CacheHit(t *testing.T) {
-cacheDir := t.TempDir()
-entry := cacheEntry{LatestVersion: "2.0.0", CheckedAt: time.Now()}
-data, err := json.Marshal(entry)
-require.NoError(t, err)
-require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), data, 0o644))
-srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-t.Fatal("server should not be called when cache is valid")
-}))
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
-ch.Run(context.Background())
-result := ch.Result()
-require.NotNil(t, result)
-assert.True(t, result.UpdateAvail)
-assert.Equal(t, "2.0.0", result.LatestVersion)
+	cacheDir := t.TempDir()
+	entry := cacheEntry{LatestVersion: "2.0.0", CheckedAt: time.Now()}
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), data, 0o644))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called when cache is valid")
+	}))
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
+	ch.Run(context.Background())
+	result := ch.Result()
+	require.NotNil(t, result)
+	assert.True(t, result.UpdateAvail)
+	assert.Equal(t, "2.0.0", result.LatestVersion)
 }
 
 func TestCheck_CacheExpired(t *testing.T) {
-cacheDir := t.TempDir()
-entry := cacheEntry{LatestVersion: "1.5.0", CheckedAt: time.Now().Add(-25 * time.Hour)}
-data, err := json.Marshal(entry)
-require.NoError(t, err)
-require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), data, 0o644))
-srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
-ch.Run(context.Background())
-result := ch.Result()
-require.NotNil(t, result)
-assert.True(t, result.UpdateAvail)
-assert.Equal(t, "2.0.0", result.LatestVersion)
-cached, ok := ch.readCache()
-assert.True(t, ok)
-assert.Equal(t, "2.0.0", cached)
+	cacheDir := t.TempDir()
+	entry := cacheEntry{LatestVersion: "1.5.0", CheckedAt: time.Now().Add(-25 * time.Hour)}
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), data, 0o644))
+	srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
+	ch.Run(context.Background())
+	result := ch.Result()
+	require.NotNil(t, result)
+	assert.True(t, result.UpdateAvail)
+	assert.Equal(t, "2.0.0", result.LatestVersion)
+	cached, ok := ch.readCache()
+	assert.True(t, ok)
+	assert.Equal(t, "2.0.0", cached)
 }
 
 func TestCheck_APIFailure(t *testing.T) {
-srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-w.WriteHeader(http.StatusInternalServerError)
-}))
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
-ch.Run(context.Background())
-assert.Nil(t, ch.Result(), "API failure should return nil")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	ch.Run(context.Background())
+	assert.Nil(t, ch.Result(), "API failure should return nil")
 }
 
 func TestCheck_APITimeout(t *testing.T) {
-srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-time.Sleep(2 * time.Second)
-w.WriteHeader(http.StatusOK)
-}))
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()),
-WithHTTPClient(&http.Client{Timeout: 100 * time.Millisecond}))
-ch.Run(context.Background())
-assert.Nil(t, ch.Result(), "timeout should return nil gracefully")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()),
+		WithHTTPClient(&http.Client{Timeout: 100 * time.Millisecond}))
+	ch.Run(context.Background())
+	assert.Nil(t, ch.Result(), "timeout should return nil gracefully")
 }
 
 func TestCheck_SkipsAzdExtTags(t *testing.T) {
-srv := newTestServer(t, []releaseInfo{
-{TagName: "azd-ext-microsoft-azd-waza_3.0.0"},
-{TagName: "v2.0.0"},
-})
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
-ch.Run(context.Background())
-result := ch.Result()
-require.NotNil(t, result)
-assert.True(t, result.UpdateAvail)
-assert.Equal(t, "2.0.0", result.LatestVersion)
+	srv := newTestServer(t, []releaseInfo{
+		{TagName: "azd-ext-microsoft-azd-waza_3.0.0"},
+		{TagName: "v2.0.0"},
+	})
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	ch.Run(context.Background())
+	result := ch.Result()
+	require.NotNil(t, result)
+	assert.True(t, result.UpdateAvail)
+	assert.Equal(t, "2.0.0", result.LatestVersion)
 }
 
 func TestCheck_NoReleases(t *testing.T) {
-srv := newTestServer(t, []releaseInfo{})
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
-ch.Run(context.Background())
-assert.Nil(t, ch.Result(), "no releases should return nil")
+	srv := newTestServer(t, []releaseInfo{})
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	ch.Run(context.Background())
+	assert.Nil(t, ch.Result(), "no releases should return nil")
 }
 
 func TestCheck_CacheDirCreated(t *testing.T) {
-srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
-defer srv.Close()
-cacheDir := filepath.Join(t.TempDir(), "nested", "dir")
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
-ch.Run(context.Background())
-result := ch.Result()
-require.NotNil(t, result)
-_, err := os.Stat(filepath.Join(cacheDir, cacheFile))
-assert.NoError(t, err)
+	srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
+	defer srv.Close()
+	cacheDir := filepath.Join(t.TempDir(), "nested", "dir")
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
+	ch.Run(context.Background())
+	result := ch.Result()
+	require.NotNil(t, result)
+	_, err := os.Stat(filepath.Join(cacheDir, cacheFile))
+	assert.NoError(t, err)
 }
 
 func TestPrintNotice_NilResult(t *testing.T) {
-assert.False(t, PrintNotice(nil, ""))
+	assert.False(t, PrintNotice(nil, ""))
 }
 
 func TestPrintNotice_NoUpdate(t *testing.T) {
-result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "1.0.0", UpdateAvail: false}
-assert.False(t, PrintNotice(result, ""))
+	result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "1.0.0", UpdateAvail: false}
+	assert.False(t, PrintNotice(result, ""))
 }
 
 func TestPrintNotice_UpdateAvailable(t *testing.T) {
-result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "2.0.0", UpdateAvail: true}
-r, w, _ := os.Pipe()
-oldStderr := os.Stderr
-os.Stderr = w
-printed := PrintNotice(result, "")
-w.Close()
-os.Stderr = oldStderr
-out := make([]byte, 1024)
-n, _ := r.Read(out)
-assert.True(t, printed)
-output := string(out[:n])
-assert.Contains(t, output, "v1.0.0")
-assert.Contains(t, output, "v2.0.0")
-assert.Contains(t, output, "install.sh")
+	result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "2.0.0", UpdateAvail: true}
+	r, w, _ := os.Pipe()
+	oldStderr := os.Stderr
+	os.Stderr = w
+	printed := PrintNotice(result, "")
+	_ = w.Close()
+	os.Stderr = oldStderr
+	out := make([]byte, 1024)
+	n, _ := r.Read(out)
+	assert.True(t, printed)
+	output := string(out[:n])
+	assert.Contains(t, output, "v1.0.0")
+	assert.Contains(t, output, "v2.0.0")
+	assert.Contains(t, output, "install.sh")
 }
 
 func TestPrintNotice_CustomInstallCmd(t *testing.T) {
-result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "2.0.0", UpdateAvail: true}
-r, w, _ := os.Pipe()
-oldStderr := os.Stderr
-os.Stderr = w
-printed := PrintNotice(result, "brew upgrade waza")
-w.Close()
-os.Stderr = oldStderr
-out := make([]byte, 1024)
-n, _ := r.Read(out)
-assert.True(t, printed)
-assert.Contains(t, string(out[:n]), "brew upgrade waza")
+	result := &CheckResult{CurrentVersion: "1.0.0", LatestVersion: "2.0.0", UpdateAvail: true}
+	r, w, _ := os.Pipe()
+	oldStderr := os.Stderr
+	os.Stderr = w
+	printed := PrintNotice(result, "brew upgrade waza")
+	_ = w.Close()
+	os.Stderr = oldStderr
+	out := make([]byte, 1024)
+	n, _ := r.Read(out)
+	assert.True(t, printed)
+	assert.Contains(t, string(out[:n]), "brew upgrade waza")
 }
 
 func TestParseSemver(t *testing.T) {
-tests := []struct {
-input string
-want  string
-err   bool
-}{
-{"v1.2.3", "1.2.3", false},
-{"1.2.3", "1.2.3", false},
-{"v0.28.0", "0.28.0", false},
-{"dev", "", true},
-{"", "", true},
-{"not-a-version", "", true},
-}
-for _, tt := range tests {
-t.Run(tt.input, func(t *testing.T) {
-v, err := parseSemver(tt.input)
-if tt.err {
-assert.Error(t, err)
-} else {
-require.NoError(t, err)
-assert.Equal(t, tt.want, v.String())
-}
-})
-}
+	tests := []struct {
+		input string
+		want  string
+		err   bool
+	}{
+		{"v1.2.3", "1.2.3", false},
+		{"1.2.3", "1.2.3", false},
+		{"v0.28.0", "0.28.0", false},
+		{"dev", "", true},
+		{"", "", true},
+		{"not-a-version", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			v, err := parseSemver(tt.input)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, v.String())
+			}
+		})
+	}
 }
 
-func TestCheck_ContextCancelled(t *testing.T) {
-srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-time.Sleep(5 * time.Second)
-}))
-defer srv.Close()
-ctx, cancel := context.WithCancel(context.Background())
-cancel()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
-ch.Run(ctx)
-assert.Nil(t, ch.Result(), "cancelled context should return nil")
+func TestCheck_ContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	ch.Run(ctx)
+	assert.Nil(t, ch.Result(), "canceled context should return nil")
 }
 
 func TestCheck_InvalidCacheJSON(t *testing.T) {
-cacheDir := t.TempDir()
-require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), []byte("not json"), 0o644))
-srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
-defer srv.Close()
-ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
-ch.Run(context.Background())
-result := ch.Result()
-require.NotNil(t, result)
-assert.True(t, result.UpdateAvail)
-assert.Equal(t, "2.0.0", result.LatestVersion)
+	cacheDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFile), []byte("not json"), 0o644))
+	srv := newTestServer(t, []releaseInfo{{TagName: "v2.0.0"}})
+	defer srv.Close()
+	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
+	ch.Run(context.Background())
+	result := ch.Result()
+	require.NotNil(t, result)
+	assert.True(t, result.UpdateAvail)
+	assert.Equal(t, "2.0.0", result.LatestVersion)
 }

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -59,6 +59,10 @@ azd waza run eval.yaml
 azd waza serve
 ```
 
+:::tip[Automatic Update Notifications]
+Waza checks for new versions in the background. If an update is available, you'll see a notice after command output. Disable with `--no-update-check` or `WAZA_NO_UPDATE_CHECK=1`.
+:::
+
 ## Quick Start
 
 Get a complete evaluation suite running in 5 minutes.

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -854,6 +854,19 @@ waza models --json
 | `--help` | Show help |
 | `--version` | Show version |
 | `--verbose` | Enable debug output |
+| `--no-update-check` | Disable automatic version update check |
+
+## Automatic Update Check
+
+Waza checks for newer versions in the background when you run any command. If an update is available, a one-line notice is printed **after** the command output:
+
+```
+A newer version of waza is available: v0.24.0 → v0.28.0. Run: curl -fsSL ... | bash
+```
+
+- The check is **non-blocking** — it never slows down your command.
+- Results are cached for 24 hours in `~/.waza/version-check.json`.
+- Disable with `--no-update-check` or set `WAZA_NO_UPDATE_CHECK=1`.
 
 ## Environment Variables
 
@@ -862,6 +875,7 @@ waza models --json
 | `GITHUB_TOKEN` | Token for Copilot SDK execution |
 | `WAZA_HOME` | Config directory (default: `~/.waza`) |
 | `WAZA_CACHE` | Cache directory (default: `.waza-cache`) |
+| `WAZA_NO_UPDATE_CHECK` | Set to `1` to disable automatic version check |
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Closes #104. Adds a non-blocking version check that runs in the background on every command. If a newer waza version exists, prints a one-line notice **after** command output.

## Changes

### New: `internal/version/` package
- `Checker` — async version check against GitHub releases API (goroutine)
- 24h cache in `~/.waza/version-check.json` to avoid API hits
- `PrintNotice()` — prints upgrade notice to stderr
- Functional options: `WithHTTPClient`, `WithCacheDir`, `WithAPIBaseURL`, `WithRepo`
- Filters `azd-ext-*` tags; only checks `v`-prefixed CLI releases
- Graceful on all failures: API errors, timeouts, corrupt cache, dev builds → silent nil

### Modified: `cmd/waza/root.go`
- `PersistentPreRun`: starts background checker (unless `--no-update-check` or `WAZA_NO_UPDATE_CHECK`)
- `PersistentPostRun`: prints notice if update available (100ms max wait — never blocks)

### Docs
- CLI reference: new `--no-update-check` flag, `WAZA_NO_UPDATE_CHECK` env var, "Automatic Update Check" section
- README: "Update Notifications" section
- Site builds clean

## Tests (18 total)
- Newer version available / current / ahead
- Dev version skipped
- Cache hit / cache expired / cache dir auto-created / invalid cache JSON
- API failure / API timeout / context cancelled
- azd-ext tag filtering / no releases
- PrintNotice: nil, no update, update available, custom install cmd
- Semver parsing: v-prefix, bare, invalid

## Non-blocking guarantee
The check runs in a goroutine. `Result()` waits at most 100ms. If the check hasn't finished, it returns nil and the command output is unaffected.