### PR TITLE
feat: add `waza quality` command — LLM-as-Judge skill quality scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,29 @@ waza dev skills/my-skill       # Improve compliance if needed
 waza check skills/my-skill     # Verify improvements
 ```
 
+### `waza quality <skill-path>`
+
+Use an LLM-as-Judge to evaluate skill content quality across five dimensions:
+clarity, completeness, trigger precision, scope coverage, and anti-patterns.
+
+| Flag | Description |
+|------|-------------|
+| `--model <model>` | Model to use as judge (default: project default model) |
+| `--format table\|json` | Output format (default: `table`) |
+| `--rubric <path>` | Path to custom rubric file (reserved for future use) |
+
+**Examples:**
+```bash
+# Evaluate skill quality (table output)
+waza quality skills/code-explainer
+
+# JSON output for CI integration
+waza quality skills/code-explainer --format json
+
+# Use a specific model as judge
+waza quality skills/code-explainer --model gpt-4o
+```
+
 ### `waza suggest <skill-path>`
 
 Use an LLM to analyze `SKILL.md` and generate suggested evaluation artifacts.

--- a/cmd/waza/cmd_quality.go
+++ b/cmd/waza/cmd_quality.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/microsoft/waza/internal/execution"
+	"github.com/microsoft/waza/internal/quality"
+	"github.com/microsoft/waza/internal/scaffold"
+	"github.com/spf13/cobra"
+)
+
+var newQualityEngine = func(modelID string) execution.AgentEngine {
+	return execution.NewCopilotEngineBuilder(modelID, nil).Build()
+}
+
+type qualityFlags struct {
+	model  string
+	format string
+	rubric string
+}
+
+func newQualityCommand() *cobra.Command {
+	_, defaultModel := scaffold.ReadProjectDefaults()
+	flags := &qualityFlags{
+		model:  defaultModel,
+		format: "table",
+	}
+
+	cmd := &cobra.Command{
+		Use:   "quality <skill-path>",
+		Short: "Evaluate skill content quality with an LLM judge",
+		Long: `Analyze a SKILL.md using an LLM-as-Judge to score quality across dimensions:
+clarity, completeness, trigger precision, scope coverage, and anti-patterns.
+
+Each dimension is scored 1-5 with specific feedback. Requires Copilot authentication.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runQualityCommand(cmd, args[0], flags)
+		},
+		SilenceErrors: true,
+	}
+
+	cmd.Flags().StringVar(&flags.model, "model", flags.model, "Model to use as judge")
+	cmd.Flags().StringVar(&flags.format, "format", "table", "Output format: table|json")
+	cmd.Flags().StringVar(&flags.rubric, "rubric", "", "Path to custom rubric file (reserved for future use)")
+
+	return cmd
+}
+
+func runQualityCommand(cmd *cobra.Command, skillPath string, flags *qualityFlags) error {
+	if flags.format != "table" && flags.format != "json" {
+		return fmt.Errorf("invalid format %q: must be table or json", flags.format)
+	}
+
+	if flags.rubric != "" {
+		return fmt.Errorf("custom rubric files are not yet supported (coming soon)")
+	}
+
+	engine := newQualityEngine(flags.model)
+
+	if err := engine.Initialize(cmd.Context()); err != nil {
+		if isAuthError(err) {
+			return fmt.Errorf("not authenticated — run \"copilot login\" first")
+		}
+		return fmt.Errorf("failed to connect to Copilot: %w", err)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	defer func() {
+		_ = engine.Shutdown(shutdownCtx)
+	}()
+
+	resp, err := quality.Judge(cmd.Context(), engine, quality.JudgeOptions{
+		SkillPath: skillPath,
+	})
+	if err != nil {
+		// If we got a partial response with validation issues, still display it
+		if resp != nil && strings.Contains(err.Error(), "judge response validation") {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n\n", err) //nolint:errcheck
+			return outputQualityReport(cmd, resp, flags.format)
+		}
+		return err
+	}
+
+	return outputQualityReport(cmd, resp, flags.format)
+}
+
+func outputQualityReport(cmd *cobra.Command, resp *quality.JudgeResponse, format string) error {
+	w := cmd.OutOrStdout()
+
+	switch format {
+	case "json":
+		output, err := quality.FormatJSON(resp)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, output) //nolint:errcheck
+	default:
+		fmt.Fprint(w, quality.FormatTable(resp)) //nolint:errcheck
+	}
+
+	return nil
+}

--- a/cmd/waza/cmd_quality_test.go
+++ b/cmd/waza/cmd_quality_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/waza/internal/execution"
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+type qualityTestEngine struct {
+	output     string
+	err        error
+	initCalled bool
+	initErr    error
+}
+
+func (e *qualityTestEngine) Initialize(context.Context) error {
+	e.initCalled = true
+	return e.initErr
+}
+
+func (e *qualityTestEngine) Execute(_ context.Context, _ *execution.ExecutionRequest) (*execution.ExecutionResponse, error) {
+	if !e.initCalled {
+		return nil, fmt.Errorf("initialize was not called before Execute!")
+	}
+	if e.err != nil {
+		return nil, e.err
+	}
+	return &execution.ExecutionResponse{FinalOutput: e.output, Success: true}, nil
+}
+
+func (e *qualityTestEngine) Shutdown(context.Context) error          { return nil }
+func (e *qualityTestEngine) SessionUsage(string) *models.UsageStats { return nil }
+
+func writeQualitySkill(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	content := `---
+name: quality-test-skill
+description: "A test skill. USE FOR: testing, debugging. DO NOT USE FOR: production deploys."
+---
+
+# Quality Test Skill
+
+## Overview
+This skill helps with testing and debugging workflows.
+
+## Steps
+1. Analyze the test input
+2. Generate appropriate test output
+3. Report results
+
+## Error Handling
+If input is invalid, return an error message.
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644))
+	return dir
+}
+
+const qualityValidJSON = `{
+  "dimensions": [
+    {"name": "clarity", "score": 4, "feedback": "Instructions are clear and well-structured."},
+    {"name": "completeness", "score": 3, "feedback": "Missing some edge case documentation."},
+    {"name": "trigger_precision", "score": 5, "feedback": "USE FOR and DO NOT USE FOR are precise and non-overlapping."},
+    {"name": "scope_coverage", "score": 4, "feedback": "Scope is well-defined with clear boundaries."},
+    {"name": "anti_patterns", "score": 3, "feedback": "Some steps could be more specific to avoid ambiguity."}
+  ],
+  "overall_score": 3.8,
+  "summary": "A solid skill with good clarity and triggers. Completeness and anti-pattern avoidance could be improved."
+}`
+
+func TestQualityCommand_TableOutput(t *testing.T) {
+	skillDir := writeQualitySkill(t)
+
+	orig := newQualityEngine
+	newQualityEngine = func(string) execution.AgentEngine {
+		return &qualityTestEngine{output: qualityValidJSON}
+	}
+	t.Cleanup(func() { newQualityEngine = orig })
+
+	cmd := newQualityCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{skillDir})
+
+	require.NoError(t, cmd.Execute())
+	output := out.String()
+	require.Contains(t, output, "clarity")
+	require.Contains(t, output, "completeness")
+	require.Contains(t, output, "trigger_precision")
+	require.Contains(t, output, "scope_coverage")
+	require.Contains(t, output, "anti_patterns")
+	require.Contains(t, output, "Overall: 3.8/5.0")
+}
+
+func TestQualityCommand_JSONOutput(t *testing.T) {
+	skillDir := writeQualitySkill(t)
+
+	orig := newQualityEngine
+	newQualityEngine = func(string) execution.AgentEngine {
+		return &qualityTestEngine{output: qualityValidJSON}
+	}
+	t.Cleanup(func() { newQualityEngine = orig })
+
+	cmd := newQualityCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{skillDir, "--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+	output := out.String()
+	require.Contains(t, output, `"overall_score"`)
+	require.Contains(t, output, `"dimensions"`)
+	require.Contains(t, output, `"clarity"`)
+}
+
+func TestQualityCommand_InvalidFormat(t *testing.T) {
+	skillDir := writeQualitySkill(t)
+
+	orig := newQualityEngine
+	newQualityEngine = func(string) execution.AgentEngine {
+		return &qualityTestEngine{output: qualityValidJSON}
+	}
+	t.Cleanup(func() { newQualityEngine = orig })
+
+	cmd := newQualityCommand()
+	cmd.SetArgs([]string{skillDir, "--format", "xml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid format")
+}
+
+func TestQualityCommand_AuthError(t *testing.T) {
+	skillDir := writeQualitySkill(t)
+
+	orig := newQualityEngine
+	newQualityEngine = func(string) execution.AgentEngine {
+		return &qualityTestEngine{
+			initErr: fmt.Errorf("failed to get copilot authentication status"),
+		}
+	}
+	t.Cleanup(func() { newQualityEngine = orig })
+
+	cmd := newQualityCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{skillDir})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "copilot login")
+}
+
+func TestQualityCommand_EngineError(t *testing.T) {
+	skillDir := writeQualitySkill(t)
+
+	orig := newQualityEngine
+	newQualityEngine = func(string) execution.AgentEngine {
+		return &qualityTestEngine{err: fmt.Errorf("LLM unavailable")}
+	}
+	t.Cleanup(func() { newQualityEngine = orig })
+
+	cmd := newQualityCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{skillDir})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "judge execution")
+}
+
+func TestQualityCommand_MissingSkill(t *testing.T) {
+	orig := newQualityEngine
+	newQualityEngine = func(string) execution.AgentEngine {
+		return &qualityTestEngine{output: qualityValidJSON}
+	}
+	t.Cleanup(func() { newQualityEngine = orig })
+
+	cmd := newQualityCommand()
+	cmd.SetArgs([]string{"/nonexistent/skill/path"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "skill path does not exist")
+}
+
+func TestQualityCommand_CustomRubricNotYetSupported(t *testing.T) {
+	skillDir := writeQualitySkill(t)
+
+	orig := newQualityEngine
+	newQualityEngine = func(string) execution.AgentEngine {
+		return &qualityTestEngine{output: qualityValidJSON}
+	}
+	t.Cleanup(func() { newQualityEngine = orig })
+
+	cmd := newQualityCommand()
+	cmd.SetArgs([]string{skillDir, "--rubric", "custom.yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not yet supported")
+}
+
+func TestQualityCommand_NoArgs(t *testing.T) {
+	orig := newQualityEngine
+	newQualityEngine = func(string) execution.AgentEngine {
+		return &qualityTestEngine{output: qualityValidJSON}
+	}
+	t.Cleanup(func() { newQualityEngine = orig })
+
+	cmd := newQualityCommand()
+	err := cmd.Execute()
+	require.Error(t, err) // cobra requires exactly 1 arg
+}

--- a/cmd/waza/cmd_quality_test.go
+++ b/cmd/waza/cmd_quality_test.go
@@ -35,7 +35,7 @@ func (e *qualityTestEngine) Execute(_ context.Context, _ *execution.ExecutionReq
 	return &execution.ExecutionResponse{FinalOutput: e.output, Success: true}, nil
 }
 
-func (e *qualityTestEngine) Shutdown(context.Context) error          { return nil }
+func (e *qualityTestEngine) Shutdown(context.Context) error         { return nil }
 func (e *qualityTestEngine) SessionUsage(string) *models.UsageStats { return nil }
 
 func writeQualitySkill(t *testing.T) string {

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -66,6 +66,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newServeCommand())
 	cmd.AddCommand(newResultsCommand())
 	cmd.AddCommand(newModelsCommand())
+	cmd.AddCommand(newQualityCommand())
 
 	return cmd
 }

--- a/internal/checks/scope_reduction.go
+++ b/internal/checks/scope_reduction.go
@@ -1,0 +1,158 @@
+package checks
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/waza/internal/skill"
+)
+
+// DefaultMinCapabilities is the minimum number of distinct capabilities
+// before a scope-reduction warning is emitted.
+const DefaultMinCapabilities = 2
+
+// ScopeReductionChecker detects when a SKILL.md has suspiciously few
+// capability signals, which may indicate that token-limit compression
+// silently removed supported workflows.
+type ScopeReductionChecker struct {
+	// MinCapabilities overrides DefaultMinCapabilities when > 0.
+	MinCapabilities int
+}
+
+var _ ComplianceChecker = (*ScopeReductionChecker)(nil)
+
+func (c *ScopeReductionChecker) Name() string { return "scope-reduction" }
+
+// ScopeReductionData holds the structured output.
+type ScopeReductionData struct {
+	Status           CheckStatus
+	UseForCount      int
+	HeadingCount     int
+	StepSequences    int
+	TotalCapabilities int
+	Threshold        int
+	Details          []string
+}
+
+// GetStatus implements StatusHolder.
+func (d *ScopeReductionData) GetStatus() CheckStatus { return d.Status }
+
+// useForPattern matches lines containing "USE FOR:" (case-insensitive).
+// Captures everything after the colon.
+var useForPattern = regexp.MustCompile(`(?im)(?:^|\n)\s*USE\s+FOR\s*:\s*(.+)`)
+
+// doNotUseForPattern matches "DO NOT USE FOR:" or "NOT USE FOR:" lines to exclude.
+var doNotUseForPattern = regexp.MustCompile(`(?i)(?:DO\s+)?NOT\s+USE\s+FOR\s*:`)
+
+
+// headingL2Pattern matches level-2 headings (## Title).
+var headingL2Pattern = regexp.MustCompile(`(?m)^##\s+\S`)
+
+// stepSequencePattern detects the start of a numbered procedure (line
+// beginning with "1."). Multiple independent sequences (separated by non-list
+// content) count as distinct capabilities.
+var stepSequencePattern = regexp.MustCompile(`(?m)^1\.\s+\S`)
+
+func (c *ScopeReductionChecker) Check(sk skill.Skill) (*CheckResult, error) {
+	threshold := c.MinCapabilities
+	if threshold <= 0 {
+		threshold = DefaultMinCapabilities
+	}
+
+	body := skillBodyContent(sk)
+	content := sk.RawContent
+
+	// 1. Count USE FOR items (from description or body)
+	useForCount := countUseForItems(content)
+
+	// 2. Count level-2 headings in the body
+	headingCount := len(headingL2Pattern.FindAllString(body, -1))
+
+	// 3. Count distinct numbered-step sequences
+	stepSequences := len(stepSequencePattern.FindAllString(body, -1))
+
+	// Total distinct capability signals — use the maximum of the three
+	// indicators since they represent different facets of capability scope.
+	total := maxInt(useForCount, headingCount, stepSequences)
+
+	var details []string
+	if useForCount > 0 {
+		details = append(details, fmt.Sprintf("%d USE FOR item(s)", useForCount))
+	}
+	if headingCount > 0 {
+		details = append(details, fmt.Sprintf("%d level-2 heading(s)", headingCount))
+	}
+	if stepSequences > 0 {
+		details = append(details, fmt.Sprintf("%d numbered procedure(s)", stepSequences))
+	}
+
+	data := &ScopeReductionData{
+		UseForCount:       useForCount,
+		HeadingCount:      headingCount,
+		StepSequences:     stepSequences,
+		TotalCapabilities: total,
+		Threshold:         threshold,
+		Details:           details,
+	}
+
+	if total < threshold {
+		data.Status = StatusWarning
+		summary := fmt.Sprintf(
+			"Low capability scope: %d signal(s) detected (minimum %d recommended) — possible token-limit compression loss",
+			total, threshold,
+		)
+		return &CheckResult{
+			Name:    "scope-reduction",
+			Passed:  false,
+			Summary: summary,
+			Data:    data,
+		}, nil
+	}
+
+	data.Status = StatusOK
+	summary := fmt.Sprintf(
+		"Capability scope: %d signal(s) detected (%s)",
+		total, strings.Join(details, ", "),
+	)
+	return &CheckResult{
+		Name:    "scope-reduction",
+		Passed:  true,
+		Summary: summary,
+		Data:    data,
+	}, nil
+}
+
+// countUseForItems parses "USE FOR:" lines and counts the comma-separated
+// items within each match. Lines containing "DO NOT USE FOR" are excluded.
+func countUseForItems(content string) int {
+	matches := useForPattern.FindAllStringSubmatch(content, -1)
+	count := 0
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		// Skip lines that are actually "DO NOT USE FOR:"
+		fullMatch := m[0]
+		if doNotUseForPattern.MatchString(fullMatch) {
+			continue
+		}
+		items := strings.Split(m[1], ",")
+		for _, item := range items {
+			if strings.TrimSpace(item) != "" {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func maxInt(a, b, c int) int {
+	if b > a {
+		a = b
+	}
+	if c > a {
+		a = c
+	}
+	return a
+}

--- a/internal/checks/scope_reduction.go
+++ b/internal/checks/scope_reduction.go
@@ -26,13 +26,13 @@ func (c *ScopeReductionChecker) Name() string { return "scope-reduction" }
 
 // ScopeReductionData holds the structured output.
 type ScopeReductionData struct {
-	Status           CheckStatus
-	UseForCount      int
-	HeadingCount     int
-	StepSequences    int
+	Status            CheckStatus
+	UseForCount       int
+	HeadingCount      int
+	StepSequences     int
 	TotalCapabilities int
-	Threshold        int
-	Details          []string
+	Threshold         int
+	Details           []string
 }
 
 // GetStatus implements StatusHolder.
@@ -44,7 +44,6 @@ var useForPattern = regexp.MustCompile(`(?im)(?:^|\n)\s*USE\s+FOR\s*:\s*(.+)`)
 
 // doNotUseForPattern matches "DO NOT USE FOR:" or "NOT USE FOR:" lines to exclude.
 var doNotUseForPattern = regexp.MustCompile(`(?i)(?:DO\s+)?NOT\s+USE\s+FOR\s*:`)
-
 
 // headingL2Pattern matches level-2 headings (## Title).
 var headingL2Pattern = regexp.MustCompile(`(?m)^##\s+\S`)

--- a/internal/checks/scope_reduction_test.go
+++ b/internal/checks/scope_reduction_test.go
@@ -46,7 +46,8 @@ description: |
 	assert.True(t, result.Passed)
 	assert.Equal(t, "scope-reduction", result.Name)
 
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, StatusOK, data.Status)
 	assert.Equal(t, 4, data.UseForCount)
 	assert.Equal(t, 3, data.HeadingCount)
@@ -71,7 +72,8 @@ Some instructions here without headings or steps.
 	assert.Contains(t, result.Summary, "Low capability scope")
 	assert.Contains(t, result.Summary, "token-limit compression loss")
 
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, StatusWarning, data.Status)
 	assert.Equal(t, 0, data.TotalCapabilities)
 }
@@ -93,7 +95,8 @@ Do something here.
 
 	assert.False(t, result.Passed, "1 heading < default threshold of 2")
 
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, StatusWarning, data.Status)
 	assert.Equal(t, 1, data.HeadingCount)
 	assert.Equal(t, 1, data.TotalCapabilities)
@@ -114,7 +117,8 @@ This skill does many things but has no headings or steps.
 	require.NoError(t, err)
 
 	assert.True(t, result.Passed)
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, 3, data.UseForCount)
 	assert.Equal(t, 3, data.TotalCapabilities)
 }
@@ -141,7 +145,8 @@ Second procedure:
 	require.NoError(t, err)
 
 	assert.True(t, result.Passed)
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, 2, data.StepSequences)
 	assert.Equal(t, 2, data.TotalCapabilities)
 }
@@ -168,7 +173,8 @@ More steps.
 	require.NoError(t, err)
 
 	assert.False(t, result.Passed)
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, 2, data.TotalCapabilities)
 	assert.Equal(t, 3, data.Threshold)
 }
@@ -185,7 +191,8 @@ description: Just a description.
 	require.NoError(t, err)
 
 	assert.False(t, result.Passed)
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, StatusWarning, data.Status)
 	assert.Equal(t, 0, data.TotalCapabilities)
 }
@@ -208,7 +215,8 @@ Some content.
 	require.NoError(t, err)
 
 	assert.True(t, result.Passed)
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, 2, data.HeadingCount)
 }
 
@@ -227,7 +235,8 @@ DO NOT USE FOR: "task D"
 	require.NoError(t, err)
 
 	assert.True(t, result.Passed)
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, 3, data.UseForCount, "USE FOR items counted, DO NOT USE FOR excluded")
 }
 
@@ -257,7 +266,8 @@ Content.
 	require.NoError(t, err)
 
 	assert.True(t, result.Passed)
-	data := result.Data.(*ScopeReductionData)
+	data, ok := result.Data.(*ScopeReductionData)
+	require.True(t, ok)
 	assert.Equal(t, 1, data.UseForCount)
 	assert.Equal(t, 3, data.HeadingCount)
 	assert.Equal(t, 3, data.TotalCapabilities, "max of signals wins")
@@ -265,9 +275,9 @@ Content.
 
 func TestCountUseForItems(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    int
+		name  string
+		input string
+		want  int
 	}{
 		{
 			name:  "single line",

--- a/internal/checks/scope_reduction_test.go
+++ b/internal/checks/scope_reduction_test.go
@@ -1,0 +1,313 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/microsoft/waza/internal/skill"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeSkillWithContent(raw string) skill.Skill {
+	sk := skill.Skill{RawContent: raw}
+	// Parse body from raw content (mirrors skillBodyContent logic).
+	sk.Body = skillBodyContent(sk)
+	return sk
+}
+
+func TestScopeReductionChecker_FullScope(t *testing.T) {
+	content := `---
+name: multi-workflow
+description: |
+  USE FOR: "deploy apps", "run tests", "lint code", "build containers"
+---
+
+## Deployment Workflow
+
+1. Build the container
+2. Push to registry
+3. Deploy to cluster
+
+## Testing Workflow
+
+1. Run unit tests
+2. Run integration tests
+
+## Linting Workflow
+
+1. Run eslint
+2. Run prettier
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.True(t, result.Passed)
+	assert.Equal(t, "scope-reduction", result.Name)
+
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, StatusOK, data.Status)
+	assert.Equal(t, 4, data.UseForCount)
+	assert.Equal(t, 3, data.HeadingCount)
+	assert.Equal(t, 3, data.StepSequences)
+	assert.GreaterOrEqual(t, data.TotalCapabilities, 2)
+}
+
+func TestScopeReductionChecker_ReducedScope(t *testing.T) {
+	content := `---
+name: compressed-skill
+description: A minimal skill.
+---
+
+Some instructions here without headings or steps.
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.False(t, result.Passed)
+	assert.Contains(t, result.Summary, "Low capability scope")
+	assert.Contains(t, result.Summary, "token-limit compression loss")
+
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, StatusWarning, data.Status)
+	assert.Equal(t, 0, data.TotalCapabilities)
+}
+
+func TestScopeReductionChecker_SingleHeading(t *testing.T) {
+	content := `---
+name: single-heading
+description: One workflow skill.
+---
+
+## Only Workflow
+
+Do something here.
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.False(t, result.Passed, "1 heading < default threshold of 2")
+
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, StatusWarning, data.Status)
+	assert.Equal(t, 1, data.HeadingCount)
+	assert.Equal(t, 1, data.TotalCapabilities)
+}
+
+func TestScopeReductionChecker_UseForOnly(t *testing.T) {
+	content := `---
+name: trigger-rich
+description: |
+  USE FOR: "analyze code", "review PRs", "generate docs"
+---
+
+This skill does many things but has no headings or steps.
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.True(t, result.Passed)
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, 3, data.UseForCount)
+	assert.Equal(t, 3, data.TotalCapabilities)
+}
+
+func TestScopeReductionChecker_StepsOnly(t *testing.T) {
+	content := `---
+name: steps-skill
+description: Multi-procedure skill.
+---
+
+First procedure:
+
+1. Do X
+2. Do Y
+
+Second procedure:
+
+1. Do A
+2. Do B
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.True(t, result.Passed)
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, 2, data.StepSequences)
+	assert.Equal(t, 2, data.TotalCapabilities)
+}
+
+func TestScopeReductionChecker_CustomThreshold(t *testing.T) {
+	content := `---
+name: two-heading
+description: Skill with two headings.
+---
+
+## Workflow A
+
+Steps here.
+
+## Workflow B
+
+More steps.
+`
+	sk := makeSkillWithContent(content)
+
+	// With threshold of 3, two headings is not enough.
+	checker := &ScopeReductionChecker{MinCapabilities: 3}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.False(t, result.Passed)
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, 2, data.TotalCapabilities)
+	assert.Equal(t, 3, data.Threshold)
+}
+
+func TestScopeReductionChecker_EmptyBody(t *testing.T) {
+	content := `---
+name: empty-body
+description: Just a description.
+---
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.False(t, result.Passed)
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, StatusWarning, data.Status)
+	assert.Equal(t, 0, data.TotalCapabilities)
+}
+
+func TestScopeReductionChecker_NoFrontmatter(t *testing.T) {
+	content := `# Plain Markdown
+
+## Section A
+
+1. Step one
+2. Step two
+
+## Section B
+
+Some content.
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.True(t, result.Passed)
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, 2, data.HeadingCount)
+}
+
+func TestScopeReductionChecker_UseForInBody(t *testing.T) {
+	content := `---
+name: body-use-for
+description: A skill.
+---
+
+USE FOR: "task A", "task B", "task C"
+DO NOT USE FOR: "task D"
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.True(t, result.Passed)
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, 3, data.UseForCount, "USE FOR items counted, DO NOT USE FOR excluded")
+}
+
+func TestScopeReductionChecker_MaxSignalWins(t *testing.T) {
+	// 1 USE FOR item, 3 headings, 0 steps → total should be 3
+	content := `---
+name: mixed
+description: |
+  USE FOR: "one thing"
+---
+
+## A
+
+Content.
+
+## B
+
+Content.
+
+## C
+
+Content.
+`
+	sk := makeSkillWithContent(content)
+	checker := &ScopeReductionChecker{}
+	result, err := checker.Check(sk)
+	require.NoError(t, err)
+
+	assert.True(t, result.Passed)
+	data := result.Data.(*ScopeReductionData)
+	assert.Equal(t, 1, data.UseForCount)
+	assert.Equal(t, 3, data.HeadingCount)
+	assert.Equal(t, 3, data.TotalCapabilities, "max of signals wins")
+}
+
+func TestCountUseForItems(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+	}{
+		{
+			name:  "single line",
+			input: `USE FOR: "a", "b", "c"`,
+			want:  3,
+		},
+		{
+			name:  "case insensitive",
+			input: `use for: alpha, beta`,
+			want:  2,
+		},
+		{
+			name:  "multiple lines",
+			input: "USE FOR: a, b\nUSE FOR: c",
+			want:  3,
+		},
+		{
+			name:  "no match",
+			input: "DO NOT USE FOR: x, y",
+			want:  0,
+		},
+		{
+			name:  "empty after colon",
+			input: "USE FOR:  ",
+			want:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countUseForItems(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMaxInt(t *testing.T) {
+	assert.Equal(t, 3, maxInt(1, 2, 3))
+	assert.Equal(t, 3, maxInt(3, 2, 1))
+	assert.Equal(t, 3, maxInt(1, 3, 2))
+	assert.Equal(t, 0, maxInt(0, 0, 0))
+	assert.Equal(t, 5, maxInt(5, 5, 5))
+}

--- a/internal/quality/judge.go
+++ b/internal/quality/judge.go
@@ -1,0 +1,191 @@
+package quality
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/microsoft/waza/internal/execution"
+	"github.com/microsoft/waza/internal/skill"
+)
+
+const defaultJudgeTimeout = 120
+
+// JudgeOptions configures the quality judge.
+type JudgeOptions struct {
+	SkillPath  string
+	TimeoutSec int
+	Rubric     []Dimension // nil means use DefaultRubric()
+}
+
+// Judge runs an LLM-based quality assessment against a SKILL.md file.
+func Judge(ctx context.Context, engine execution.AgentEngine, opts JudgeOptions) (*JudgeResponse, error) {
+	skillFile, err := resolveSkillFile(opts.SkillPath)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := os.ReadFile(skillFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading SKILL.md: %w", err)
+	}
+
+	var sk skill.Skill
+	if err := sk.UnmarshalText(content); err != nil {
+		return nil, fmt.Errorf("parsing SKILL.md: %w", err)
+	}
+
+	rubric := opts.Rubric
+	if rubric == nil {
+		rubric = DefaultRubric()
+	}
+
+	timeoutSec := opts.TimeoutSec
+	if timeoutSec <= 0 {
+		timeoutSec = defaultJudgeTimeout
+	}
+
+	prompt := BuildJudgePrompt(string(content), rubric)
+
+	resp, err := engine.Execute(ctx, &execution.ExecutionRequest{
+		Message: prompt,
+		Timeout: time.Duration(timeoutSec) * time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("judge execution: %w", err)
+	}
+	if resp == nil {
+		return nil, errors.New("empty engine response from judge")
+	}
+
+	judgeResp, err := ParseJudgeResponse(resp.FinalOutput)
+	if err != nil {
+		return nil, fmt.Errorf("parsing judge response: %w", err)
+	}
+
+	issues := ValidateJudgeResponse(judgeResp, rubric)
+	if len(issues) > 0 {
+		return judgeResp, fmt.Errorf("judge response validation: %s", strings.Join(issues, "; "))
+	}
+
+	return judgeResp, nil
+}
+
+// BuildJudgePrompt constructs the system prompt for the LLM judge.
+func BuildJudgePrompt(skillContent string, rubric []Dimension) string {
+	var b strings.Builder
+	b.WriteString("You are a skill quality judge. Evaluate the following SKILL.md content against each quality dimension.\n\n")
+	b.WriteString("Score each dimension from 1 (poor) to 5 (excellent). Provide specific, actionable feedback for each.\n\n")
+	b.WriteString("Quality dimensions:\n")
+	for _, d := range rubric {
+		fmt.Fprintf(&b, "- **%s**: %s\n", d.Name, d.Description)
+	}
+	b.WriteString("\nRespond with ONLY a JSON object in this exact format (no markdown fences, no extra text):\n")
+	b.WriteString(`{
+  "dimensions": [
+    {"name": "<dimension_name>", "score": <1-5>, "feedback": "<specific feedback>"}
+  ],
+  "overall_score": <1.0-5.0>,
+  "summary": "<overall assessment>"
+}`)
+	b.WriteString("\n\nImportant rules:\n")
+	b.WriteString("- Include ALL dimensions listed above, in the same order\n")
+	b.WriteString("- overall_score should be the weighted average of dimension scores\n")
+	b.WriteString("- Keep feedback concise but actionable (1-2 sentences per dimension)\n")
+	b.WriteString("- Be critical but fair — a score of 5 means exceptional quality\n\n")
+	b.WriteString("SKILL.md content to evaluate:\n")
+	b.WriteString("---\n")
+	b.WriteString(skillContent)
+	b.WriteString("\n---\n")
+	return b.String()
+}
+
+// ParseJudgeResponse extracts a JudgeResponse from LLM output.
+func ParseJudgeResponse(raw string) (*JudgeResponse, error) {
+	cleaned := extractJSON(raw)
+	if cleaned == "" {
+		return nil, errors.New("no JSON found in judge response")
+	}
+
+	var resp JudgeResponse
+	if err := json.Unmarshal([]byte(cleaned), &resp); err != nil {
+		return nil, fmt.Errorf("invalid judge JSON: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// extractJSON pulls a JSON object from potentially decorated LLM output.
+func extractJSON(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	// Try to find JSON in fenced code block
+	if start := strings.Index(trimmed, "```"); start >= 0 {
+		rest := trimmed[start+3:]
+		// Skip language tag (e.g., ```json)
+		if nl := strings.Index(rest, "\n"); nl >= 0 {
+			rest = rest[nl+1:]
+		}
+		if end := strings.Index(rest, "```"); end >= 0 {
+			return strings.TrimSpace(rest[:end])
+		}
+	}
+
+	// Try to find bare JSON object
+	start := strings.Index(trimmed, "{")
+	if start < 0 {
+		return ""
+	}
+	end := strings.LastIndex(trimmed, "}")
+	if end < start {
+		return ""
+	}
+	return trimmed[start : end+1]
+}
+
+// resolveSkillFile resolves a path to a SKILL.md file.
+func resolveSkillFile(input string) (string, error) {
+	if strings.TrimSpace(input) == "" {
+		return "", errors.New("skill path is required")
+	}
+
+	resolved := input
+	if !filepath.IsAbs(resolved) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("getting working directory: %w", err)
+		}
+		resolved = filepath.Join(wd, resolved)
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("skill path does not exist: %s", input)
+		}
+		return "", fmt.Errorf("checking skill path: %w", err)
+	}
+
+	if info.IsDir() {
+		resolved = filepath.Join(resolved, "SKILL.md")
+	}
+
+	if filepath.Base(resolved) != "SKILL.md" {
+		return "", fmt.Errorf("expected SKILL.md or skill directory, got %s", input)
+	}
+	if _, err := os.Stat(resolved); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("no SKILL.md found in %s", input)
+		}
+		return "", fmt.Errorf("checking SKILL.md: %w", err)
+	}
+	return resolved, nil
+}

--- a/internal/quality/judge_test.go
+++ b/internal/quality/judge_test.go
@@ -1,0 +1,215 @@
+package quality
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/waza/internal/execution"
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+type mockJudgeEngine struct {
+	output string
+	err    error
+}
+
+func (m *mockJudgeEngine) Initialize(context.Context) error { return nil }
+
+func (m *mockJudgeEngine) Execute(_ context.Context, _ *execution.ExecutionRequest) (*execution.ExecutionResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &execution.ExecutionResponse{FinalOutput: m.output, Success: true}, nil
+}
+
+func (m *mockJudgeEngine) Shutdown(context.Context) error               { return nil }
+func (m *mockJudgeEngine) SessionUsage(string) *models.UsageStats { return nil }
+
+const validJudgeJSON = `{
+  "dimensions": [
+    {"name": "clarity", "score": 4, "feedback": "Instructions are clear and well-structured."},
+    {"name": "completeness", "score": 3, "feedback": "Missing error handling guidance."},
+    {"name": "trigger_precision", "score": 5, "feedback": "USE FOR and DO NOT USE FOR are precise."},
+    {"name": "scope_coverage", "score": 4, "feedback": "Scope is well-defined."},
+    {"name": "anti_patterns", "score": 3, "feedback": "Some steps could be more specific."}
+  ],
+  "overall_score": 3.8,
+  "summary": "A solid skill with room for improvement in completeness and anti-pattern avoidance."
+}`
+
+func writeTestSkill(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	content := `---
+name: test-skill
+description: "A test skill. USE FOR: testing. DO NOT USE FOR: production."
+---
+
+# Test Skill
+
+## Overview
+This is a test skill for quality evaluation.
+
+## Steps
+1. Step one
+2. Step two
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644))
+	return dir
+}
+
+func TestJudge_Success(t *testing.T) {
+	skillDir := writeTestSkill(t)
+	engine := &mockJudgeEngine{output: validJudgeJSON}
+
+	resp, err := Judge(context.Background(), engine, JudgeOptions{
+		SkillPath: skillDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Dimensions, 5)
+	require.InDelta(t, 3.8, resp.OverallScore, 0.01)
+	require.Contains(t, resp.Summary, "solid skill")
+}
+
+func TestJudge_EngineError(t *testing.T) {
+	skillDir := writeTestSkill(t)
+	engine := &mockJudgeEngine{err: fmt.Errorf("engine failure")}
+
+	_, err := Judge(context.Background(), engine, JudgeOptions{
+		SkillPath: skillDir,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "judge execution")
+}
+
+func TestJudge_InvalidJSON(t *testing.T) {
+	skillDir := writeTestSkill(t)
+	engine := &mockJudgeEngine{output: "not json at all"}
+
+	_, err := Judge(context.Background(), engine, JudgeOptions{
+		SkillPath: skillDir,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parsing judge response")
+}
+
+func TestJudge_MissingSkill(t *testing.T) {
+	engine := &mockJudgeEngine{output: validJudgeJSON}
+
+	_, err := Judge(context.Background(), engine, JudgeOptions{
+		SkillPath: "/nonexistent/path",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "skill path does not exist")
+}
+
+func TestJudge_ValidationFailure(t *testing.T) {
+	skillDir := writeTestSkill(t)
+	// Return response with missing dimensions
+	engine := &mockJudgeEngine{output: `{
+		"dimensions": [{"name": "clarity", "score": 4, "feedback": "OK"}],
+		"overall_score": 4.0,
+		"summary": "Incomplete"
+	}`}
+
+	resp, err := Judge(context.Background(), engine, JudgeOptions{
+		SkillPath: skillDir,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "judge response validation")
+	require.NotNil(t, resp) // partial response still returned
+}
+
+func TestParseJudgeResponse_BareJSON(t *testing.T) {
+	resp, err := ParseJudgeResponse(validJudgeJSON)
+	require.NoError(t, err)
+	require.Len(t, resp.Dimensions, 5)
+	require.Equal(t, "clarity", resp.Dimensions[0].Name)
+	require.Equal(t, 4, resp.Dimensions[0].Score)
+}
+
+func TestParseJudgeResponse_FencedJSON(t *testing.T) {
+	input := "Here is my analysis:\n```json\n" + validJudgeJSON + "\n```\n"
+	resp, err := ParseJudgeResponse(input)
+	require.NoError(t, err)
+	require.Len(t, resp.Dimensions, 5)
+}
+
+func TestParseJudgeResponse_EmptyOutput(t *testing.T) {
+	_, err := ParseJudgeResponse("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no JSON found")
+}
+
+func TestParseJudgeResponse_InvalidJSON(t *testing.T) {
+	_, err := ParseJudgeResponse("{invalid json}")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid judge JSON")
+}
+
+func TestBuildJudgePrompt(t *testing.T) {
+	rubric := DefaultRubric()
+	prompt := BuildJudgePrompt("# My Skill\nDoes stuff.", rubric)
+
+	require.Contains(t, prompt, "skill quality judge")
+	require.Contains(t, prompt, "clarity")
+	require.Contains(t, prompt, "completeness")
+	require.Contains(t, prompt, "trigger_precision")
+	require.Contains(t, prompt, "scope_coverage")
+	require.Contains(t, prompt, "anti_patterns")
+	require.Contains(t, prompt, "# My Skill")
+	require.Contains(t, prompt, `"dimensions"`)
+	require.Contains(t, prompt, `"overall_score"`)
+}
+
+func TestExtractJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantJSON bool
+	}{
+		{"bare json", `{"key": "value"}`, true},
+		{"fenced json", "```json\n{\"key\": \"value\"}\n```", true},
+		{"with preamble", "Analysis:\n{\"key\": \"value\"}", true},
+		{"empty", "", false},
+		{"no json", "just text", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractJSON(tt.input)
+			if tt.wantJSON {
+				require.NotEmpty(t, result)
+			} else {
+				require.Empty(t, result)
+			}
+		})
+	}
+}
+
+func TestResolveSkillFile(t *testing.T) {
+	dir := writeTestSkill(t)
+
+	// Directory resolves to SKILL.md
+	resolved, err := resolveSkillFile(dir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "SKILL.md"), resolved)
+
+	// Direct path to SKILL.md
+	resolved, err = resolveSkillFile(filepath.Join(dir, "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "SKILL.md"), resolved)
+
+	// Empty path
+	_, err = resolveSkillFile("")
+	require.Error(t, err)
+
+	// Non-SKILL.md file
+	_, err = resolveSkillFile(filepath.Join(dir, "other.md"))
+	require.Error(t, err)
+}

--- a/internal/quality/judge_test.go
+++ b/internal/quality/judge_test.go
@@ -26,7 +26,7 @@ func (m *mockJudgeEngine) Execute(_ context.Context, _ *execution.ExecutionReque
 	return &execution.ExecutionResponse{FinalOutput: m.output, Success: true}, nil
 }
 
-func (m *mockJudgeEngine) Shutdown(context.Context) error               { return nil }
+func (m *mockJudgeEngine) Shutdown(context.Context) error         { return nil }
 func (m *mockJudgeEngine) SessionUsage(string) *models.UsageStats { return nil }
 
 const validJudgeJSON = `{

--- a/internal/quality/report.go
+++ b/internal/quality/report.go
@@ -25,14 +25,14 @@ func FormatTable(resp *JudgeResponse) string {
 
 	for _, d := range resp.Dimensions {
 		bar := scoreBar(d.Score)
-		b.WriteString(fmt.Sprintf("%-*s  %s  %s\n", nameWidth, d.Name, bar, d.Feedback))
+		fmt.Fprintf(&b, "%-*s  %s  %s\n", nameWidth, d.Name, bar, d.Feedback)
 	}
 
 	b.WriteString(strings.Repeat("─", len(header)+10))
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("Overall: %.1f/5.0\n", resp.OverallScore))
+	fmt.Fprintf(&b, "Overall: %.1f/5.0\n", resp.OverallScore)
 	if resp.Summary != "" {
-		b.WriteString(fmt.Sprintf("\n%s\n", resp.Summary))
+		fmt.Fprintf(&b, "\n%s\n", resp.Summary)
 	}
 
 	return b.String()

--- a/internal/quality/report.go
+++ b/internal/quality/report.go
@@ -1,0 +1,61 @@
+package quality
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// FormatTable renders the judge response as a CLI-friendly table.
+func FormatTable(resp *JudgeResponse) string {
+	var b strings.Builder
+
+	nameWidth := len("DIMENSION")
+	for _, d := range resp.Dimensions {
+		if len(d.Name) > nameWidth {
+			nameWidth = len(d.Name)
+		}
+	}
+
+	header := fmt.Sprintf("%-*s  %-5s  %s", nameWidth, "DIMENSION", "SCORE", "FEEDBACK")
+	b.WriteString(header)
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat("─", len(header)+10))
+	b.WriteString("\n")
+
+	for _, d := range resp.Dimensions {
+		bar := scoreBar(d.Score)
+		b.WriteString(fmt.Sprintf("%-*s  %s  %s\n", nameWidth, d.Name, bar, d.Feedback))
+	}
+
+	b.WriteString(strings.Repeat("─", len(header)+10))
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("Overall: %.1f/5.0\n", resp.OverallScore))
+	if resp.Summary != "" {
+		b.WriteString(fmt.Sprintf("\n%s\n", resp.Summary))
+	}
+
+	return b.String()
+}
+
+// FormatJSON renders the judge response as indented JSON.
+func FormatJSON(resp *JudgeResponse) (string, error) {
+	data, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling judge response: %w", err)
+	}
+	return string(data), nil
+}
+
+// scoreBar renders a visual bar for a 1-5 score.
+func scoreBar(score int) string {
+	if score < 1 {
+		score = 1
+	}
+	if score > 5 {
+		score = 5
+	}
+	filled := strings.Repeat("█", score)
+	empty := strings.Repeat("░", 5-score)
+	return fmt.Sprintf("%s%s", filled, empty)
+}

--- a/internal/quality/report_test.go
+++ b/internal/quality/report_test.go
@@ -62,8 +62,8 @@ func TestScoreBar(t *testing.T) {
 		{3, "███░░"},
 		{4, "████░"},
 		{5, "█████"},
-		{0, "█░░░░"},  // clamped to 1
-		{6, "█████"},  // clamped to 5
+		{0, "█░░░░"}, // clamped to 1
+		{6, "█████"}, // clamped to 5
 	}
 
 	for _, tt := range tests {

--- a/internal/quality/report_test.go
+++ b/internal/quality/report_test.go
@@ -1,0 +1,74 @@
+package quality
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatTable(t *testing.T) {
+	resp := &JudgeResponse{
+		Dimensions: []DimensionResult{
+			{Name: "clarity", Score: 4, Feedback: "Clear instructions"},
+			{Name: "completeness", Score: 3, Feedback: "Missing edge cases"},
+			{Name: "trigger_precision", Score: 5, Feedback: "Perfect triggers"},
+			{Name: "scope_coverage", Score: 2, Feedback: "Too broad"},
+			{Name: "anti_patterns", Score: 4, Feedback: "Good patterns"},
+		},
+		OverallScore: 3.6,
+		Summary:      "Decent skill with room to improve scope.",
+	}
+
+	output := FormatTable(resp)
+
+	require.Contains(t, output, "DIMENSION")
+	require.Contains(t, output, "SCORE")
+	require.Contains(t, output, "FEEDBACK")
+	require.Contains(t, output, "clarity")
+	require.Contains(t, output, "completeness")
+	require.Contains(t, output, "Overall: 3.6/5.0")
+	require.Contains(t, output, "Decent skill")
+	// Check score bars
+	require.Contains(t, output, "████░") // score 4
+	require.Contains(t, output, "███░░") // score 3
+	require.Contains(t, output, "█████") // score 5
+	require.Contains(t, output, "██░░░") // score 2
+}
+
+func TestFormatJSON(t *testing.T) {
+	resp := &JudgeResponse{
+		Dimensions: []DimensionResult{
+			{Name: "clarity", Score: 4, Feedback: "Clear"},
+		},
+		OverallScore: 4.0,
+		Summary:      "Good",
+	}
+
+	output, err := FormatJSON(resp)
+	require.NoError(t, err)
+	require.Contains(t, output, `"clarity"`)
+	require.Contains(t, output, `"overall_score": 4`)
+	require.Contains(t, output, `"summary": "Good"`)
+}
+
+func TestScoreBar(t *testing.T) {
+	tests := []struct {
+		score    int
+		expected string
+	}{
+		{1, "█░░░░"},
+		{2, "██░░░"},
+		{3, "███░░"},
+		{4, "████░"},
+		{5, "█████"},
+		{0, "█░░░░"},  // clamped to 1
+		{6, "█████"},  // clamped to 5
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("score_%d", tt.score), func(t *testing.T) {
+			require.Equal(t, tt.expected, scoreBar(tt.score))
+		})
+	}
+}

--- a/internal/quality/rubric.go
+++ b/internal/quality/rubric.go
@@ -1,0 +1,97 @@
+package quality
+
+// Dimension represents a single quality dimension in the rubric.
+type Dimension struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	MinScore    int    `json:"min_score"`
+	MaxScore    int    `json:"max_score"`
+}
+
+// DimensionResult holds a judge's score and feedback for one dimension.
+type DimensionResult struct {
+	Name     string `json:"name"`
+	Score    int    `json:"score"`
+	Feedback string `json:"feedback"`
+}
+
+// JudgeResponse is the structured response expected from the LLM judge.
+type JudgeResponse struct {
+	Dimensions   []DimensionResult `json:"dimensions"`
+	OverallScore float64           `json:"overall_score"`
+	Summary      string            `json:"summary"`
+}
+
+// DefaultRubric returns the built-in quality dimensions.
+func DefaultRubric() []Dimension {
+	return []Dimension{
+		{
+			Name:        "clarity",
+			Description: "How clear and unambiguous are the instructions? Is the purpose immediately obvious? Are steps well-ordered and easy to follow?",
+			MinScore:    1,
+			MaxScore:    5,
+		},
+		{
+			Name:        "completeness",
+			Description: "Does the skill cover all necessary aspects? Are edge cases addressed? Is there enough detail for the agent to succeed?",
+			MinScore:    1,
+			MaxScore:    5,
+		},
+		{
+			Name:        "trigger_precision",
+			Description: "Are USE FOR and DO NOT USE FOR triggers well-defined? Do they avoid overlap? Would they correctly route requests?",
+			MinScore:    1,
+			MaxScore:    5,
+		},
+		{
+			Name:        "scope_coverage",
+			Description: "Does the skill define clear boundaries? Are capabilities and limitations explicit? Is the scope neither too broad nor too narrow?",
+			MinScore:    1,
+			MaxScore:    5,
+		},
+		{
+			Name:        "anti_patterns",
+			Description: "Does the skill avoid common anti-patterns such as vague instructions, conflicting directives, missing error handling guidance, or overly prescriptive steps?",
+			MinScore:    1,
+			MaxScore:    5,
+		},
+	}
+}
+
+// ValidateDimensionResult checks that a DimensionResult matches the rubric.
+func ValidateDimensionResult(result DimensionResult, rubric []Dimension) bool {
+	for _, d := range rubric {
+		if d.Name == result.Name {
+			return result.Score >= d.MinScore && result.Score <= d.MaxScore
+		}
+	}
+	return false
+}
+
+// ValidateJudgeResponse checks that the response has all expected dimensions with valid scores.
+func ValidateJudgeResponse(resp *JudgeResponse, rubric []Dimension) []string {
+	var issues []string
+
+	dimMap := make(map[string]bool, len(resp.Dimensions))
+	for _, d := range resp.Dimensions {
+		dimMap[d.Name] = true
+	}
+
+	for _, rd := range rubric {
+		if !dimMap[rd.Name] {
+			issues = append(issues, "missing dimension: "+rd.Name)
+		}
+	}
+
+	for _, d := range resp.Dimensions {
+		if !ValidateDimensionResult(d, rubric) {
+			issues = append(issues, "invalid score for "+d.Name)
+		}
+	}
+
+	if resp.OverallScore < 1.0 || resp.OverallScore > 5.0 {
+		issues = append(issues, "overall_score must be between 1.0 and 5.0")
+	}
+
+	return issues
+}

--- a/internal/quality/rubric_test.go
+++ b/internal/quality/rubric_test.go
@@ -1,0 +1,102 @@
+package quality
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultRubric(t *testing.T) {
+	rubric := DefaultRubric()
+	require.Len(t, rubric, 5)
+
+	names := make(map[string]bool)
+	for _, d := range rubric {
+		names[d.Name] = true
+		require.Equal(t, 1, d.MinScore)
+		require.Equal(t, 5, d.MaxScore)
+		require.NotEmpty(t, d.Description)
+	}
+
+	require.True(t, names["clarity"])
+	require.True(t, names["completeness"])
+	require.True(t, names["trigger_precision"])
+	require.True(t, names["scope_coverage"])
+	require.True(t, names["anti_patterns"])
+}
+
+func TestValidateDimensionResult(t *testing.T) {
+	rubric := DefaultRubric()
+
+	tests := []struct {
+		name  string
+		dim   DimensionResult
+		valid bool
+	}{
+		{"valid clarity", DimensionResult{Name: "clarity", Score: 3}, true},
+		{"min score", DimensionResult{Name: "clarity", Score: 1}, true},
+		{"max score", DimensionResult{Name: "clarity", Score: 5}, true},
+		{"too low", DimensionResult{Name: "clarity", Score: 0}, false},
+		{"too high", DimensionResult{Name: "clarity", Score: 6}, false},
+		{"unknown dimension", DimensionResult{Name: "unknown", Score: 3}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateDimensionResult(tt.dim, rubric)
+			require.Equal(t, tt.valid, result)
+		})
+	}
+}
+
+func TestValidateJudgeResponse_Valid(t *testing.T) {
+	rubric := DefaultRubric()
+	resp := &JudgeResponse{
+		Dimensions: []DimensionResult{
+			{Name: "clarity", Score: 4, Feedback: "Clear"},
+			{Name: "completeness", Score: 3, Feedback: "Missing edge cases"},
+			{Name: "trigger_precision", Score: 5, Feedback: "Excellent triggers"},
+			{Name: "scope_coverage", Score: 4, Feedback: "Well-bounded"},
+			{Name: "anti_patterns", Score: 3, Feedback: "Some vague steps"},
+		},
+		OverallScore: 3.8,
+		Summary:      "Good skill overall",
+	}
+
+	issues := ValidateJudgeResponse(resp, rubric)
+	require.Empty(t, issues)
+}
+
+func TestValidateJudgeResponse_MissingDimension(t *testing.T) {
+	rubric := DefaultRubric()
+	resp := &JudgeResponse{
+		Dimensions: []DimensionResult{
+			{Name: "clarity", Score: 4, Feedback: "Clear"},
+		},
+		OverallScore: 4.0,
+		Summary:      "Incomplete",
+	}
+
+	issues := ValidateJudgeResponse(resp, rubric)
+	require.NotEmpty(t, issues)
+	require.Contains(t, issues[0], "missing dimension")
+}
+
+func TestValidateJudgeResponse_InvalidOverallScore(t *testing.T) {
+	rubric := DefaultRubric()
+	resp := &JudgeResponse{
+		Dimensions: []DimensionResult{
+			{Name: "clarity", Score: 4, Feedback: "Clear"},
+			{Name: "completeness", Score: 3, Feedback: "OK"},
+			{Name: "trigger_precision", Score: 5, Feedback: "Good"},
+			{Name: "scope_coverage", Score: 4, Feedback: "OK"},
+			{Name: "anti_patterns", Score: 3, Feedback: "OK"},
+		},
+		OverallScore: 6.0,
+		Summary:      "Invalid score",
+	}
+
+	issues := ValidateJudgeResponse(resp, rubric)
+	require.NotEmpty(t, issues)
+	require.Contains(t, issues[0], "overall_score")
+}

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -321,8 +321,23 @@ Skill: code-explainer
 🧪 Evaluation Suite: Found
    ✅ eval.yaml detected.
 
+💡 Advisory Checks
+   ✅ scope-reduction: Capability scope: 3 signal(s) detected
+
 ✅ Your skill is ready for submission!
 ```
+
+### Advisory: Scope Reduction Warning
+
+The `scope-reduction` advisory check detects when a SKILL.md may have lost workflow coverage due to token-limit compression. It parses three concrete signals:
+
+| Signal | What it counts |
+|--------|---------------|
+| **USE FOR items** | Comma-separated phrases after `USE FOR:` |
+| **Level-2 headings** | `## ` headings in the body (distinct capability sections) |
+| **Numbered procedures** | Sequences starting with `1.` (distinct workflows) |
+
+The check takes the **maximum** of these three indicators. If the count is below the minimum threshold (default: 2), a warning is emitted suggesting possible scope loss. This is advisory only — it does not block readiness.
 
 ### Examples
 
@@ -797,6 +812,61 @@ graders:
 ```bash
 waza run eval.yaml --baseline -o results.json
 # Output includes pairwise judge scores comparing baseline vs treatment approaches
+```
+
+## waza quality
+
+Evaluate skill content quality using an LLM-as-Judge. Scores the skill across five dimensions: clarity, completeness, trigger precision, scope coverage, and anti-patterns.
+
+```bash
+waza quality <skill-path>
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--model` | string | project default | Model to use as judge |
+| `--format` | string | `table` | Output format: `table` or `json` |
+| `--rubric` | string | | Path to custom rubric file (reserved for future use) |
+
+### Output
+
+Displays a table with dimension scores (1-5), visual bars, and feedback:
+
+```
+DIMENSION          SCORE  FEEDBACK
+──────────────────────────────────────────────────────────────────────
+clarity            ████░  Instructions are clear and well-structured.
+completeness       ███░░  Missing some edge case documentation.
+trigger_precision  █████  USE FOR and DO NOT USE FOR are precise.
+scope_coverage     ████░  Scope is well-defined with clear boundaries.
+anti_patterns      ███░░  Some steps could be more specific.
+──────────────────────────────────────────────────────────────────────
+Overall: 3.8/5.0
+
+A solid skill with good clarity and triggers.
+```
+
+### Authentication
+
+Requires Copilot authentication. If not authenticated, you will see:
+
+```
+Error: not authenticated — run "copilot login" first
+```
+
+### Examples
+
+```bash
+# Table output (default)
+waza quality skills/code-explainer
+
+# JSON output for CI pipelines
+waza quality skills/code-explainer --format json
+
+# Use a specific judge model
+waza quality skills/code-explainer --model gpt-4o
 ```
 
 ## waza models


### PR DESCRIPTION
## Summary

Closes #98

Adds `waza quality <skill-path>` — an LLM-as-Judge command that evaluates skill content quality across five dimensions, each scored 1–5:

| Dimension | What it measures |
|-----------|-----------------|
| **clarity** | Instruction clarity, structure, step ordering |
| **completeness** | Edge case coverage, detail level |
| **trigger_precision** | USE FOR / DO NOT USE FOR quality |
| **scope_coverage** | Boundary definition, capability explicitness |
| **anti_patterns** | Avoidance of vague/conflicting instructions |

### New files
- `internal/quality/rubric.go` — Dimension definitions, validation
- `internal/quality/judge.go` — Prompt construction, copilot SDK execution, JSON response parsing
- `internal/quality/report.go` — Table (with visual score bars) and JSON formatters
- `cmd/waza/cmd_quality.go` — CLI command registration
- `cmd/waza/cmd_quality_test.go` — 8 command-level tests
- `internal/quality/*_test.go` — 20 unit tests

### CLI usage
```bash
waza quality skills/my-skill                    # table output
waza quality skills/my-skill --format json      # JSON for CI
waza quality skills/my-skill --model gpt-4o     # specific judge model
```

### Flags
| Flag | Default | Description |
|------|---------|-------------|
| `--model` | project default | Model to use as judge |
| `--format` | `table` | Output: `table` or `json` |
| `--rubric` | — | Custom rubric file (reserved, errors for now) |

### Design decisions
- Judge prompt requests structured JSON: `{dimensions: [{name, score, feedback}], overall_score, summary}`
- Copilot SDK mocked in all tests — no real LLM calls
- Auth failures produce clear `copilot login` message (same pattern as `waza models`)
- Partial responses with validation issues still display with a warning

### Tests
- `go test ./...` — all pass
- `go vet ./...` — clean
- Site builds: `cd site && npm run build` — ✅

### Docs updated
- `README.md` — new command section
- `site/src/content/docs/reference/cli.mdx` — full CLI reference entry