### PR TITLE
docs: update README with missing CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,26 @@ Generate a skill-to-eval coverage grid showing which skills are fully covered, p
 | `--format <fmt>` | `-f` | Output format: `text`, `markdown`, or `json` (default: `text`) |
 | `--path <dir>` | | Additional directory to scan for skills/evals (repeatable) |
 
+### `waza models`
+
+List models available for evaluation via the Copilot SDK. Shows model IDs and metadata that can be used with `--model` flags in `waza run`, `waza quality`, and other commands.
+
+Requires authentication via `copilot login`.
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output as JSON |
+
+**Examples:**
+
+```bash
+# List available models in table format
+waza models
+
+# Output available models as JSON
+waza models --json
+```
+
 ### `waza cache clear`
 
 Clear all cached evaluation results to force re-execution on the next run.


### PR DESCRIPTION
## Summary

Updated the README.md to document the `waza models` command, which was implemented but missing from the CLI reference.

### Changes
- Added documentation for `waza models` command in the Commands section
- Documented the `--json` flag for JSON output
- Included examples of typical usage
- Verified documentation site builds successfully

### Related Issue
Requested by Shayne Boyer to ensure all CLI commands are documented.

---

**Branch:** squad/readme-update  
**Co-authored-by:** Copilot <223556219+Copilot@users.noreply.github.com>