### PR TITLE
feat: add disabled_skills config and --no-skills CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Run an evaluation benchmark from a spec file.
 | `--no-summary` | | Skip writing combined summary.json for multi-skill runs |
 | `--update-snapshots` | | Update or create diff grader snapshot files to match current output |
 | `--skip-graders` | | Skip grading (execution only); grade later with `waza grade` |
+| `--keep-workspace` | | Preserve temp workspaces after execution for debugging |
 
 **Result Caching**
 

--- a/cmd/waza/cmd_run.go
+++ b/cmd/waza/cmd_run.go
@@ -65,6 +65,7 @@ var (
 	strictFlag      bool
 	updateSnapshots bool
 	skipGradersFlag bool
+	noSkillsFlag    bool
 
 	// newCopilotClientFn allows you to override the client used by the copilot engine, for this command.
 	newCopilotClientFn func(clientOptions *copilot.ClientOptions) execution.CopilotClient
@@ -124,6 +125,7 @@ You can also specify a skill name to run its eval:
 	cmd.Flags().BoolVar(&strictFlag, "strict", false, "With --discover, fail if any SKILL.md lacks an eval.yaml")
 	cmd.Flags().BoolVar(&updateSnapshots, "update-snapshots", false, "Update or create diff grader snapshot files to match current workspace output")
 	cmd.Flags().BoolVar(&skipGradersFlag, "skip-graders", false, "Skip grading (execution only); use with waza grade to grade later")
+	cmd.Flags().BoolVar(&noSkillsFlag, "no-skills", false, "Disable all skill loading for the evaluation")
 
 	return cmd
 }
@@ -467,6 +469,9 @@ func runCommandForSpec(cmd *cobra.Command, sp skillSpecPath, defaultSkills []str
 	if baselineFlag {
 		spec.Baseline = true
 	}
+	if noSkillsFlag {
+		spec.Config.DisabledSkills = []string{"*"}
+	}
 	if judgeModel != "" {
 		spec.Config.JudgeModel = judgeModel
 	}
@@ -735,9 +740,11 @@ func runSingleModel(cmd *cobra.Command, spec *models.BenchmarkSpec, specPath str
 		fmt.Printf("Parallel: %d workers\n", w)
 	}
 
-	if verbose && len(spec.Config.SkillPaths) > 0 {
+	if verbose && spec.Config.AllSkillsDisabled() {
+		fmt.Printf("Skills: disabled (all skills disabled)\n")
+	} else if verbose && len(spec.Config.SkillPaths) > 0 {
 		fmt.Printf("Skill Directories:\n")
-		resolvedPaths := utils.ResolvePaths(spec.Config.SkillPaths, specDir)
+		resolvedPaths := utils.ResolvePaths(spec.Config.FilteredSkillPaths(), specDir)
 		for _, path := range resolvedPaths {
 			fmt.Printf("  - %s\n", path)
 		}

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -155,15 +155,16 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 		}
 	}
 
-	// Build skill directories list: start with CWD, then add any from request
-	skillDirs := e.getSkillDirs(sourceDir, req)
-
-	// Load skill definitions from directories and build system message
+	// Build skill directories list and system message, unless skills are disabled
+	var skillDirs []string
 	var systemMessage *copilot.SystemMessageConfig
-	if msg := buildSkillSystemMessage(skillDirs, req.SkillName); msg != "" {
-		systemMessage = &copilot.SystemMessageConfig{
-			Mode:    "append",
-			Content: msg,
+	if !req.NoSkills {
+		skillDirs = e.getSkillDirs(sourceDir, req)
+		if msg := buildSkillSystemMessage(skillDirs, req.SkillName); msg != "" {
+			systemMessage = &copilot.SystemMessageConfig{
+				Mode:    "append",
+				Content: msg,
+			}
 		}
 	}
 

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -41,6 +41,7 @@ type ExecutionRequest struct {
 
 	SourceDir  string   // used when looking for workspace items via relative path, like skills.
 	SkillPaths []string // Directories to search for skills
+	NoSkills   bool     // When true, skip all skill loading
 
 	Timeout time.Duration
 

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -41,6 +41,7 @@ type Config struct {
 	EngineType     string         `yaml:"executor" json:"engine_type"`
 	ModelID        string         `yaml:"model" json:"model_id"`
 	SkillPaths     []string       `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
+	DisabledSkills []string       `yaml:"disabled_skills,omitempty" json:"disabled_skills,omitempty"`
 	RequiredSkills []string       `yaml:"required_skills,omitempty" json:"required_skills,omitempty"`
 	ServerConfigs  map[string]any `yaml:"mcp_servers,omitempty" json:"server_configs,omitempty"`
 	MaxAttempts    int            `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty"`
@@ -199,6 +200,42 @@ func (g *GraderConfig) Validate() error {
 	}
 
 	return nil
+}
+
+// AllSkillsDisabled returns true when skills should be completely disabled.
+func (c *Config) AllSkillsDisabled() bool {
+	for _, s := range c.DisabledSkills {
+		if s == "*" {
+			return true
+		}
+	}
+	for _, s := range c.SkillPaths {
+		if s == "none" {
+			return true
+		}
+	}
+	return false
+}
+
+// FilteredSkillPaths returns SkillPaths with any disabled skill directories removed.
+func (c *Config) FilteredSkillPaths() []string {
+	if c.AllSkillsDisabled() {
+		return nil
+	}
+	if len(c.DisabledSkills) == 0 {
+		return c.SkillPaths
+	}
+	disabled := make(map[string]bool, len(c.DisabledSkills))
+	for _, s := range c.DisabledSkills {
+		disabled[s] = true
+	}
+	var filtered []string
+	for _, p := range c.SkillPaths {
+		if !disabled[p] && !disabled[filepath.Base(p)] {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
 }
 
 // MeasurementDef defines a metric

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -363,3 +363,117 @@ config:
 		}
 	})
 }
+
+func TestConfig_AllSkillsDisabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		expected bool
+	}{
+		{name: "empty config", config: Config{}, expected: false},
+		{name: "wildcard disabled", config: Config{DisabledSkills: []string{"*"}}, expected: true},
+		{name: "specific skill disabled", config: Config{DisabledSkills: []string{"my-skill"}}, expected: false},
+		{name: "skill_directories none", config: Config{SkillPaths: []string{"none"}}, expected: true},
+		{name: "skill_directories with paths", config: Config{SkillPaths: []string{"./skills"}}, expected: false},
+		{name: "wildcard among specific", config: Config{DisabledSkills: []string{"a", "*", "b"}}, expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.config.AllSkillsDisabled(); got != tt.expected {
+				t.Errorf("AllSkillsDisabled() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfig_FilteredSkillPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		expected []string
+	}{
+		{name: "no disabled skills", config: Config{SkillPaths: []string{"./a", "./b"}}, expected: []string{"./a", "./b"}},
+		{name: "all disabled", config: Config{SkillPaths: []string{"./a"}, DisabledSkills: []string{"*"}}, expected: nil},
+		{name: "filter basename", config: Config{SkillPaths: []string{"./skills/a", "./skills/b", "./skills/c"}, DisabledSkills: []string{"b"}}, expected: []string{"./skills/a", "./skills/c"}},
+		{name: "filter full path", config: Config{SkillPaths: []string{"./skills/a", "./skills/b"}, DisabledSkills: []string{"./skills/a"}}, expected: []string{"./skills/b"}},
+		{name: "no skill paths", config: Config{DisabledSkills: []string{"a"}}, expected: nil},
+		{name: "empty disabled", config: Config{SkillPaths: []string{"./a"}, DisabledSkills: []string{}}, expected: []string{"./a"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.FilteredSkillPaths()
+			if len(got) != len(tt.expected) {
+				t.Fatalf("FilteredSkillPaths() = %v, want %v", got, tt.expected)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBenchmarkSpec_DisabledSkillsDeserialization(t *testing.T) {
+	t.Run("wildcard", func(t *testing.T) {
+		tempDir := t.TempDir()
+		yamlStr := `name: test-disabled
+description: test
+skill: test-skill
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: gpt-4o
+  disabled_skills: ["*"]
+graders:
+  - type: text
+    name: basic
+    rubric: check
+tasks:
+  - "*.yaml"
+`
+		p := filepath.Join(tempDir, "eval.yaml")
+		os.WriteFile(p, []byte(yamlStr), 0644)
+		spec, err := LoadBenchmarkSpec(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !spec.Config.AllSkillsDisabled() {
+			t.Error("expected AllSkillsDisabled true")
+		}
+	})
+
+	t.Run("specific", func(t *testing.T) {
+		tempDir := t.TempDir()
+		yamlStr := `name: test-specific
+description: test
+skill: test-skill
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: gpt-4o
+  disabled_skills: [my-skill]
+  skill_directories: [./skills/a, ./skills/my-skill, ./skills/b]
+graders:
+  - type: text
+    name: basic
+    rubric: check
+tasks:
+  - "*.yaml"
+`
+		p := filepath.Join(tempDir, "eval.yaml")
+		os.WriteFile(p, []byte(yamlStr), 0644)
+		spec, err := LoadBenchmarkSpec(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if spec.Config.AllSkillsDisabled() {
+			t.Error("expected AllSkillsDisabled false")
+		}
+		if filtered := spec.Config.FilteredSkillPaths(); len(filtered) != 2 {
+			t.Errorf("expected 2 filtered paths, got %d: %v", len(filtered), filtered)
+		}
+	})
+}

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -645,6 +645,11 @@ func (r *TestRunner) loadTestCasesFromFiles() ([]*models.TestCase, error) {
 func (r *TestRunner) validateRequiredSkills() error {
 	spec := r.cfg.Spec()
 
+	// If all skills are disabled, skip validation
+	if spec.Config.AllSkillsDisabled() {
+		return nil
+	}
+
 	// If no required skills specified, skip validation
 	if len(spec.Config.RequiredSkills) == 0 {
 		return nil
@@ -1135,11 +1140,12 @@ func (r *TestRunner) buildExecutionRequest(tc *models.TestCase) *execution.Execu
 	}
 
 	// Use task-level skill paths if specified, otherwise fall back to eval-level
-	skillPaths := spec.Config.SkillPaths
+	skillPaths := spec.Config.FilteredSkillPaths()
 	if len(tc.SkillPaths) > 0 {
 		skillPaths = tc.SkillPaths
 	}
 	resolvedSkillPaths := utils.ResolvePaths(skillPaths, r.cfg.SpecDir())
+	noSkills := spec.Config.AllSkillsDisabled()
 
 	return &execution.ExecutionRequest{
 		Message:    tc.Stimulus.Message,
@@ -1147,6 +1153,7 @@ func (r *TestRunner) buildExecutionRequest(tc *models.TestCase) *execution.Execu
 		Resources:  resources,
 		SkillName:  spec.SkillName,
 		SkillPaths: resolvedSkillPaths,
+		NoSkills:   noSkills,
 		Timeout:    time.Duration(timeout) * time.Second,
 		MCPServers: convertMCPServers(spec.Config.ServerConfigs),
 	}

--- a/internal/trigger/runner.go
+++ b/internal/trigger/runner.go
@@ -173,7 +173,8 @@ func (r *Runner) testTrigger(ctx context.Context, prompt string) (*execution.Exe
 	return r.engine.Execute(ctx, &execution.ExecutionRequest{
 		Message:                 prompt,
 		SkillName:               r.spec.Skill,
-		SkillPaths:              utils.ResolvePaths(spec.Config.SkillPaths, r.cfg.SpecDir()),
+		SkillPaths:              utils.ResolvePaths(spec.Config.FilteredSkillPaths(), r.cfg.SpecDir()),
+		NoSkills:                spec.Config.AllSkillsDisabled(),
 		SourceDir:               r.cfg.SpecDir(),
 		Resources:               r.fixtures,
 		MCPServers:              r.mcpConfig,

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -164,6 +164,13 @@
           },
           "description": "Additional directories to search for skill definitions."
         },
+        "disabled_skills": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Skills to disable. Use [\"*\"] to disable all skills, or list specific skill directory names to exclude."
+        },
         "required_skills": {
           "type": "array",
           "items": {

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -86,6 +86,7 @@ config:
 | `group_by`          | string    | —                 | Group results by a field (e.g., `tags`, `task_id`)          |
 | `fail_fast`         | bool      | false             | Stop the entire run on first task failure                   |
 | `skill_directories` | list[str] | `[]`              | Additional directories to search for skills                 |
+| `disabled_skills`   | list[str] | `[]`              | Skills to disable. Use `["*"]` to disable all skills        |
 | `required_skills`   | list[str] | `[]`              | Skills that must be available before running                |
 | `mcp_servers`       | object    | —                 | MCP server configurations for the evaluation                |
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -58,8 +58,10 @@ waza run [eval.yaml | skill-name]
 | `--session-dir` | | string | `.` | Directory for session log files |
 | `--no-summary` | | bool | false | Skip combined summary.json for multi-skill runs |
 | `--skip-graders` | | bool | false | Skip grading (execution only); grade later with `waza grade` |
+| `--no-skills` | | bool | false | Disable all skill loading for the evaluation |
 | `--transcript-dir` | | string | | Save per-task transcript JSON files |
 | `--no-cache` | | bool | false | Explicitly disable result caching |
+| `--keep-workspace` | | bool | false | Preserve temp workspaces after execution for debugging |
 
 ### Examples
 
@@ -116,6 +118,9 @@ waza run eval.yaml --session-log --session-dir ./logs
 
 # Multi-model comparison with recommendation
 waza run eval.yaml --model gpt-4o --model claude-sonnet-4.6 --recommend
+
+# Keep temp workspaces for debugging fixture issues
+waza run eval.yaml --keep-workspace -v
 ```
 
 ## waza init

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -232,6 +232,25 @@ config:
     - test-runner
 ```
 
+### disabled_skills
+
+**Type:** list[string]  
+**Default:** `[]`
+
+Skills to disable for the evaluation. Use `["*"]` to disable all skill loading entirely, or list specific skill directory names to exclude.
+
+```yaml
+# Disable all skills
+config:
+  disabled_skills: ["*"]
+
+# Disable specific skills
+config:
+  disabled_skills:
+    - noisy-skill
+    - experimental-skill
+```
+
 ### mcp_servers
 
 **Type:** object  


### PR DESCRIPTION
## Summary

Implements #126 — allows users to control which skills are loaded during evals, including a "none" option to disable all skills.

### Changes

**New config field: `disabled_skills`**
- `["*"]` disables all skill loading entirely
- Specific skill names (e.g., `["noisy-skill"]`) exclude individual skill directories
- Works by matching against both full path and basename of `skill_directories` entries

**New CLI flag: `--no-skills`**
- Equivalent to `disabled_skills: ["*"]` in YAML
- Overrides any `skill_directories` configured in the eval spec

**Implementation details:**
- `Config.AllSkillsDisabled()` — checks for wildcard disable or `skill_directories: ["none"]`
- `Config.FilteredSkillPaths()` — returns skill paths with disabled entries removed
- `ExecutionRequest.NoSkills` — signals CopilotEngine to skip `getSkillDirs()` and `buildSkillSystemMessage()`
- `validateRequiredSkills()` — early returns when all skills disabled
- Updated schema, CLI reference, eval-yaml guide, and schema reference docs

### Testing

14 new test cases across 3 test functions:
- `TestConfig_AllSkillsDisabled` (6 subtests)
- `TestConfig_FilteredSkillPaths` (6 subtests)
- `TestBenchmarkSpec_DisabledSkillsDeserialization` (2 subtests)

All existing tests pass. Docs site builds cleanly.

### Usage

```yaml
# Disable all skills
config:
  disabled_skills: ["*"]

# Disable specific skills
config:
  skill_directories: [./skills/a, ./skills/b, ./skills/c]
  disabled_skills: [b]  # only a and c are loaded
```

```bash
# CLI flag
waza run eval.yaml --no-skills
```

Working as Linus (Backend Developer)

Closes #126