### PR TITLE
feat: add --keep-workspace flag for debugging #123

### DIFF
--- a/cmd/waza/cmd_run.go
+++ b/cmd/waza/cmd_run.go
@@ -66,6 +66,7 @@ var (
 	updateSnapshots bool
 	skipGradersFlag bool
 	noSkillsFlag    bool
+	keepWorkspace   bool
 
 	// newCopilotClientFn allows you to override the client used by the copilot engine, for this command.
 	newCopilotClientFn func(clientOptions *copilot.ClientOptions) execution.CopilotClient
@@ -126,6 +127,7 @@ You can also specify a skill name to run its eval:
 	cmd.Flags().BoolVar(&updateSnapshots, "update-snapshots", false, "Update or create diff grader snapshot files to match current workspace output")
 	cmd.Flags().BoolVar(&skipGradersFlag, "skip-graders", false, "Skip grading (execution only); use with waza grade to grade later")
 	cmd.Flags().BoolVar(&noSkillsFlag, "no-skills", false, "Disable all skill loading for the evaluation")
+	cmd.Flags().BoolVar(&keepWorkspace, "keep-workspace", false, "Preserve temp workspace directories after execution for debugging")
 
 	return cmd
 }
@@ -642,6 +644,11 @@ func runSingleModel(cmd *cobra.Command, spec *models.BenchmarkSpec, specPath str
 	default:
 		return nil, fmt.Errorf("unknown engine type: %s", spec.Config.EngineType)
 	}
+	if keepWorkspace {
+		if wk, ok := engine.(execution.WorkspaceKeeper); ok {
+			wk.SetKeepWorkspace(true)
+		}
+	}
 	if err := engine.Initialize(context.Background()); err != nil {
 		return nil, fmt.Errorf("failed to initialize agent: %w", err)
 	}
@@ -975,6 +982,11 @@ func verboseProgressListener(event orchestration.ProgressEvent) {
 	case orchestration.EventRunComplete:
 		duration := time.Duration(event.DurationMs) * time.Millisecond
 		fmt.Printf(" %s (%v)\n", event.Status, duration)
+		if keepWorkspace {
+			if wsDir, ok := event.Details["workspace_dir"].(string); ok && wsDir != "" {
+				fmt.Printf("  Workspace: %s\n", wsDir)
+			}
+		}
 	case orchestration.EventTestComplete:
 		fmt.Printf("  Test %s: %s\n\n", event.TestName, event.Status)
 	case orchestration.EventBenchmarkComplete:

--- a/cmd/waza/cmd_run_shutdown_test.go
+++ b/cmd/waza/cmd_run_shutdown_test.go
@@ -237,7 +237,7 @@ func TestRunSingleModel_KeepWorkspaceFlag(t *testing.T) {
 
 	err := cmd.Execute()
 
-	w.Close()
+	_ = w.Close()
 	var buf [8192]byte
 	n, _ := r.Read(buf[:])
 	os.Stderr = oldStderr
@@ -275,7 +275,7 @@ func TestRunSingleModel_DefaultCleansWorkspace(t *testing.T) {
 
 	err := cmd.Execute()
 
-	w.Close()
+	_ = w.Close()
 	var buf [8192]byte
 	n, _ := r.Read(buf[:])
 	os.Stderr = oldStderr

--- a/cmd/waza/cmd_run_shutdown_test.go
+++ b/cmd/waza/cmd_run_shutdown_test.go
@@ -216,3 +216,71 @@ func TestRunSingleModel_ShutdownWithVerbose(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err, "verbose run should shutdown cleanly")
 }
+
+// ---------------------------------------------------------------------------
+// --keep-workspace flag integration tests (#123)
+// ---------------------------------------------------------------------------
+
+func TestRunSingleModel_KeepWorkspaceFlag(t *testing.T) {
+	resetRunGlobals()
+
+	specPath := createTestSpec(t, "mock")
+
+	// Capture stderr to check for "Workspace preserved:" message
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	cmd := newRunCommand()
+	cmd.SetArgs([]string{specPath, "--keep-workspace"})
+	cmd.SetOut(io.Discard)
+
+	err := cmd.Execute()
+
+	w.Close()
+	var buf [8192]byte
+	n, _ := r.Read(buf[:])
+	os.Stderr = oldStderr
+
+	assert.NoError(t, err, "run with --keep-workspace should succeed")
+	assert.Contains(t, string(buf[:n]), "Workspace preserved:",
+		"stderr should contain workspace path when --keep-workspace is set")
+}
+
+func TestRunSingleModel_KeepWorkspaceVerbose(t *testing.T) {
+	resetRunGlobals()
+
+	specPath := createTestSpec(t, "mock")
+
+	cmd := newRunCommand()
+	cmd.SetArgs([]string{specPath, "--keep-workspace", "--verbose"})
+
+	err := cmd.Execute()
+	assert.NoError(t, err, "verbose run with --keep-workspace should succeed")
+}
+
+func TestRunSingleModel_DefaultCleansWorkspace(t *testing.T) {
+	resetRunGlobals()
+
+	specPath := createTestSpec(t, "mock")
+
+	// Capture stderr — should NOT contain "Workspace preserved:"
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	cmd := newRunCommand()
+	cmd.SetArgs([]string{specPath})
+	cmd.SetOut(io.Discard)
+
+	err := cmd.Execute()
+
+	w.Close()
+	var buf [8192]byte
+	n, _ := r.Read(buf[:])
+	os.Stderr = oldStderr
+
+	assert.NoError(t, err, "default run should succeed")
+	assert.NotContains(t, string(buf[:n]), "Workspace preserved:",
+		"stderr should NOT mention workspace preservation by default")
+}

--- a/cmd/waza/cmd_run_test.go
+++ b/cmd/waza/cmd_run_test.go
@@ -53,6 +53,7 @@ func resetRunGlobals() {
 	reporters = nil
 	suggestFlag = false
 	updateSnapshots = false
+	keepWorkspace = false
 	newCopilotClientFn = nil
 }
 

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -26,9 +26,9 @@ type CopilotEngine struct {
 
 	startOnce sync.Once
 
-	workspacesMu   sync.Mutex
-	workspaces     []string // workspaces to clean up at Shutdown
-	keepWorkspace  bool     // when true, skip workspace cleanup on shutdown
+	workspacesMu  sync.Mutex
+	workspaces    []string // workspaces to clean up at Shutdown
+	keepWorkspace bool     // when true, skip workspace cleanup on shutdown
 
 	// sessions maps session IDs to copilotSessions
 	sessions   map[string]CopilotSession

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -26,8 +26,9 @@ type CopilotEngine struct {
 
 	startOnce sync.Once
 
-	workspacesMu sync.Mutex
-	workspaces   []string // workspaces to clean up at Shutdown
+	workspacesMu   sync.Mutex
+	workspaces     []string // workspaces to clean up at Shutdown
+	keepWorkspace  bool     // when true, skip workspace cleanup on shutdown
 
 	// sessions maps session IDs to copilotSessions
 	sessions   map[string]CopilotSession
@@ -83,6 +84,11 @@ func NewCopilotEngineBuilder(defaultModelID string, options *CopilotEngineBuilde
 
 func (b *CopilotEngineBuilder) Build() *CopilotEngine {
 	return b.engine
+}
+
+// SetKeepWorkspace enables or disables workspace preservation on shutdown.
+func (e *CopilotEngine) SetKeepWorkspace(keep bool) {
+	e.keepWorkspace = keep
 }
 
 // Initialize sets up the Copilot client
@@ -355,7 +361,9 @@ func (e *CopilotEngine) doShutdown(ctx context.Context) error {
 
 	for _, ws := range workspaces {
 		if ws != "" {
-			if err := os.RemoveAll(ws); err != nil {
+			if e.keepWorkspace {
+				fmt.Fprintf(os.Stderr, "Workspace preserved: %s\n", ws)
+			} else if err := os.RemoveAll(ws); err != nil {
 				// errors here probably indicate some issue with our code continuing to lock files
 				// even after tests have completed...
 				slog.Warn("failed to cleanup stale workspace", "path", ws, "error", err)

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -28,6 +28,12 @@ type AgentEngine interface {
 	SessionUsage(sessionID string) *models.UsageStats
 }
 
+// WorkspaceKeeper is an optional interface that engines can implement to support
+// preserving temp workspaces after execution (for debugging).
+type WorkspaceKeeper interface {
+	SetKeepWorkspace(keep bool)
+}
+
 // ExecutionRequest represents a test execution request
 type ExecutionRequest struct {
 	ModelID   string

--- a/internal/execution/engine_shutdown_test.go
+++ b/internal/execution/engine_shutdown_test.go
@@ -223,7 +223,7 @@ func TestMockEngine_KeepWorkspace_PreservesDir(t *testing.T) {
 	assert.DirExists(t, wsDir)
 
 	// Clean up manually since the engine didn't
-	os.RemoveAll(wsDir)
+	_ = os.RemoveAll(wsDir)
 }
 
 func TestMockEngine_DefaultBehavior_CleansUpDir(t *testing.T) {
@@ -278,7 +278,7 @@ func TestCopilotEngine_KeepWorkspace_PrintsPath(t *testing.T) {
 	err := engine.Shutdown(context.Background())
 	require.NoError(t, err)
 
-	w.Close()
+	_ = w.Close()
 	var buf [4096]byte
 	n, _ := r.Read(buf[:])
 	os.Stderr = oldStderr

--- a/internal/execution/engine_shutdown_test.go
+++ b/internal/execution/engine_shutdown_test.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"errors"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -199,6 +200,95 @@ func TestCopilotEngine_Shutdown_WithCancelledContext(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// KeepWorkspace — workspace preservation tests
+// ---------------------------------------------------------------------------
+
+func TestMockEngine_KeepWorkspace_PreservesDir(t *testing.T) {
+	engine := NewMockEngine("test-model")
+	engine.SetKeepWorkspace(true)
+
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message:   "hello",
+		Resources: []ResourceFile{{Path: "file.txt", Content: []byte("data")}},
+	})
+	require.NoError(t, err)
+	wsDir := resp.WorkspaceDir
+	require.DirExists(t, wsDir)
+
+	require.NoError(t, engine.Shutdown(context.Background()))
+
+	// Workspace must still exist after shutdown
+	assert.DirExists(t, wsDir)
+
+	// Clean up manually since the engine didn't
+	os.RemoveAll(wsDir)
+}
+
+func TestMockEngine_DefaultBehavior_CleansUpDir(t *testing.T) {
+	engine := NewMockEngine("test-model")
+	// keepWorkspace defaults to false
+
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{Message: "hello"})
+	require.NoError(t, err)
+	wsDir := resp.WorkspaceDir
+	require.DirExists(t, wsDir)
+
+	require.NoError(t, engine.Shutdown(context.Background()))
+
+	// Workspace must be removed after shutdown (default behavior)
+	_, statErr := os.Stat(wsDir)
+	assert.True(t, os.IsNotExist(statErr), "workspace should be removed by default")
+}
+
+func TestCopilotEngine_KeepWorkspace_PreservesDir(t *testing.T) {
+	engine := NewCopilotEngineBuilder("test-model", nil).Build()
+	engine.SetKeepWorkspace(true)
+
+	// Simulate a workspace existing (without running the full SDK)
+	tmpDir := t.TempDir()
+	engine.workspacesMu.Lock()
+	engine.workspaces = append(engine.workspaces, tmpDir)
+	engine.workspacesMu.Unlock()
+
+	err := engine.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	// Workspace must still exist after shutdown
+	assert.DirExists(t, tmpDir)
+}
+
+func TestCopilotEngine_KeepWorkspace_PrintsPath(t *testing.T) {
+	engine := NewCopilotEngineBuilder("test-model", nil).Build()
+	engine.SetKeepWorkspace(true)
+
+	tmpDir := t.TempDir()
+	engine.workspacesMu.Lock()
+	engine.workspaces = append(engine.workspaces, tmpDir)
+	engine.workspacesMu.Unlock()
+
+	// Capture stderr to verify "Workspace preserved:" message
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := engine.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	w.Close()
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	os.Stderr = oldStderr
+
+	output := string(buf[:n])
+	assert.Contains(t, output, "Workspace preserved:")
+	assert.Contains(t, output, tmpDir)
+}
+
+// ---------------------------------------------------------------------------
 // AgentEngine interface compliance — static check
 // ---------------------------------------------------------------------------
 
@@ -206,4 +296,10 @@ var (
 	_ AgentEngine = (*MockEngine)(nil)
 	_ AgentEngine = (*CopilotEngine)(nil)
 	_ AgentEngine = (*SpyEngine)(nil)
+)
+
+// WorkspaceKeeper interface compliance — static check
+var (
+	_ WorkspaceKeeper = (*MockEngine)(nil)
+	_ WorkspaceKeeper = (*CopilotEngine)(nil)
 )

--- a/internal/execution/mock.go
+++ b/internal/execution/mock.go
@@ -14,10 +14,11 @@ import (
 
 // MockEngine is a simple mock implementation for testing
 type MockEngine struct {
-	modelID    string
-	workspace  string
-	mtx        *sync.Mutex
-	initCalled atomic.Bool
+	modelID       string
+	workspace     string
+	keepWorkspace bool
+	mtx           *sync.Mutex
+	initCalled    atomic.Bool
 }
 
 // NewMockEngine creates a new mock engine
@@ -26,6 +27,11 @@ func NewMockEngine(modelID string) *MockEngine {
 		modelID: modelID,
 		mtx:     &sync.Mutex{},
 	}
+}
+
+// SetKeepWorkspace enables or disables workspace preservation on shutdown.
+func (m *MockEngine) SetKeepWorkspace(keep bool) {
+	m.keepWorkspace = keep
 }
 
 func (m *MockEngine) Initialize(ctx context.Context) error {
@@ -100,7 +106,9 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 
 func (m *MockEngine) Shutdown(ctx context.Context) error {
 	if m.workspace != "" {
-		if err := os.RemoveAll(m.workspace); err != nil {
+		if m.keepWorkspace {
+			fmt.Fprintf(os.Stderr, "Workspace preserved: %s\n", m.workspace)
+		} else if err := os.RemoveAll(m.workspace); err != nil {
 			return fmt.Errorf("failed to remove mock workspace %s: %w", m.workspace, err)
 		}
 		m.workspace = ""

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -156,6 +156,7 @@ type RunResult struct {
 	FinalOutput      string                   `json:"final_output"`
 	ErrorMsg         string                   `json:"error_msg,omitempty"`
 	SkillInvocations []SkillInvocation        `json:"skill_invocations,omitempty"`
+	WorkspaceDir     string                   `json:"workspace_dir,omitempty"`
 }
 
 type GraderResults struct {

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -434,7 +434,9 @@ tasks:
   - "*.yaml"
 `
 		p := filepath.Join(tempDir, "eval.yaml")
-		os.WriteFile(p, []byte(yamlStr), 0644)
+		if err := os.WriteFile(p, []byte(yamlStr), 0644); err != nil {
+			t.Fatal(err)
+		}
 		spec, err := LoadBenchmarkSpec(p)
 		if err != nil {
 			t.Fatal(err)
@@ -464,7 +466,9 @@ tasks:
   - "*.yaml"
 `
 		p := filepath.Join(tempDir, "eval.yaml")
-		os.WriteFile(p, []byte(yamlStr), 0644)
+		if err := os.WriteFile(p, []byte(yamlStr), 0644); err != nil {
+			t.Fatal(err)
+		}
 		spec, err := LoadBenchmarkSpec(p)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -964,6 +964,7 @@ func (r *TestRunner) runTestUncached(ctx context.Context, tc *models.TestCase, t
 			TotalRuns:  runsPerTest,
 			Status:     run.Status,
 			DurationMs: run.DurationMs,
+			Details:    map[string]any{"workspace_dir": run.WorkspaceDir},
 		})
 	}
 
@@ -1126,6 +1127,7 @@ func (r *TestRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		FinalOutput:      resp.FinalOutput,
 		ErrorMsg:         resp.ErrorMsg,
 		SkillInvocations: skillInvocations,
+		WorkspaceDir:     resp.WorkspaceDir,
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a `--keep-workspace` flag to `waza run` that preserves temp workspaces after execution, allowing users to inspect fixture files and agent modifications for debugging.

Closes #123

Working as Linus (Backend Developer)

## Changes

### Core
- **`WorkspaceKeeper` interface** (`internal/execution/engine.go`): Optional interface with `SetKeepWorkspace(bool)` — avoids breaking the `AgentEngine` interface contract
- **CopilotEngine** (`internal/execution/copilot.go`): Skips `os.RemoveAll` when `keepWorkspace` is true; prints `Workspace preserved: <path>` to stderr
- **MockEngine** (`internal/execution/mock.go`): Same pattern for test engine

### Model & Orchestration
- **`RunResult.WorkspaceDir`** (`internal/models/outcome.go`): New field (`omitempty` for JSON compat)
- **Runner** (`internal/orchestration/runner.go`): Propagates `WorkspaceDir` from execution response; adds `workspace_dir` to `RunComplete` progress event

### CLI
- **`--keep-workspace` flag** (`cmd/waza/cmd_run.go`): Registered as bool flag, wired to engine via type assertion
- **Verbose output**: Shows workspace path per-run when flag is active
- **Test globals** (`cmd/waza/cmd_run_test.go`): Reset `keepWorkspace = false`

### Tests (4 new)
- `TestMockEngine_KeepWorkspace_PreservesDir` — workspace survives shutdown
- `TestMockEngine_DefaultBehavior_CleansUpDir` — regression: default still cleans up
- `TestCopilotEngine_KeepWorkspace_PreservesDir` — copilot engine workspace survives
- `TestCopilotEngine_KeepWorkspace_PrintsPath` — stderr message verification
- Interface compliance checks for `WorkspaceKeeper`

### Docs
- `README.md`: Added flag to run command flags table
- `site/src/content/docs/reference/cli.mdx`: Added flag to table + example

## Usage

```bash
# Run eval and keep workspaces for inspection
waza run eval.yaml --keep-workspace -v

# Workspaces printed to stderr on shutdown:
# Workspace preserved: /var/folders/.../waza-abc123
```

## Testing

- All 4 new tests pass
- Full `go test ./internal/...` passes
- `go vet` clean
- Site builds successfully
