### PR TITLE
feat: allow specifying skill_directories per task (#156)

### DIFF
--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -16,6 +16,7 @@ type TestCase struct {
 	ContextRoot string            `yaml:"context_dir,omitempty" json:"context_root,omitempty"`
 	DisplayName string            `yaml:"name" json:"display_name"`
 	Expectation TestExpectation   `yaml:"expected,omitempty" json:"expectation,omitempty"`
+	SkillPaths  []string          `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
 	Stimulus    TestStimulus      `yaml:"inputs" json:"stimulus"`
 	Summary     string            `yaml:"description,omitempty" json:"summary,omitempty"`
 	Tags        []string          `yaml:"tags,omitempty" json:"labels,omitempty"`

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -135,7 +135,7 @@ expected:
 // field is implemented.
 
 func TestLoadTestCase_SkillDirectories(t *testing.T) {
-yamlContent := `id: skill-test
+	yamlContent := `id: skill-test
 name: Skill directories test
 inputs:
   prompt: "test prompt"
@@ -143,23 +143,23 @@ skill_directories:
   - ./skills/custom
   - /absolute/skills
 `
-dir := t.TempDir()
-p := filepath.Join(dir, "tc.yaml")
-if err := os.WriteFile(p, []byte(yamlContent), 0o644); err != nil {
-t.Fatalf("write file: %v", err)
-}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tc.yaml")
+	if err := os.WriteFile(p, []byte(yamlContent), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
 
-tc, err := LoadTestCase(p)
-if err != nil {
-t.Fatalf("LoadTestCase: %v", err)
-}
-if len(tc.SkillPaths) != 2 {
-t.Fatalf("Expected 2 skill paths, got %d", len(tc.SkillPaths))
-}
-if tc.SkillPaths[0] != "./skills/custom" {
-t.Errorf("Expected first skill path './skills/custom', got %q", tc.SkillPaths[0])
-}
-if tc.SkillPaths[1] != "/absolute/skills" {
-t.Errorf("Expected second skill path '/absolute/skills', got %q", tc.SkillPaths[1])
-}
+	tc, err := LoadTestCase(p)
+	if err != nil {
+		t.Fatalf("LoadTestCase: %v", err)
+	}
+	if len(tc.SkillPaths) != 2 {
+		t.Fatalf("Expected 2 skill paths, got %d", len(tc.SkillPaths))
+	}
+	if tc.SkillPaths[0] != "./skills/custom" {
+		t.Errorf("Expected first skill path './skills/custom', got %q", tc.SkillPaths[0])
+	}
+	if tc.SkillPaths[1] != "/absolute/skills" {
+		t.Errorf("Expected second skill path '/absolute/skills', got %q", tc.SkillPaths[1])
+	}
 }

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -133,3 +133,33 @@ expected:
 // TestLoadTestCase_FollowUpPrompts was removed: it referenced
 // TestStimulus.FollowUps which does not exist. Re-add when that
 // field is implemented.
+
+func TestLoadTestCase_SkillDirectories(t *testing.T) {
+yamlContent := `id: skill-test
+name: Skill directories test
+inputs:
+  prompt: "test prompt"
+skill_directories:
+  - ./skills/custom
+  - /absolute/skills
+`
+dir := t.TempDir()
+p := filepath.Join(dir, "tc.yaml")
+if err := os.WriteFile(p, []byte(yamlContent), 0o644); err != nil {
+t.Fatalf("write file: %v", err)
+}
+
+tc, err := LoadTestCase(p)
+if err != nil {
+t.Fatalf("LoadTestCase: %v", err)
+}
+if len(tc.SkillPaths) != 2 {
+t.Fatalf("Expected 2 skill paths, got %d", len(tc.SkillPaths))
+}
+if tc.SkillPaths[0] != "./skills/custom" {
+t.Errorf("Expected first skill path './skills/custom', got %q", tc.SkillPaths[0])
+}
+if tc.SkillPaths[1] != "/absolute/skills" {
+t.Errorf("Expected second skill path '/absolute/skills', got %q", tc.SkillPaths[1])
+}
+}

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1134,8 +1134,12 @@ func (r *TestRunner) buildExecutionRequest(tc *models.TestCase) *execution.Execu
 		timeout = *tc.TimeoutSec
 	}
 
-	// Resolve skill paths relative to spec directory
-	resolvedSkillPaths := utils.ResolvePaths(spec.Config.SkillPaths, r.cfg.SpecDir())
+	// Use task-level skill paths if specified, otherwise fall back to eval-level
+	skillPaths := spec.Config.SkillPaths
+	if len(tc.SkillPaths) > 0 {
+		skillPaths = tc.SkillPaths
+	}
+	resolvedSkillPaths := utils.ResolvePaths(skillPaths, r.cfg.SpecDir())
 
 	return &execution.ExecutionRequest{
 		Message:    tc.Stimulus.Message,

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -180,6 +180,50 @@ func TestBuildExecutionRequest_TimeoutOverride(t *testing.T) {
 	assert.Equal(t, float64(300), req.Timeout.Seconds(), "test case timeout should override spec timeout")
 }
 
+func TestBuildExecutionRequest_TaskLevelSkillPaths(t *testing.T) {
+specDir := t.TempDir()
+
+spec := &models.BenchmarkSpec{
+SpecIdentity: models.SpecIdentity{
+Name: "test-benchmark",
+},
+SkillName: "test-skill",
+Config: models.Config{
+EngineType: "mock",
+ModelID:    "gpt-4",
+SkillPaths: []string{"./eval-skills"},
+TimeoutSec: 60,
+},
+}
+
+cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(specDir))
+runner := NewTestRunner(cfg, nil)
+
+// Task with its own skill_directories should override eval-level
+tc := &models.TestCase{
+TestID:      "test-001",
+DisplayName: "Test Case",
+Stimulus:    models.TestStimulus{Message: "test"},
+SkillPaths:  []string{"./task-skills", "./more-skills"},
+}
+req := runner.buildExecutionRequest(tc)
+require.NotNil(t, req)
+assert.Equal(t, 2, len(req.SkillPaths), "task-level skill paths should override eval-level")
+assert.Equal(t, filepath.Join(specDir, "task-skills"), req.SkillPaths[0])
+assert.Equal(t, filepath.Join(specDir, "more-skills"), req.SkillPaths[1])
+
+// Task without skill_directories should fall back to eval-level
+tc2 := &models.TestCase{
+TestID:      "test-002",
+DisplayName: "Test Case 2",
+Stimulus:    models.TestStimulus{Message: "test"},
+}
+req2 := runner.buildExecutionRequest(tc2)
+require.NotNil(t, req2)
+assert.Equal(t, 1, len(req2.SkillPaths), "should fall back to eval-level skill paths")
+assert.Equal(t, filepath.Join(specDir, "eval-skills"), req2.SkillPaths[0])
+}
+
 func TestComputeTestStats_ErrorRunsAreSeparateFromFailed(t *testing.T) {
 	runs := []models.RunResult{
 		{

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -181,47 +181,47 @@ func TestBuildExecutionRequest_TimeoutOverride(t *testing.T) {
 }
 
 func TestBuildExecutionRequest_TaskLevelSkillPaths(t *testing.T) {
-specDir := t.TempDir()
+	specDir := t.TempDir()
 
-spec := &models.BenchmarkSpec{
-SpecIdentity: models.SpecIdentity{
-Name: "test-benchmark",
-},
-SkillName: "test-skill",
-Config: models.Config{
-EngineType: "mock",
-ModelID:    "gpt-4",
-SkillPaths: []string{"./eval-skills"},
-TimeoutSec: 60,
-},
-}
+	spec := &models.BenchmarkSpec{
+		SpecIdentity: models.SpecIdentity{
+			Name: "test-benchmark",
+		},
+		SkillName: "test-skill",
+		Config: models.Config{
+			EngineType: "mock",
+			ModelID:    "gpt-4",
+			SkillPaths: []string{"./eval-skills"},
+			TimeoutSec: 60,
+		},
+	}
 
-cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(specDir))
-runner := NewTestRunner(cfg, nil)
+	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(specDir))
+	runner := NewTestRunner(cfg, nil)
 
-// Task with its own skill_directories should override eval-level
-tc := &models.TestCase{
-TestID:      "test-001",
-DisplayName: "Test Case",
-Stimulus:    models.TestStimulus{Message: "test"},
-SkillPaths:  []string{"./task-skills", "./more-skills"},
-}
-req := runner.buildExecutionRequest(tc)
-require.NotNil(t, req)
-assert.Equal(t, 2, len(req.SkillPaths), "task-level skill paths should override eval-level")
-assert.Equal(t, filepath.Join(specDir, "task-skills"), req.SkillPaths[0])
-assert.Equal(t, filepath.Join(specDir, "more-skills"), req.SkillPaths[1])
+	// Task with its own skill_directories should override eval-level
+	tc := &models.TestCase{
+		TestID:      "test-001",
+		DisplayName: "Test Case",
+		Stimulus:    models.TestStimulus{Message: "test"},
+		SkillPaths:  []string{"./task-skills", "./more-skills"},
+	}
+	req := runner.buildExecutionRequest(tc)
+	require.NotNil(t, req)
+	assert.Equal(t, 2, len(req.SkillPaths), "task-level skill paths should override eval-level")
+	assert.Equal(t, filepath.Join(specDir, "task-skills"), req.SkillPaths[0])
+	assert.Equal(t, filepath.Join(specDir, "more-skills"), req.SkillPaths[1])
 
-// Task without skill_directories should fall back to eval-level
-tc2 := &models.TestCase{
-TestID:      "test-002",
-DisplayName: "Test Case 2",
-Stimulus:    models.TestStimulus{Message: "test"},
-}
-req2 := runner.buildExecutionRequest(tc2)
-require.NotNil(t, req2)
-assert.Equal(t, 1, len(req2.SkillPaths), "should fall back to eval-level skill paths")
-assert.Equal(t, filepath.Join(specDir, "eval-skills"), req2.SkillPaths[0])
+	// Task without skill_directories should fall back to eval-level
+	tc2 := &models.TestCase{
+		TestID:      "test-002",
+		DisplayName: "Test Case 2",
+		Stimulus:    models.TestStimulus{Message: "test"},
+	}
+	req2 := runner.buildExecutionRequest(tc2)
+	require.NotNil(t, req2)
+	assert.Equal(t, 1, len(req2.SkillPaths), "should fall back to eval-level skill paths")
+	assert.Equal(t, filepath.Join(specDir, "eval-skills"), req2.SkillPaths[0])
 }
 
 func TestComputeTestStats_ErrorRunsAreSeparateFromFailed(t *testing.T) {

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -64,6 +64,13 @@
         "type": "string"
       },
       "description": "Sequential follow-up prompts sent after the initial prompt, reusing the same session and workspace."
+    },
+    "skill_directories": {
+      "type": "array",
+      "description": "List of directories containing agent skills for this task (overrides eval-level skill_directories)",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "$defs": {

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -187,6 +187,7 @@ expected:
 | `tags`        | array  | Tags for filtering (e.g., `["basic", "edge-case"]`) |
 | `inputs`      | object | Test inputs (prompt, files)                         |
 | `expected`    | object | Validation rules and expected behavior              |
+| `skill_directories` | string[] | Skill directories for this task (overrides eval-level) |
 
 ### Inputs Section
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -379,6 +379,17 @@ waza run eval.yaml --tags "basic"
 waza run eval.yaml --tags "edge-case"
 ```
 
+### skill_directories (optional)
+
+Override the eval-level `skill_directories` for a specific task. Paths are resolved relative to the eval YAML directory.
+
+```yaml
+skill_directories:
+  - ./skills/custom-task-skills
+```
+
+When specified on a task, this **replaces** (not merges with) the eval-level `skill_directories`.
+
 ## inputs Section
 
 Test inputs passed to the agent.


### PR DESCRIPTION
## Summary

Allow `skill_directories` to be specified per-task in eval YAML files, overriding the eval-level setting. This enables tasks that need different skills from the rest of the eval.

### Changes

- **`internal/models/testcase.go`**: Add `SkillPaths []string` field to `TestCase` struct (`yaml:"skill_directories"`)
- **`internal/orchestration/runner.go`**: Update `buildExecutionRequest()` to prefer task-level `SkillPaths` over eval-level, falling back when unset
- **`internal/models/testcase_test.go`**: Add `TestLoadTestCase_SkillDirectories` — verifies YAML parsing of the new field
- **`internal/orchestration/runner_test.go`**: Add `TestBuildExecutionRequest_TaskLevelSkillPaths` — verifies override and fallback logic
- **`schemas/task.schema.json`**: Add `skill_directories` array property
- **`site/src/content/docs/guides/eval-yaml.mdx`**: Add `skill_directories` to Task Fields table
- **`site/src/content/docs/reference/schema.mdx`**: Add `skill_directories` section to Task File Format

### Behavior

- Task-level `skill_directories` **replaces** (not merges with) eval-level paths
- If task has no `skill_directories`, falls back to eval-level
- Paths resolved relative to the spec directory (same as eval-level)

### Example

```yaml
# eval.yaml
config:
  skill_directories:
    - ./default-skills

tasks:
  - file: special-task.yaml  # can override with its own skill_directories
```

```yaml
# special-task.yaml
id: special-task
name: Special task with custom skills
skill_directories:
  - ./custom-skills
inputs:
  prompt: "Do something special"
```

Closes #156

Working as Linus (Backend Developer)