### PR TITLE
refactor: complete vocabulary renames — BenchmarkSpec→EvalSpec, TestRunner→EvalRunner (#166)

### DIFF
--- a/.squad/agents/linus/history.md
+++ b/.squad/agents/linus/history.md
@@ -91,7 +91,14 @@ All code roles now use `claude-opus-4.6`. Docs/Scribe/diversity use `gemini-3-pr
 - **Branch:** `squad/287-suggest-command`
 - **Files changed:** `cmd/waza/cmd_suggest.go` (new), `cmd/waza/cmd_suggest_test.go` (new), `internal/suggest/prompt.go` (new), `internal/suggest/suggest.go` (new), `internal/suggest/suggest_test.go` (new), `cmd/waza/root.go`, `README.md`, `site/src/content/docs/reference/cli.mdx`
 - **What:** Added `waza suggest <skill-path>` for LLM-driven eval generation. Command supports `--model`, `--dry-run` (default), `--apply`, `--output-dir`, and `--format yaml|json`. New `internal/suggest` package builds prompt context from SKILL.md + grader types + eval schema summary + example eval, parses structured YAML responses, validates generated `eval_yaml`, and writes `eval.yaml`/task/fixture files when applying.
-- **Key learning:** A robust parser needs to handle both structured wrapper YAML (`eval_yaml` + files) and fenced YAML blocks from models. Validating generated `eval_yaml` against `models.BenchmarkSpec.Validate()` catches malformed model output early before writing files.
+- **Key learning:** A robust parser needs to handle both structured wrapper YAML (`eval_yaml` + files) and fenced YAML blocks from models. Validating generated `eval_yaml` against `models.EvalSpec.Validate()` catches malformed model output early before writing files.
+
+### #166 — Vocabulary Renames: Benchmark/Test → Eval/Task (PR #222)
+- **Date:** 2026-02-21
+- **Branch:** `squad/166-vocabulary-renames`
+- **Files changed:** 35 files across `cmd/waza/`, `internal/`, `README.md`, `AGENTS.md`
+- **What:** Completed vocabulary renames across Go codebase. `BenchmarkSpec`→`EvalSpec`, `LoadBenchmarkSpec`→`LoadEvalSpec`, `BenchmarkConfig`→`EvalConfig`, `NewBenchmarkConfig`→`NewEvalConfig`, `TestRunner`→`EvalRunner`, `TestStimulus`→`TaskStimulus`, `TestExpectation`→`TaskExpectation`. Added backward-compat type aliases and wrapper functions for all exported names. YAML/JSON tags unchanged. `TestCase` intentionally kept (Go convention).
+- **Key learning:** Bulk sed renames of `TestRunner` will also catch test function names like `func TestRunnerXxx(t *testing.T)` — these must be restored to `func TestEvalRunnerXxx` to keep the `Test` prefix required by `go test`. Always verify test function names after bulk renames.
 
 ## Learnings
 - Windows local test runs can fail in `cmd/waza/tokens/internal/git` when temporary repos inherit strict CRLF behavior; setting `core.autocrlf=false` and `core.safecrlf=false` inside test repo setup makes these tests cross-platform stable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,11 @@ waza-go/
 │   │   ├── mock.go        # Mock engine for testing
 │   │   └── copilot.go     # Copilot SDK integration
 │   ├── models/            # Data structures
-│   │   ├── spec.go        # BenchmarkSpec (eval configuration)
+│   │   ├── spec.go        # EvalSpec (eval configuration)
 │   │   ├── testcase.go    # TestCase (task definition)
 │   │   └── outcome.go     # EvaluationOutcome (results)
-│   ├── orchestration/     # TestRunner for coordinating execution
-│   │   └── runner.go      # Benchmark orchestration
+│   ├── orchestration/     # EvalRunner for coordinating execution
+│   │   └── runner.go      # Eval orchestration
 │   └── scoring/           # Validator interface and implementations
 │       ├── validator.go   # Validator registry pattern
 │       └── code_validators.go  # Code and text validators
@@ -47,7 +47,7 @@ The Go implementation uses idiomatic Go naming:
 
 | Concept | Go Name | Python Equivalent |
 |---------|---------|-------------------|
-| Eval configuration | `BenchmarkSpec` | `EvalSpec` |
+| Eval configuration | `EvalSpec` | `EvalSpec` |
 | Executor | `AgentEngine` | `BaseExecutor` |
 | Grader | `Validator` | `Grader` |
 | Task | `TestCase` | `Task` |

--- a/README.md
+++ b/README.md
@@ -835,8 +835,8 @@ internal/
   execution/           AgentEngine interface (mock, copilot)
   graders/             Validator registry and built-in graders
   metrics/             Scoring metrics
-  models/              Data structures (BenchmarkSpec, TestCase, EvaluationOutcome)
-  orchestration/       TestRunner for coordinating execution
+  models/              Data structures (EvalSpec, TestCase, EvaluationOutcome)
+  orchestration/       EvalRunner for coordinating execution
   reporting/           Result formatting and output
   transcript/          Per-task transcript capture
   wizard/              Interactive init wizard

--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -62,7 +62,7 @@ func runGrade(ctx context.Context, w, errW io.Writer, specPath, taskID, resultsF
 		return fmt.Errorf("--workspace path %q is not a directory", workspace)
 	}
 
-	spec, err := models.LoadBenchmarkSpec(specPath)
+	spec, err := models.LoadEvalSpec(specPath)
 	if err != nil {
 		return fmt.Errorf("failed to load spec: %w", err)
 	}
@@ -190,7 +190,7 @@ func runGrade(ctx context.Context, w, errW io.Writer, specPath, taskID, resultsF
 	return nil
 }
 
-func loadGradeTasks(spec *models.BenchmarkSpec, specPath, taskID string) ([]*models.TestCase, error) {
+func loadGradeTasks(spec *models.EvalSpec, specPath, taskID string) ([]*models.TestCase, error) {
 	all, err := loadTestCases(spec, specPath)
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func loadGradeTasks(spec *models.BenchmarkSpec, specPath, taskID string) ([]*mod
 	return nil, nil
 }
 
-func gradeTaskRuns(ctx context.Context, spec *models.BenchmarkSpec, tc *models.TestCase, runs []models.RunResult, workspace, judgeModel string, errW io.Writer, verbose bool) (models.GradeOutcome, []models.RunResult, error) {
+func gradeTaskRuns(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, runs []models.RunResult, workspace, judgeModel string, errW io.Writer, verbose bool) (models.GradeOutcome, []models.RunResult, error) {
 	totalScore := 0.0
 	allPassed := true
 	graderWeightedTotals := make(map[string]float64)
@@ -249,7 +249,7 @@ func gradeTaskRuns(ctx context.Context, spec *models.BenchmarkSpec, tc *models.T
 	}, gradedRuns, nil
 }
 
-func gradeRun(ctx context.Context, spec *models.BenchmarkSpec, tc *models.TestCase, run *models.RunResult, workspace, judgeModel string, errW io.Writer, verbose bool) (*models.RunResult, error) {
+func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, run *models.RunResult, workspace, judgeModel string, errW io.Writer, verbose bool) (*models.RunResult, error) {
 	gradedRun := *run
 	if gradedRun.ErrorMsg != "" || gradedRun.Status == models.StatusError {
 		gradedRun.Validations = map[string]models.GraderResults{}

--- a/cmd/waza/cmd_new_task_test.go
+++ b/cmd/waza/cmd_new_task_test.go
@@ -275,7 +275,7 @@ func TestNewTaskFromPromptCommand_EndToEndCreatesTaskFile(t *testing.T) {
 		DisplayName: "auto-generated",
 		TestID:      "auto-generated",
 		Tags:        []string{"auto-generated"},
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "use the example horn",
 		},
 		Validators: []models.ValidatorInline{

--- a/cmd/waza/cmd_run.go
+++ b/cmd/waza/cmd_run.go
@@ -447,7 +447,7 @@ func runCommandForSpec(cmd *cobra.Command, sp skillSpecPath, defaultSkills []str
 	specPath := sp.evalSpecPath
 
 	// Load spec
-	spec, err := models.LoadBenchmarkSpec(specPath)
+	spec, err := models.LoadEvalSpec(specPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load spec: %w", err)
 	}
@@ -574,7 +574,7 @@ func runCommandForSpec(cmd *cobra.Command, sp skillSpecPath, defaultSkills []str
 
 // runSingleModel executes a benchmark for one model and returns the outcome.
 // It prints the per-model summary and saves output for single-model runs.
-func runSingleModel(cmd *cobra.Command, spec *models.BenchmarkSpec, specPath string, defaultSkills []string) (*models.EvaluationOutcome, error) {
+func runSingleModel(cmd *cobra.Command, spec *models.EvalSpec, specPath string, defaultSkills []string) (*models.EvaluationOutcome, error) {
 	// Get spec directory for resolving relative paths
 	specDir := filepath.Dir(specPath)
 	if !filepath.IsAbs(specDir) {
@@ -601,7 +601,7 @@ func runSingleModel(cmd *cobra.Command, spec *models.BenchmarkSpec, specPath str
 	}
 
 	// Create config with both directories
-	cfg := config.NewBenchmarkConfig(spec,
+	cfg := config.NewEvalConfig(spec,
 		config.WithSpecDir(specDir),
 		config.WithFixtureDir(fixtureDir),
 		config.WithVerbose(verbose),
@@ -672,7 +672,7 @@ func runSingleModel(cmd *cobra.Command, spec *models.BenchmarkSpec, specPath str
 	if skipGradersFlag {
 		runnerOpts = append(runnerOpts, orchestration.WithSkipGraders())
 	}
-	runner := orchestration.NewTestRunner(cfg, engine, runnerOpts...)
+	runner := orchestration.NewEvalRunner(cfg, engine, runnerOpts...)
 
 	// Setup session logger if enabled
 	var sessLogger session.Logger = session.NopLogger{}

--- a/cmd/waza/cmd_run_suggest.go
+++ b/cmd/waza/cmd_run_suggest.go
@@ -41,7 +41,7 @@ var (
 func generateEvalAnalysis(
 	ctx context.Context,
 	engine execution.AgentEngine,
-	spec *models.BenchmarkSpec,
+	spec *models.EvalSpec,
 	specPath string,
 	outcome *models.EvaluationOutcome,
 	triggerResults []models.TriggerResult,
@@ -122,7 +122,7 @@ func summarizeSessionEventTypes(events []copilot.SessionEvent) []string {
 	return lines
 }
 
-func generateFakeSuggestionReport(spec *models.BenchmarkSpec, failedTests, failedTriggers int) string {
+func generateFakeSuggestionReport(spec *models.EvalSpec, failedTests, failedTriggers int) string {
 	totalFailures := failedTests + failedTriggers
 	var b strings.Builder
 
@@ -138,7 +138,7 @@ func generateFakeSuggestionReport(spec *models.BenchmarkSpec, failedTests, faile
 	return b.String()
 }
 
-func resolveSuggestionSkillPaths(spec *models.BenchmarkSpec, specPath string) []string {
+func resolveSuggestionSkillPaths(spec *models.EvalSpec, specPath string) []string {
 	specDir := filepath.Dir(specPath)
 	paths := utils.ResolvePaths(spec.Config.SkillPaths, specDir)
 	paths = append(paths, specDir)
@@ -157,7 +157,7 @@ func resolveSuggestionSkillPaths(spec *models.BenchmarkSpec, specPath string) []
 	return unique
 }
 
-func resolveEvaluatedSkillDirs(spec *models.BenchmarkSpec, specDir string, resolvedPaths []string) []string {
+func resolveEvaluatedSkillDirs(spec *models.EvalSpec, specDir string, resolvedPaths []string) []string {
 	if spec == nil || strings.TrimSpace(spec.SkillName) == "" {
 		return nil
 	}
@@ -277,7 +277,7 @@ func isTextFile(name string) bool {
 }
 
 func buildRunAnalysisPrompt(
-	spec *models.BenchmarkSpec,
+	spec *models.EvalSpec,
 	failingTests []models.TestOutcome,
 	failedTriggers []models.TriggerResult,
 	testDefinitions map[string]string,
@@ -294,7 +294,7 @@ func buildRunAnalysisPrompt(
 // buildGraderDocsSection collects grader types from the spec and from failed
 // test outcomes, then returns the embedded documentation for each type so the
 // suggestion model understands how graders work and how to fix failures.
-func buildGraderDocsSection(spec *models.BenchmarkSpec, failingTests []models.TestOutcome) string {
+func buildGraderDocsSection(spec *models.EvalSpec, failingTests []models.TestOutcome) string {
 	kinds := collectFailedGraderKinds(spec, failingTests)
 	if len(kinds) == 0 {
 		return ""
@@ -325,7 +325,7 @@ func buildGraderDocsSection(spec *models.BenchmarkSpec, failingTests []models.Te
 
 // collectFailedGraderKinds returns the set of grader kind strings from the
 // spec's global graders and from any failed grader results in test outcomes.
-func collectFailedGraderKinds(spec *models.BenchmarkSpec, failingTests []models.TestOutcome) map[string]bool {
+func collectFailedGraderKinds(spec *models.EvalSpec, failingTests []models.TestOutcome) map[string]bool {
 	kinds := make(map[string]bool)
 
 	// Include global graders from the spec.
@@ -350,7 +350,7 @@ func collectFailedGraderKinds(spec *models.BenchmarkSpec, failingTests []models.
 }
 
 func buildFailingTestEvidence(
-	spec *models.BenchmarkSpec,
+	spec *models.EvalSpec,
 	failingTests []models.TestOutcome,
 	testDefinitions map[string]string,
 ) string {
@@ -464,7 +464,7 @@ func selectFailedTriggerResults(results []models.TriggerResult) []models.Trigger
 	return failed
 }
 
-func loadTestDefinitionYAML(spec *models.BenchmarkSpec, specPath string) (map[string]string, error) {
+func loadTestDefinitionYAML(spec *models.EvalSpec, specPath string) (map[string]string, error) {
 	testCases, err := loadTestCases(spec, specPath)
 	if err != nil {
 		return nil, err
@@ -487,14 +487,14 @@ func loadTestDefinitionYAML(spec *models.BenchmarkSpec, specPath string) (map[st
 	return defs, nil
 }
 
-func loadTestCases(spec *models.BenchmarkSpec, specPath string) ([]*models.TestCase, error) {
+func loadTestCases(spec *models.EvalSpec, specPath string) ([]*models.TestCase, error) {
 	if spec.TasksFrom != "" {
 		return loadTestCasesFromCSV(spec, specPath)
 	}
 	return loadTestCasesFromFiles(spec, specPath)
 }
 
-func loadTestCasesFromFiles(spec *models.BenchmarkSpec, specPath string) ([]*models.TestCase, error) {
+func loadTestCasesFromFiles(spec *models.EvalSpec, specPath string) ([]*models.TestCase, error) {
 	specDir := filepath.Dir(specPath)
 	testFiles := make([]string, 0)
 	for _, pattern := range spec.Tasks {
@@ -523,7 +523,7 @@ func loadTestCasesFromFiles(spec *models.BenchmarkSpec, specPath string) ([]*mod
 	return testCases, nil
 }
 
-func loadTestCasesFromCSV(spec *models.BenchmarkSpec, specPath string) ([]*models.TestCase, error) {
+func loadTestCasesFromCSV(spec *models.EvalSpec, specPath string) ([]*models.TestCase, error) {
 	specDir := filepath.Dir(specPath)
 	csvPath := spec.TasksFrom
 	if !filepath.IsAbs(csvPath) {
@@ -609,7 +609,7 @@ func loadTestCasesFromCSV(spec *models.BenchmarkSpec, specPath string) ([]*model
 		testCases = append(testCases, &models.TestCase{
 			TestID:      testID,
 			DisplayName: displayName,
-			Stimulus: models.TestStimulus{
+			Stimulus: models.TaskStimulus{
 				Message: prompt,
 			},
 		})

--- a/cmd/waza/cmd_run_suggest_test.go
+++ b/cmd/waza/cmd_run_suggest_test.go
@@ -20,7 +20,7 @@ func TestResolveSuggestionSkillPaths_DedupesAndSorts(t *testing.T) {
 	require.NoError(t, os.MkdirAll(a, 0o755))
 	require.NoError(t, os.MkdirAll(b, 0o755))
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		Config: models.Config{
 			SkillPaths: []string{b, a, b},
 		},
@@ -39,7 +39,7 @@ func TestResolveSuggestionSkillPaths_IncludesEvaluatedSkillDirectory(t *testing.
 	require.NoError(t, os.MkdirAll(evaluatedSkillDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(evaluatedSkillDir, "SKILL.md"), []byte("# My Skill"), 0o644))
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SkillName: "my-skill",
 		Config: models.Config{
 			SkillPaths: []string{skillRoot},
@@ -55,7 +55,7 @@ func TestMaybeGenerateSuggestionReport_SkipsWhenNoFailures(t *testing.T) {
 	suggestFlag = true
 	t.Cleanup(func() { suggestFlag = oldSuggest })
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SkillName: "test-skill",
 		Config: models.Config{
 			EngineType: "mock",
@@ -147,7 +147,7 @@ func TestBuildRunSuggestionPrompt_IncludesOnlyFailureEvidence(t *testing.T) {
 	secretContent := "UNIQUE_SKILL_CONTENT_SHOULD_NOT_APPEAR_IN_PROMPT"
 	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(secretContent), 0o644))
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SkillName: "test-skill",
 		Config: models.Config{
 			EngineType: "copilot-sdk",
@@ -254,7 +254,7 @@ func TestBuildRunSuggestionPrompt_IncludesOnlyFailureEvidence(t *testing.T) {
 }
 
 func TestBuildRunSuggestionPrompt_OmitsBenchmarkSectionWhenNoBenchmarkFailures(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SkillName: "test-skill",
 		Config: models.Config{
 			EngineType: "copilot-sdk",
@@ -278,7 +278,7 @@ func TestBuildRunSuggestionPrompt_OmitsBenchmarkSectionWhenNoBenchmarkFailures(t
 }
 
 func TestBuildRunSuggestionPrompt_OmitsTriggerSectionWhenNoTriggerFailures(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SkillName: "test-skill",
 		Config: models.Config{
 			EngineType: "copilot-sdk",
@@ -305,7 +305,7 @@ func TestBuildRunSuggestionPrompt_OmitsTriggerSectionWhenNoTriggerFailures(t *te
 }
 
 func TestBuildRunSuggestionPrompt_IncludesGraderDocs(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SkillName: "test-skill",
 		Config: models.Config{
 			EngineType: "copilot-sdk",
@@ -350,13 +350,13 @@ func TestBuildRunSuggestionPrompt_IncludesGraderDocs(t *testing.T) {
 }
 
 func TestBuildGraderDocsSection_EmptyWhenNoGraders(t *testing.T) {
-	spec := &models.BenchmarkSpec{}
+	spec := &models.EvalSpec{}
 	result := buildGraderDocsSection(spec, nil)
 	assert.Empty(t, result)
 }
 
 func TestCollectFailedGraderKinds(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		Graders: []models.GraderConfig{
 			{Kind: models.GraderKindInlineScript, Identifier: "assertions"},
 		},

--- a/cmd/waza/newtask/converters_test.go
+++ b/cmd/waza/newtask/converters_test.go
@@ -23,7 +23,7 @@ func TestCreateTestCaseFromCopilotLog_UsingSkillFixture(t *testing.T) {
 		DisplayName: "fixture-case",
 		TestID:      "fixture-id",
 		Tags:        []string{"from-fixture"},
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "use the example horn",
 		},
 		Validators: []models.ValidatorInline{

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -31,7 +31,7 @@ func New(dir string) *Cache {
 // - task content (test case definition)
 // - model ID
 // - fixture file hashes
-func CacheKey(spec *models.BenchmarkSpec, task *models.TestCase, fixtureDir string) (string, error) {
+func CacheKey(spec *models.EvalSpec, task *models.TestCase, fixtureDir string) (string, error) {
 	h := sha256.New()
 
 	// Include spec identity
@@ -202,7 +202,7 @@ func (c *Cache) cachePath(key string) string {
 
 // HasNonDeterministicGraders checks if any graders are non-deterministic
 // Non-deterministic graders include: behavior and prompt
-func HasNonDeterministicGraders(spec *models.BenchmarkSpec) bool {
+func HasNonDeterministicGraders(spec *models.EvalSpec) bool {
 	for _, g := range spec.Graders {
 		if g.Kind == models.GraderKindBehavior || g.Kind == models.GraderKindPrompt {
 			return true

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCacheKey(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-spec",
 		},
@@ -31,7 +31,7 @@ func TestCacheKey(t *testing.T) {
 	task := &models.TestCase{
 		TestID:      "test-1",
 		DisplayName: "Test Task",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Do something",
 			Resources: []models.ResourceRef{
 				{Location: "file1.txt"},
@@ -61,7 +61,7 @@ func TestCacheKey(t *testing.T) {
 }
 
 func TestCacheKey_DifferentModelChangesKey(t *testing.T) {
-	spec1 := &models.BenchmarkSpec{
+	spec1 := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -71,7 +71,7 @@ func TestCacheKey_DifferentModelChangesKey(t *testing.T) {
 		},
 	}
 
-	spec2 := &models.BenchmarkSpec{
+	spec2 := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -84,7 +84,7 @@ func TestCacheKey_DifferentModelChangesKey(t *testing.T) {
 	task := &models.TestCase{
 		TestID:      "test-1",
 		DisplayName: "Test",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Test",
 		},
 	}
@@ -99,7 +99,7 @@ func TestCacheKey_DifferentModelChangesKey(t *testing.T) {
 }
 
 func TestCacheKey_DifferentSkillPathsChangesKey(t *testing.T) {
-	spec1 := &models.BenchmarkSpec{
+	spec1 := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -110,7 +110,7 @@ func TestCacheKey_DifferentSkillPathsChangesKey(t *testing.T) {
 		},
 	}
 
-	spec2 := &models.BenchmarkSpec{
+	spec2 := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -124,7 +124,7 @@ func TestCacheKey_DifferentSkillPathsChangesKey(t *testing.T) {
 	task := &models.TestCase{
 		TestID:      "test-1",
 		DisplayName: "Test",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Test",
 		},
 	}
@@ -139,7 +139,7 @@ func TestCacheKey_DifferentSkillPathsChangesKey(t *testing.T) {
 }
 
 func TestCacheKey_DifferentFixturesChangesKey(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -152,7 +152,7 @@ func TestCacheKey_DifferentFixturesChangesKey(t *testing.T) {
 	task := &models.TestCase{
 		TestID:      "test-1",
 		DisplayName: "Test",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Test",
 			Resources: []models.ResourceRef{
 				{Location: "file1.txt"},
@@ -314,7 +314,7 @@ func TestHasNonDeterministicGraders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := &models.BenchmarkSpec{
+			spec := &models.EvalSpec{
 				Graders: tt.graders,
 			}
 			result := HasNonDeterministicGraders(spec)
@@ -324,7 +324,7 @@ func TestHasNonDeterministicGraders(t *testing.T) {
 }
 
 func TestCacheKey_FixtureOrdering(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -338,7 +338,7 @@ func TestCacheKey_FixtureOrdering(t *testing.T) {
 	// because the task structure itself is different. This is acceptable.
 	task1 := &models.TestCase{
 		TestID: "test-1",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Test",
 			Resources: []models.ResourceRef{
 				{Location: "b.txt"},
@@ -350,7 +350,7 @@ func TestCacheKey_FixtureOrdering(t *testing.T) {
 
 	task2 := &models.TestCase{
 		TestID: "test-1",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Test",
 			Resources: []models.ResourceRef{
 				{Location: "a.txt"},
@@ -376,7 +376,7 @@ func TestCacheKey_FixtureOrdering(t *testing.T) {
 }
 
 func TestCacheKey_MissingFixtures(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -388,7 +388,7 @@ func TestCacheKey_MissingFixtures(t *testing.T) {
 
 	task := &models.TestCase{
 		TestID: "test-1",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Test",
 			Resources: []models.ResourceRef{
 				{Location: "nonexistent.txt"},
@@ -405,7 +405,7 @@ func TestCacheKey_MissingFixtures(t *testing.T) {
 }
 
 func TestCacheKey_DifferentRunsPerTaskChangesKey(t *testing.T) {
-	spec1 := &models.BenchmarkSpec{
+	spec1 := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -416,7 +416,7 @@ func TestCacheKey_DifferentRunsPerTaskChangesKey(t *testing.T) {
 		},
 	}
 
-	spec2 := &models.BenchmarkSpec{
+	spec2 := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test"},
 		SkillName:    "skill",
 		Config: models.Config{
@@ -429,7 +429,7 @@ func TestCacheKey_DifferentRunsPerTaskChangesKey(t *testing.T) {
 
 	task := &models.TestCase{
 		TestID: "test-1",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Test",
 		},
 	}
@@ -445,7 +445,7 @@ func TestCacheKey_DifferentRunsPerTaskChangesKey(t *testing.T) {
 
 func TestCacheKey_NoHashCollision(t *testing.T) {
 	// Test that field delimiters prevent hash collisions
-	spec1 := &models.BenchmarkSpec{
+	spec1 := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "ab"},
 		SkillName:    "cd",
 		Config: models.Config{
@@ -456,7 +456,7 @@ func TestCacheKey_NoHashCollision(t *testing.T) {
 		},
 	}
 
-	spec2 := &models.BenchmarkSpec{
+	spec2 := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "abc"},
 		SkillName:    "d",
 		Config: models.Config{
@@ -469,7 +469,7 @@ func TestCacheKey_NoHashCollision(t *testing.T) {
 
 	task := &models.TestCase{
 		TestID: "test-1",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Test",
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,11 @@ import (
 	"github.com/microsoft/waza/internal/models"
 )
 
-// BenchmarkConfig is the main configuration with functional options
-type BenchmarkConfig struct {
-	spec          *models.BenchmarkSpec
+// EvalConfig is the main configuration with functional options.
+//
+// Deprecated alias: BenchmarkConfig is provided for backward compatibility.
+type EvalConfig struct {
+	spec          *models.EvalSpec
 	specDir       string // Directory containing the spec file (for resolving test patterns)
 	fixtureDir    string // Directory containing fixtures/context files
 	verbose       bool
@@ -15,12 +17,12 @@ type BenchmarkConfig struct {
 	transcriptDir string // Directory for per-task transcript JSON files
 }
 
-// Option is a functional option for BenchmarkConfig
-type Option func(*BenchmarkConfig)
+// Option is a functional option for EvalConfig
+type Option func(*EvalConfig)
 
-// NewBenchmarkConfig creates a new configuration with options
-func NewBenchmarkConfig(spec *models.BenchmarkSpec, opts ...Option) *BenchmarkConfig {
-	cfg := &BenchmarkConfig{
+// NewEvalConfig creates a new configuration with options
+func NewEvalConfig(spec *models.EvalSpec, opts ...Option) *EvalConfig {
+	cfg := &EvalConfig{
 		spec:    spec,
 		verbose: false,
 	}
@@ -34,14 +36,14 @@ func NewBenchmarkConfig(spec *models.BenchmarkSpec, opts ...Option) *BenchmarkCo
 
 // WithSpecDir sets the spec directory (for resolving test patterns)
 func WithSpecDir(path string) Option {
-	return func(c *BenchmarkConfig) {
+	return func(c *EvalConfig) {
 		c.specDir = path
 	}
 }
 
 // WithFixtureDir sets the fixture directory (for loading resource files)
 func WithFixtureDir(path string) Option {
-	return func(c *BenchmarkConfig) {
+	return func(c *EvalConfig) {
 		c.fixtureDir = path
 	}
 }
@@ -53,38 +55,46 @@ func WithContextRoot(path string) Option {
 
 // WithVerbose enables verbose output
 func WithVerbose(enabled bool) Option {
-	return func(c *BenchmarkConfig) {
+	return func(c *EvalConfig) {
 		c.verbose = enabled
 	}
 }
 
 // WithOutputPath sets the output file path
 func WithOutputPath(path string) Option {
-	return func(c *BenchmarkConfig) {
+	return func(c *EvalConfig) {
 		c.outputPath = path
 	}
 }
 
 // WithLogPath sets the log file path
 func WithLogPath(path string) Option {
-	return func(c *BenchmarkConfig) {
+	return func(c *EvalConfig) {
 		c.logPath = path
 	}
 }
 
 // WithTranscriptDir sets the directory for per-task transcript files
 func WithTranscriptDir(path string) Option {
-	return func(c *BenchmarkConfig) {
+	return func(c *EvalConfig) {
 		c.transcriptDir = path
 	}
 }
 
 // Getters
-func (c *BenchmarkConfig) Spec() *models.BenchmarkSpec { return c.spec }
-func (c *BenchmarkConfig) SpecDir() string             { return c.specDir }
-func (c *BenchmarkConfig) FixtureDir() string          { return c.fixtureDir }
-func (c *BenchmarkConfig) ContextRoot() string         { return c.fixtureDir } // Alias for compatibility
-func (c *BenchmarkConfig) Verbose() bool               { return c.verbose }
-func (c *BenchmarkConfig) OutputPath() string          { return c.outputPath }
-func (c *BenchmarkConfig) LogPath() string             { return c.logPath }
-func (c *BenchmarkConfig) TranscriptDir() string       { return c.transcriptDir }
+func (c *EvalConfig) Spec() *models.EvalSpec { return c.spec }
+func (c *EvalConfig) SpecDir() string             { return c.specDir }
+func (c *EvalConfig) FixtureDir() string          { return c.fixtureDir }
+func (c *EvalConfig) ContextRoot() string         { return c.fixtureDir } // Alias for compatibility
+func (c *EvalConfig) Verbose() bool               { return c.verbose }
+func (c *EvalConfig) OutputPath() string          { return c.outputPath }
+func (c *EvalConfig) LogPath() string             { return c.logPath }
+func (c *EvalConfig) TranscriptDir() string       { return c.transcriptDir }
+
+// Deprecated: Use EvalConfig instead.
+type BenchmarkConfig = EvalConfig
+
+// Deprecated: Use NewEvalConfig instead.
+func NewBenchmarkConfig(spec *models.EvalSpec, opts ...Option) *EvalConfig {
+	return NewEvalConfig(spec, opts...)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,13 +83,13 @@ func WithTranscriptDir(path string) Option {
 
 // Getters
 func (c *EvalConfig) Spec() *models.EvalSpec { return c.spec }
-func (c *EvalConfig) SpecDir() string             { return c.specDir }
-func (c *EvalConfig) FixtureDir() string          { return c.fixtureDir }
-func (c *EvalConfig) ContextRoot() string         { return c.fixtureDir } // Alias for compatibility
-func (c *EvalConfig) Verbose() bool               { return c.verbose }
-func (c *EvalConfig) OutputPath() string          { return c.outputPath }
-func (c *EvalConfig) LogPath() string             { return c.logPath }
-func (c *EvalConfig) TranscriptDir() string       { return c.transcriptDir }
+func (c *EvalConfig) SpecDir() string        { return c.specDir }
+func (c *EvalConfig) FixtureDir() string     { return c.fixtureDir }
+func (c *EvalConfig) ContextRoot() string    { return c.fixtureDir } // Alias for compatibility
+func (c *EvalConfig) Verbose() bool          { return c.verbose }
+func (c *EvalConfig) OutputPath() string     { return c.outputPath }
+func (c *EvalConfig) LogPath() string        { return c.logPath }
+func (c *EvalConfig) TranscriptDir() string  { return c.transcriptDir }
 
 // Deprecated: Use EvalConfig instead.
 type BenchmarkConfig = EvalConfig

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/microsoft/waza/internal/models"
 )
 
-func TestNewBenchmarkConfig_DefaultValues(t *testing.T) {
-	spec := &models.BenchmarkSpec{SpecIdentity: models.SpecIdentity{Name: "test-spec"}}
+func TestNewEvalConfig_DefaultValues(t *testing.T) {
+	spec := &models.EvalSpec{SpecIdentity: models.SpecIdentity{Name: "test-spec"}}
 
-	cfg := NewBenchmarkConfig(spec)
+	cfg := NewEvalConfig(spec)
 
 	if cfg.Spec() != spec {
 		t.Fatalf("Spec() = %p, want %p", cfg.Spec(), spec)
@@ -37,10 +37,10 @@ func TestNewBenchmarkConfig_DefaultValues(t *testing.T) {
 	}
 }
 
-func TestNewBenchmarkConfig_AppliesFunctionalOptions(t *testing.T) {
-	spec := &models.BenchmarkSpec{}
+func TestNewEvalConfig_AppliesFunctionalOptions(t *testing.T) {
+	spec := &models.EvalSpec{}
 
-	cfg := NewBenchmarkConfig(
+	cfg := NewEvalConfig(
 		spec,
 		WithSpecDir("/tmp/specs"),
 		WithFixtureDir("/tmp/fixtures"),
@@ -74,7 +74,7 @@ func TestNewBenchmarkConfig_AppliesFunctionalOptions(t *testing.T) {
 }
 
 func TestWithContextRoot_Alias(t *testing.T) {
-	cfg := NewBenchmarkConfig(&models.BenchmarkSpec{}, WithContextRoot("fixtures"))
+	cfg := NewEvalConfig(&models.EvalSpec{}, WithContextRoot("fixtures"))
 
 	if cfg.FixtureDir() != "fixtures" {
 		t.Fatalf("FixtureDir() = %q, want %q", cfg.FixtureDir(), "fixtures")
@@ -85,8 +85,8 @@ func TestWithContextRoot_Alias(t *testing.T) {
 }
 
 func TestOptionOrder_LastOptionWins(t *testing.T) {
-	cfg := NewBenchmarkConfig(
-		&models.BenchmarkSpec{},
+	cfg := NewEvalConfig(
+		&models.EvalSpec{},
 		WithVerbose(true),
 		WithVerbose(false),
 		WithFixtureDir("first"),
@@ -104,8 +104,8 @@ func TestOptionOrder_LastOptionWins(t *testing.T) {
 	}
 }
 
-func TestNewBenchmarkConfig_NilSpecAllowed(t *testing.T) {
-	cfg := NewBenchmarkConfig(nil, WithOutputPath(""), WithLogPath(""), WithTranscriptDir(""))
+func TestNewEvalConfig_NilSpecAllowed(t *testing.T) {
+	cfg := NewEvalConfig(nil, WithOutputPath(""), WithLogPath(""), WithTranscriptDir(""))
 
 	if cfg.Spec() != nil {
 		t.Fatalf("Spec() = %v, want nil", cfg.Spec())
@@ -121,12 +121,12 @@ func TestNewBenchmarkConfig_NilSpecAllowed(t *testing.T) {
 	}
 }
 
-func TestNewBenchmarkConfig_NilOptionPanics(t *testing.T) {
+func TestNewEvalConfig_NilOptionPanics(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
 			t.Fatal("expected panic for nil option, got none")
 		}
 	}()
 
-	_ = NewBenchmarkConfig(&models.BenchmarkSpec{}, nil)
+	_ = NewEvalConfig(&models.EvalSpec{}, nil)
 }

--- a/internal/graders/prompt_grader_test.go
+++ b/internal/graders/prompt_grader_test.go
@@ -230,7 +230,7 @@ func TestUsingPreviousSessionID(t *testing.T) {
 }
 
 func TestLoadPromptGrader(t *testing.T) {
-	spec, err := models.LoadBenchmarkSpec("testdata/eval-grader-prompt.yaml")
+	spec, err := models.LoadEvalSpec("testdata/eval-grader-prompt.yaml")
 	require.NoError(t, err)
 
 	grader, err := Create(spec.Graders[0].Identifier, spec.Graders[0].Parameters)

--- a/internal/graders/run_test.go
+++ b/internal/graders/run_test.go
@@ -65,7 +65,7 @@ func TestApplyDefaults_OtherGrader(t *testing.T) {
 func TestEvaluateExpectations_MayInclude(t *testing.T) {
 	t.Run("passes when any match found", func(t *testing.T) {
 		tc := &models.TestCase{
-			Expectation: models.TestExpectation{
+			Expectation: models.TaskExpectation{
 				MayInclude: []string{"alpha", "beta", "gamma"},
 			},
 		}
@@ -80,7 +80,7 @@ func TestEvaluateExpectations_MayInclude(t *testing.T) {
 
 	t.Run("fails when none match", func(t *testing.T) {
 		tc := &models.TestCase{
-			Expectation: models.TestExpectation{
+			Expectation: models.TaskExpectation{
 				MayInclude: []string{"alpha", "beta"},
 			},
 		}
@@ -104,7 +104,7 @@ func TestEvaluateExpectations_MayInclude(t *testing.T) {
 func TestEvaluateExpectations_MustInclude(t *testing.T) {
 	t.Run("all present", func(t *testing.T) {
 		tc := &models.TestCase{
-			Expectation: models.TestExpectation{
+			Expectation: models.TaskExpectation{
 				MustInclude: []string{"hello", "world"},
 			},
 		}
@@ -117,7 +117,7 @@ func TestEvaluateExpectations_MustInclude(t *testing.T) {
 
 	t.Run("partial match", func(t *testing.T) {
 		tc := &models.TestCase{
-			Expectation: models.TestExpectation{
+			Expectation: models.TaskExpectation{
 				MustInclude: []string{"hello", "world"},
 			},
 		}
@@ -132,7 +132,7 @@ func TestEvaluateExpectations_MustInclude(t *testing.T) {
 func TestEvaluateExpectations_MustExclude(t *testing.T) {
 	t.Run("none present passes", func(t *testing.T) {
 		tc := &models.TestCase{
-			Expectation: models.TestExpectation{
+			Expectation: models.TaskExpectation{
 				MustExclude: []string{"error", "fail"},
 			},
 		}
@@ -145,7 +145,7 @@ func TestEvaluateExpectations_MustExclude(t *testing.T) {
 
 	t.Run("some present fails", func(t *testing.T) {
 		tc := &models.TestCase{
-			Expectation: models.TestExpectation{
+			Expectation: models.TaskExpectation{
 				MustExclude: []string{"error", "fail"},
 			},
 		}
@@ -159,7 +159,7 @@ func TestEvaluateExpectations_MustExclude(t *testing.T) {
 
 func TestEvaluateExpectations_Combined(t *testing.T) {
 	tc := &models.TestCase{
-		Expectation: models.TestExpectation{
+		Expectation: models.TaskExpectation{
 			MustInclude: []string{"result"},
 			MustExclude: []string{"error"},
 			MayInclude:  []string{"option_a", "option_b"},

--- a/internal/graders/trigger_grader_test.go
+++ b/internal/graders/trigger_grader_test.go
@@ -53,7 +53,7 @@ func TestTriggerHeuristicGrader_PositiveAndNegativeModes(t *testing.T) {
 
 		result, err := g.Grade(context.Background(), &Context{
 			TestCase: &models.TestCase{
-				Stimulus: models.TestStimulus{
+				Stimulus: models.TaskStimulus{
 					Message: "Please deploy this API to Azure and publish it.",
 				},
 			},
@@ -72,7 +72,7 @@ func TestTriggerHeuristicGrader_PositiveAndNegativeModes(t *testing.T) {
 
 		result, err := g.Grade(context.Background(), &Context{
 			TestCase: &models.TestCase{
-				Stimulus: models.TestStimulus{
+				Stimulus: models.TaskStimulus{
 					Message: "Write unit tests for my Go package.",
 				},
 			},
@@ -91,7 +91,7 @@ func TestTriggerHeuristicGrader_PositiveAndNegativeModes(t *testing.T) {
 
 		result, err := g.Grade(context.Background(), &Context{
 			TestCase: &models.TestCase{
-				Stimulus: models.TestStimulus{
+				Stimulus: models.TaskStimulus{
 					Message: "Write unit tests for my Go package.",
 				},
 			},
@@ -109,7 +109,7 @@ func TestTriggerHeuristicGrader_PositiveAndNegativeModes(t *testing.T) {
 
 		result, err := g.Grade(context.Background(), &Context{
 			TestCase: &models.TestCase{
-				Stimulus: models.TestStimulus{
+				Stimulus: models.TaskStimulus{
 					Message: "Can you deploy this app to Azure?",
 				},
 			},
@@ -132,7 +132,7 @@ func TestTriggerHeuristicGrader_ThresholdBoundary(t *testing.T) {
 
 	result, err := g.Grade(context.Background(), &Context{
 		TestCase: &models.TestCase{
-			Stimulus: models.TestStimulus{
+			Stimulus: models.TaskStimulus{
 				Message: "deploy azure",
 			},
 		},
@@ -205,7 +205,7 @@ func TestTriggerHeuristicGrader_DuplicateTokensDoNotDiluteScore(t *testing.T) {
 	// With unique-token normalization: 1 match / 1 unique token = 1.0
 	// Without normalization: 1 match / 3 tokens = 0.33 (artificially low)
 	result, err := g.Grade(context.Background(), &Context{
-		TestCase: &models.TestCase{Stimulus: models.TestStimulus{Message: "deploy deploy deploy"}},
+		TestCase: &models.TestCase{Stimulus: models.TaskStimulus{Message: "deploy deploy deploy"}},
 	})
 	require.NoError(t, err)
 	assert.True(t, result.Passed, "repeated keyword prompt should pass")
@@ -224,7 +224,7 @@ func TestTriggerHeuristicGrader_SkillPathDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	result, err := g.Grade(context.Background(), &Context{
-		TestCase: &models.TestCase{Stimulus: models.TestStimulus{Message: "deploy to azure"}},
+		TestCase: &models.TestCase{Stimulus: models.TaskStimulus{Message: "deploy to azure"}},
 	})
 	require.NoError(t, err)
 	assert.True(t, result.Passed)

--- a/internal/jsonrpc/handlers.go
+++ b/internal/jsonrpc/handlers.go
@@ -88,7 +88,7 @@ func (h *HandlerContext) handleEvalList(_ context.Context, params json.RawMessag
 		}
 		base := filepath.Base(path)
 		if base == "eval.yaml" || base == "eval.yml" {
-			spec, loadErr := models.LoadBenchmarkSpec(path)
+			spec, loadErr := models.LoadEvalSpec(path)
 			summary := EvalSummary{Path: path}
 			if loadErr == nil {
 				summary.Name = spec.Name
@@ -140,7 +140,7 @@ func (h *HandlerContext) handleEvalGet(_ context.Context, params json.RawMessage
 		return nil, ErrEvalNotFound(p.Path)
 	}
 
-	spec, err := models.LoadBenchmarkSpec(p.Path)
+	spec, err := models.LoadEvalSpec(p.Path)
 	if err != nil {
 		return nil, ErrInternalError(err.Error())
 	}
@@ -219,7 +219,7 @@ func (h *HandlerContext) handleEvalValidate(_ context.Context, params json.RawMe
 
 	// Finally, after we've validated the spec against the schema, parse the actual spec
 	// to catch any errors in our loading logic (if the schema doesn't match the implementation).
-	var spec models.BenchmarkSpec
+	var spec models.EvalSpec
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 	yerr := decoder.Decode(&spec)
@@ -274,7 +274,7 @@ func (h *HandlerContext) handleEvalRun(_ context.Context, params json.RawMessage
 	}
 
 	// Validate the spec can be loaded
-	if _, err := models.LoadBenchmarkSpec(p.Path); err != nil {
+	if _, err := models.LoadEvalSpec(p.Path); err != nil {
 		return nil, ErrValidationFailed(err.Error())
 	}
 
@@ -332,7 +332,7 @@ func (h *HandlerContext) handleTaskList(_ context.Context, params json.RawMessag
 		return nil, ErrEvalNotFound(p.Path)
 	}
 
-	spec, err := models.LoadBenchmarkSpec(p.Path)
+	spec, err := models.LoadEvalSpec(p.Path)
 	if err != nil {
 		return nil, ErrInternalError(err.Error())
 	}
@@ -379,7 +379,7 @@ func (h *HandlerContext) handleTaskGet(_ context.Context, params json.RawMessage
 		return nil, ErrEvalNotFound(p.Path)
 	}
 
-	spec, err := models.LoadBenchmarkSpec(p.Path)
+	spec, err := models.LoadEvalSpec(p.Path)
 	if err != nil {
 		return nil, ErrInternalError(err.Error())
 	}

--- a/internal/models/baseline_test.go
+++ b/internal/models/baseline_test.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestBenchmarkSpec_BaselineYAMLSerialization(t *testing.T) {
+func TestEvalSpec_BaselineYAMLSerialization(t *testing.T) {
 	tests := []struct {
 		name           string
 		yamlContent    string
@@ -67,7 +67,7 @@ tasks: []
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var spec BenchmarkSpec
+			var spec EvalSpec
 			decoder := yaml.NewDecoder(bytes.NewReader([]byte(tt.yamlContent)))
 			decoder.KnownFields(true)
 			err := decoder.Decode(&spec)

--- a/internal/models/grader_params_test.go
+++ b/internal/models/grader_params_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestLoadBenchmarkSpec_PolymorphicGraderParameters(t *testing.T) {
+func TestLoadEvalSpec_PolymorphicGraderParameters(t *testing.T) {
 	tempDir := t.TempDir()
 	yamlContent := `name: typed-graders
 skill: test-skill
@@ -38,9 +38,9 @@ tasks: []
 		t.Fatalf("write spec file: %v", err)
 	}
 
-	spec, err := LoadBenchmarkSpec(specPath)
+	spec, err := LoadEvalSpec(specPath)
 	if err != nil {
-		t.Fatalf("LoadBenchmarkSpec: %v", err)
+		t.Fatalf("LoadEvalSpec: %v", err)
 	}
 
 	textParams, ok := spec.Graders[0].Parameters.(TextGraderParameters)

--- a/internal/models/grader_validation_test.go
+++ b/internal/models/grader_validation_test.go
@@ -285,9 +285,9 @@ graders:
 				t.Fatalf("Failed to write spec file: %v", err)
 			}
 
-			_, err := LoadBenchmarkSpec(specPath)
+			_, err := LoadEvalSpec(specPath)
 			if (err != nil) != tt.expectError {
-				t.Errorf("LoadBenchmarkSpec() error = %v, expectError %v", err, tt.expectError)
+				t.Errorf("LoadEvalSpec() error = %v, expectError %v", err, tt.expectError)
 			}
 
 			if tt.expectError && err != nil && tt.errorMsg != "" {

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -10,8 +10,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// BenchmarkSpec represents a complete evaluation specification
-type BenchmarkSpec struct {
+// EvalSpec represents a complete evaluation specification.
+//
+// Deprecated alias: BenchmarkSpec is provided for backward compatibility.
+type EvalSpec struct {
 	SpecIdentity `yaml:",inline"`
 	SkillName    string            `yaml:"skill"`
 	Version      string            `yaml:"version"`
@@ -247,23 +249,23 @@ type MeasurementDef struct {
 	Desc       string  `yaml:"description,omitempty" json:"desc,omitempty"`
 }
 
-// LoadBenchmarkSpec loads a spec from a YAML file with strict validation.
+// LoadEvalSpec loads a spec from a YAML file with strict validation.
 //
 // Normally the schema validation will catch errors in the eval.yaml, but this also does
 // strict YAML parsing to catch errors like unknown fields or type errors that the schema
 // validation might miss.
-func LoadBenchmarkSpec(path string) (*BenchmarkSpec, error) {
+func LoadEvalSpec(path string) (*EvalSpec, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var spec BenchmarkSpec
+	var spec EvalSpec
 
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&spec); err != nil {
-		return nil, fmt.Errorf("parsing benchmark spec YAML (%s): %w", path, err)
+		return nil, fmt.Errorf("parsing eval spec YAML (%s): %w", path, err)
 	}
 
 	// Validate spec
@@ -275,7 +277,7 @@ func LoadBenchmarkSpec(path string) (*BenchmarkSpec, error) {
 }
 
 // Validate checks that the spec is valid
-func (s *BenchmarkSpec) Validate() error {
+func (s *EvalSpec) Validate() error {
 	if s.Config.TrialsPerTask < 1 {
 		return fmt.Errorf("trials_per_task must be at least 1, got %d", s.Config.TrialsPerTask)
 	}
@@ -286,7 +288,7 @@ func (s *BenchmarkSpec) Validate() error {
 }
 
 // ResolveTestFiles expands glob patterns to actual test files
-func (s *BenchmarkSpec) ResolveTestFiles(basePath string) ([]string, error) {
+func (s *EvalSpec) ResolveTestFiles(basePath string) ([]string, error) {
 	var files []string
 	for _, pattern := range s.Tasks {
 		fullPattern := filepath.Join(basePath, pattern)
@@ -297,4 +299,12 @@ func (s *BenchmarkSpec) ResolveTestFiles(basePath string) ([]string, error) {
 		files = append(files, matches...)
 	}
 	return files, nil
+}
+
+// Deprecated: Use EvalSpec instead.
+type BenchmarkSpec = EvalSpec
+
+// Deprecated: Use LoadEvalSpec instead.
+func LoadBenchmarkSpec(path string) (*EvalSpec, error) {
+	return LoadEvalSpec(path)
 }

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestLoadBenchmarkSpec_StrictYAML(t *testing.T) {
+func TestLoadEvalSpec_StrictYAML(t *testing.T) {
 	tests := []struct {
 		name        string
 		specYAML    string
@@ -60,15 +60,15 @@ config:
 			if err := os.WriteFile(specPath, []byte(tt.specYAML), 0644); err != nil {
 				t.Fatalf("Failed to write spec file: %v", err)
 			}
-			_, err := LoadBenchmarkSpec(specPath)
+			_, err := LoadEvalSpec(specPath)
 			if (err != nil) != tt.expectError {
-				t.Errorf("LoadBenchmarkSpec() error = %v, expectError %v", err, tt.expectError)
+				t.Errorf("LoadEvalSpec() error = %v, expectError %v", err, tt.expectError)
 			}
 		})
 	}
 }
 
-func TestBenchmarkSpec_LoadFromYAML(t *testing.T) {
+func TestEvalSpec_LoadFromYAML(t *testing.T) {
 	// Create temp YAML file
 	tempDir := t.TempDir()
 	yamlContent := `name: test-benchmark
@@ -87,7 +87,7 @@ config:
 	}
 
 	// Load spec
-	spec, err := LoadBenchmarkSpec(specPath)
+	spec, err := LoadEvalSpec(specPath)
 	if err != nil {
 		t.Fatalf("Failed to load spec: %v", err)
 	}
@@ -141,7 +141,7 @@ enabled: true
 	}
 }
 
-func TestBenchmarkSpec_InputsDeserialization(t *testing.T) {
+func TestEvalSpec_InputsDeserialization(t *testing.T) {
 	tempDir := t.TempDir()
 	yamlContent := `name: inputs-test
 skill: test-skill
@@ -159,7 +159,7 @@ inputs:
 		t.Fatalf("Failed to write spec file: %v", err)
 	}
 
-	spec, err := LoadBenchmarkSpec(specPath)
+	spec, err := LoadEvalSpec(specPath)
 	if err != nil {
 		t.Fatalf("Failed to load spec: %v", err)
 	}
@@ -180,7 +180,7 @@ inputs:
 	}
 }
 
-func TestBenchmarkSpec_InputsOmittedWhenEmpty(t *testing.T) {
+func TestEvalSpec_InputsOmittedWhenEmpty(t *testing.T) {
 	tempDir := t.TempDir()
 	yamlContent := `name: no-inputs
 skill: test-skill
@@ -194,7 +194,7 @@ config:
 		t.Fatalf("Failed to write spec file: %v", err)
 	}
 
-	spec, err := LoadBenchmarkSpec(specPath)
+	spec, err := LoadEvalSpec(specPath)
 	if err != nil {
 		t.Fatalf("Failed to load spec: %v", err)
 	}
@@ -204,7 +204,7 @@ config:
 	}
 }
 
-func TestBenchmarkSpec_DefaultValues(t *testing.T) {
+func TestEvalSpec_DefaultValues(t *testing.T) {
 	tempDir := t.TempDir()
 	// Minimal YAML - defaults need to be set by loader
 	yamlContent := `name: minimal
@@ -219,7 +219,7 @@ config:
 		t.Fatalf("Failed to write spec file: %v", err)
 	}
 
-	spec, err := LoadBenchmarkSpec(specPath)
+	spec, err := LoadEvalSpec(specPath)
 	if err != nil {
 		t.Fatalf("Failed to load spec: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestGraderConfig_EffectiveWeight(t *testing.T) {
 	}
 }
 
-func TestBenchmarkSpec_GraderWeight(t *testing.T) {
+func TestEvalSpec_GraderWeight(t *testing.T) {
 	tempDir := t.TempDir()
 	yamlContent := `name: weighted-graders
 skill: test
@@ -283,7 +283,7 @@ graders:
 		t.Fatalf("Failed to write spec file: %v", err)
 	}
 
-	spec, err := LoadBenchmarkSpec(specPath)
+	spec, err := LoadEvalSpec(specPath)
 	if err != nil {
 		t.Fatalf("Failed to load spec: %v", err)
 	}
@@ -308,7 +308,7 @@ graders:
 	}
 }
 
-func TestBenchmarkSpec_JudgeModel(t *testing.T) {
+func TestEvalSpec_JudgeModel(t *testing.T) {
 	tempDir := t.TempDir()
 
 	t.Run("parses judge_model from YAML", func(t *testing.T) {
@@ -326,7 +326,7 @@ config:
 			t.Fatalf("Failed to write spec file: %v", err)
 		}
 
-		spec, err := LoadBenchmarkSpec(specPath)
+		spec, err := LoadEvalSpec(specPath)
 		if err != nil {
 			t.Fatalf("Failed to load spec: %v", err)
 		}
@@ -353,7 +353,7 @@ config:
 			t.Fatalf("Failed to write spec file: %v", err)
 		}
 
-		spec, err := LoadBenchmarkSpec(specPath)
+		spec, err := LoadEvalSpec(specPath)
 		if err != nil {
 			t.Fatalf("Failed to load spec: %v", err)
 		}
@@ -414,7 +414,7 @@ func TestConfig_FilteredSkillPaths(t *testing.T) {
 	}
 }
 
-func TestBenchmarkSpec_DisabledSkillsDeserialization(t *testing.T) {
+func TestEvalSpec_DisabledSkillsDeserialization(t *testing.T) {
 	t.Run("wildcard", func(t *testing.T) {
 		tempDir := t.TempDir()
 		yamlStr := `name: test-disabled
@@ -437,7 +437,7 @@ tasks:
 		if err := os.WriteFile(p, []byte(yamlStr), 0644); err != nil {
 			t.Fatal(err)
 		}
-		spec, err := LoadBenchmarkSpec(p)
+		spec, err := LoadEvalSpec(p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -469,7 +469,7 @@ tasks:
 		if err := os.WriteFile(p, []byte(yamlStr), 0644); err != nil {
 			t.Fatal(err)
 		}
-		spec, err := LoadBenchmarkSpec(p)
+		spec, err := LoadEvalSpec(p)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -15,9 +15,9 @@ type TestCase struct {
 	Active      *bool             `yaml:"enabled,omitempty" json:"active,omitempty"`
 	ContextRoot string            `yaml:"context_dir,omitempty" json:"context_root,omitempty"`
 	DisplayName string            `yaml:"name" json:"display_name"`
-	Expectation TestExpectation   `yaml:"expected,omitempty" json:"expectation,omitempty"`
+	Expectation TaskExpectation   `yaml:"expected,omitempty" json:"expectation,omitempty"`
 	SkillPaths  []string          `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
-	Stimulus    TestStimulus      `yaml:"inputs" json:"stimulus"`
+	Stimulus    TaskStimulus      `yaml:"inputs" json:"stimulus"`
 	Summary     string            `yaml:"description,omitempty" json:"summary,omitempty"`
 	Tags        []string          `yaml:"tags,omitempty" json:"labels,omitempty"`
 	TestID      string            `yaml:"id" json:"test_id"`
@@ -25,8 +25,10 @@ type TestCase struct {
 	Validators  []ValidatorInline `yaml:"graders,omitempty" json:"validators,omitempty"`
 }
 
-// TestStimulus defines the input for a test
-type TestStimulus struct {
+// TaskStimulus defines the input for a task.
+//
+// Deprecated alias: TestStimulus is provided for backward compatibility.
+type TaskStimulus struct {
 	Message     string            `yaml:"prompt" json:"message"`
 	MessageFile string            `yaml:"prompt_file,omitempty" json:"message_file,omitempty"`
 	Metadata    map[string]any    `yaml:"context,omitempty" json:"metadata,omitempty"`
@@ -41,8 +43,10 @@ type ResourceRef struct {
 	Body     string `yaml:"content,omitempty" json:"body,omitempty"`
 }
 
-// TestExpectation defines expected outcomes
-type TestExpectation struct {
+// TaskExpectation defines expected outcomes.
+//
+// Deprecated alias: TestExpectation is provided for backward compatibility.
+type TaskExpectation struct {
 	OutcomeSpecs    []OutcomeSpec  `yaml:"outcomes,omitempty" json:"outcome_specs,omitempty"`
 	ToolPatterns    map[string]any `yaml:"tool_calls,omitempty" json:"tool_patterns,omitempty"`
 	BehaviorRules   BehaviorRules  `yaml:"behavior,omitempty" json:"behavior_rules,omitempty"`
@@ -247,7 +251,7 @@ func LoadTestCase(path string) (*TestCase, error) {
 // resolvePromptFile loads prompt content from a file if prompt_file is set.
 // The path is resolved relative to baseDir. Absolute and traversal paths are
 // rejected, consistent with resource path validation in the runner.
-func (s *TestStimulus) resolvePromptFile(baseDir string) error {
+func (s *TaskStimulus) resolvePromptFile(baseDir string) error {
 	if s.MessageFile == "" {
 		return nil
 	}
@@ -275,3 +279,9 @@ func (s *TestStimulus) resolvePromptFile(baseDir string) error {
 	s.MessageFile = "" // clear to avoid leaking file paths in serialized output
 	return nil
 }
+
+// Deprecated: Use TaskStimulus instead.
+type TestStimulus = TaskStimulus
+
+// Deprecated: Use TaskExpectation instead.
+type TestExpectation = TaskExpectation

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -131,7 +131,7 @@ expected:
 }
 
 // TestLoadTestCase_FollowUpPrompts was removed: it referenced
-// TestStimulus.FollowUps which does not exist. Re-add when that
+// TaskStimulus.FollowUps which does not exist. Re-add when that
 // field is implemented.
 
 func TestLoadTestCase_SkillDirectories(t *testing.T) {

--- a/internal/orchestration/baseline_test.go
+++ b/internal/orchestration/baseline_test.go
@@ -242,7 +242,7 @@ func TestComputeSkillImpact(t *testing.T) {
 func TestRunBenchmark_BaselineNoSkills(t *testing.T) {
 	t.Skip("Requires baseline implementation and task loading setup")
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-eval",
 		},
@@ -257,9 +257,9 @@ func TestRunBenchmark_BaselineNoSkills(t *testing.T) {
 		Tasks: []string{"task-001.yaml"},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec)
+	cfg := config.NewEvalConfig(spec)
 	engine := execution.NewMockEngine("gpt-4")
-	runner := NewTestRunner(cfg, engine)
+	runner := NewEvalRunner(cfg, engine)
 
 	ctx := context.Background()
 	outcome, err := runner.RunBenchmark(ctx)
@@ -280,7 +280,7 @@ func TestRunBenchmark_BaselineWithSkills(t *testing.T) {
 
 	tmpSkillDir := t.TempDir()
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-eval",
 		},
@@ -296,9 +296,9 @@ func TestRunBenchmark_BaselineWithSkills(t *testing.T) {
 		Tasks: []string{"task-001.yaml"},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec)
+	cfg := config.NewEvalConfig(spec)
 	engine := execution.NewMockEngine("gpt-4")
-	runner := NewTestRunner(cfg, engine)
+	runner := NewEvalRunner(cfg, engine)
 
 	ctx := context.Background()
 	outcome, err := runner.RunBenchmark(ctx)
@@ -324,7 +324,7 @@ func TestRunBenchmark_BaselineEmptyTasks(t *testing.T) {
 
 	tmpSkillDir := t.TempDir()
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-eval",
 		},
@@ -340,9 +340,9 @@ func TestRunBenchmark_BaselineEmptyTasks(t *testing.T) {
 		Tasks: []string{},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec)
+	cfg := config.NewEvalConfig(spec)
 	engine := execution.NewMockEngine("gpt-4")
-	runner := NewTestRunner(cfg, engine)
+	runner := NewEvalRunner(cfg, engine)
 
 	ctx := context.Background()
 	outcome, err := runner.RunBenchmark(ctx)
@@ -356,7 +356,7 @@ func TestRunBenchmark_BaselineEmptyTasks(t *testing.T) {
 
 // TestMergeBaselineOutcomes_TaskMismatch tests error handling when task sets don't align
 func TestMergeBaselineOutcomes_TaskMismatch(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-eval",
 		},
@@ -369,8 +369,8 @@ func TestMergeBaselineOutcomes_TaskMismatch(t *testing.T) {
 		},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, nil)
 
 	withSkills := &models.EvaluationOutcome{
 		TestOutcomes: []models.TestOutcome{
@@ -394,7 +394,7 @@ func TestMergeBaselineOutcomes_TaskMismatch(t *testing.T) {
 
 // TestMergeBaselineOutcomes_ExtraTaskInBaseline tests error when baseline has tasks not in skills-enabled
 func TestMergeBaselineOutcomes_ExtraTaskInBaseline(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-eval",
 		},
@@ -407,8 +407,8 @@ func TestMergeBaselineOutcomes_ExtraTaskInBaseline(t *testing.T) {
 		},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, nil)
 
 	withSkills := &models.EvaluationOutcome{
 		TestOutcomes: []models.TestOutcome{
@@ -432,7 +432,7 @@ func TestMergeBaselineOutcomes_ExtraTaskInBaseline(t *testing.T) {
 
 // TestMergeBaselineOutcomes_Success tests successful outcome merging
 func TestMergeBaselineOutcomes_Success(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-eval",
 		},
@@ -445,8 +445,8 @@ func TestMergeBaselineOutcomes_Success(t *testing.T) {
 		},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, nil)
 
 	withSkills := &models.EvaluationOutcome{
 		RunID:       "eval-001",

--- a/internal/orchestration/csv_integration_test.go
+++ b/internal/orchestration/csv_integration_test.go
@@ -22,12 +22,12 @@ func TestLoadTestCasesFromCSV_BasicLoading(t *testing.T) {
 	tmpDir := t.TempDir()
 	writeCSV(t, tmpDir, "data.csv", "id,prompt\nA,hello\nB,world\nC,foo\n")
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		TasksFrom: "data.csv",
 		Config:    models.Config{ModelID: "test-model"},
 	}
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+	runner := NewEvalRunner(cfg, nil)
 
 	cases, err := runner.loadTestCasesFromCSV()
 	require.NoError(t, err)
@@ -42,12 +42,12 @@ func TestLoadTestCasesFromCSV_TemplateResolution(t *testing.T) {
 	tmpDir := t.TempDir()
 	writeCSV(t, tmpDir, "data.csv", "id,lang,prompt\n1,Go,Explain {{.Vars.lang}}\n2,Rust,Explain {{.Vars.lang}}\n")
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		TasksFrom: "data.csv",
 		Config:    models.Config{ModelID: "test-model"},
 	}
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+	runner := NewEvalRunner(cfg, nil)
 
 	cases, err := runner.loadTestCasesFromCSV()
 	require.NoError(t, err)
@@ -60,13 +60,13 @@ func TestLoadTestCasesFromCSV_RangeFiltering(t *testing.T) {
 	tmpDir := t.TempDir()
 	writeCSV(t, tmpDir, "data.csv", "id,prompt\nA,one\nB,two\nC,three\nD,four\nE,five\n")
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		TasksFrom: "data.csv",
 		Range:     [2]int{2, 4},
 		Config:    models.Config{ModelID: "test-model"},
 	}
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+	runner := NewEvalRunner(cfg, nil)
 
 	cases, err := runner.loadTestCasesFromCSV()
 	require.NoError(t, err)
@@ -91,13 +91,13 @@ func TestLoadTestCasesFromCSV_InvalidRange(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := &models.BenchmarkSpec{
+			spec := &models.EvalSpec{
 				TasksFrom: "data.csv",
 				Range:     tt.rng,
 				Config:    models.Config{ModelID: "test-model"},
 			}
-			cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-			runner := NewTestRunner(cfg, nil)
+			cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+			runner := NewEvalRunner(cfg, nil)
 
 			_, err := runner.loadTestCasesFromCSV()
 			require.Error(t, err)
@@ -112,12 +112,12 @@ func TestLoadTestCasesFromCSV_PathTraversal(t *testing.T) {
 	parentDir := filepath.Dir(tmpDir)
 	writeCSV(t, parentDir, "escape.csv", "id,prompt\nA,bad\n")
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		TasksFrom: "../escape.csv",
 		Config:    models.Config{ModelID: "test-model"},
 	}
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+	runner := NewEvalRunner(cfg, nil)
 
 	_, err := runner.loadTestCasesFromCSV()
 	require.Error(t, err)

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -25,9 +25,11 @@ import (
 	copilot "github.com/github/copilot-sdk/go"
 )
 
-// TestRunner orchestrates the execution of tests
-type TestRunner struct {
-	cfg     *config.BenchmarkConfig
+// EvalRunner orchestrates the execution of tests.
+//
+// Deprecated alias: TestRunner is provided for backward compatibility.
+type EvalRunner struct {
+	cfg     *config.EvalConfig
 	engine  execution.AgentEngine
 	verbose bool
 
@@ -88,46 +90,46 @@ type ProgressEvent struct {
 	Details    map[string]any
 }
 
-// RunnerOption configures a TestRunner.
-type RunnerOption func(*TestRunner)
+// RunnerOption configures a EvalRunner.
+type RunnerOption func(*EvalRunner)
 
 // WithTaskFilters sets glob patterns used to filter test cases by DisplayName or TestID.
 func WithTaskFilters(patterns ...string) RunnerOption {
-	return func(r *TestRunner) {
+	return func(r *EvalRunner) {
 		r.taskFilters = patterns
 	}
 }
 
 func WithTagFilters(patterns ...string) RunnerOption {
-	return func(r *TestRunner) {
+	return func(r *EvalRunner) {
 		r.tagFilters = patterns
 	}
 }
 
 // WithCache enables result caching
 func WithCache(c *cache.Cache) RunnerOption {
-	return func(r *TestRunner) {
+	return func(r *EvalRunner) {
 		r.cache = c
 	}
 }
 
 // WithUpdateSnapshots enables snapshot file updates in diff graders.
 func WithUpdateSnapshots(enabled bool) RunnerOption {
-	return func(r *TestRunner) {
+	return func(r *EvalRunner) {
 		r.updateSnapshots = enabled
 	}
 }
 
 // WithSkipGraders disables grading so only execution occurs.
 func WithSkipGraders() RunnerOption {
-	return func(r *TestRunner) {
+	return func(r *EvalRunner) {
 		r.skipGraders = true
 	}
 }
 
-// NewTestRunner creates a new test runner. The caller owns the engine and is responsible for initializing and shutting it down as needed.
-func NewTestRunner(cfg *config.BenchmarkConfig, engine execution.AgentEngine, opts ...RunnerOption) *TestRunner {
-	r := &TestRunner{
+// NewEvalRunner creates a new test runner. The caller owns the engine and is responsible for initializing and shutting it down as needed.
+func NewEvalRunner(cfg *config.EvalConfig, engine execution.AgentEngine, opts ...RunnerOption) *EvalRunner {
+	r := &EvalRunner{
 		cfg:       cfg,
 		engine:    engine,
 		verbose:   cfg.Verbose(),
@@ -140,7 +142,7 @@ func NewTestRunner(cfg *config.BenchmarkConfig, engine execution.AgentEngine, op
 }
 
 // OnProgress registers a progress listener
-func (r *TestRunner) OnProgress(listener ProgressListener) {
+func (r *EvalRunner) OnProgress(listener ProgressListener) {
 	r.progressMu.Lock()
 	defer r.progressMu.Unlock()
 	r.listeners = append(r.listeners, listener)
@@ -161,7 +163,7 @@ func testOutcomeDetails(o *models.TestOutcome) map[string]any {
 	}
 }
 
-func (r *TestRunner) notifyProgress(event ProgressEvent) {
+func (r *EvalRunner) notifyProgress(event ProgressEvent) {
 	r.progressMu.Lock()
 	listeners := make([]ProgressListener, len(r.listeners))
 	copy(listeners, r.listeners)
@@ -174,7 +176,7 @@ func (r *TestRunner) notifyProgress(event ProgressEvent) {
 
 // RunBenchmark executes the entire benchmark
 // If Baseline is enabled, runs twice: skills-enabled and skills-disabled
-func (r *TestRunner) RunBenchmark(ctx context.Context) (*models.EvaluationOutcome, error) {
+func (r *EvalRunner) RunBenchmark(ctx context.Context) (*models.EvaluationOutcome, error) {
 
 	if err := r.engine.Initialize(ctx); err != nil {
 		return nil, err
@@ -190,7 +192,7 @@ func (r *TestRunner) RunBenchmark(ctx context.Context) (*models.EvaluationOutcom
 }
 
 // runNormalBenchmark executes a normal single-pass evaluation
-func (r *TestRunner) runNormalBenchmark(ctx context.Context) (*models.EvaluationOutcome, error) {
+func (r *EvalRunner) runNormalBenchmark(ctx context.Context) (*models.EvaluationOutcome, error) {
 	startTime := time.Now()
 
 	// Set up hooks runner
@@ -286,7 +288,7 @@ func (r *TestRunner) runNormalBenchmark(ctx context.Context) (*models.Evaluation
 }
 
 // runBaselineComparison orchestrates A/B testing: skills-enabled vs skills-disabled
-func (r *TestRunner) runBaselineComparison(ctx context.Context) (*models.EvaluationOutcome, error) {
+func (r *EvalRunner) runBaselineComparison(ctx context.Context) (*models.EvaluationOutcome, error) {
 	spec := r.cfg.Spec()
 
 	// Validation: eval must have skills configured
@@ -331,7 +333,7 @@ func (r *TestRunner) runBaselineComparison(ctx context.Context) (*models.Evaluat
 }
 
 // mergeBaselineOutcomes pairs task results and computes skill impact
-func (r *TestRunner) mergeBaselineOutcomes(
+func (r *EvalRunner) mergeBaselineOutcomes(
 	withSkills, withoutSkills *models.EvaluationOutcome,
 ) (*models.EvaluationOutcome, error) {
 
@@ -409,7 +411,7 @@ func computePassRate(outcome *models.TestOutcome) float64 {
 }
 
 // printSkillImpactReport prints the A/B comparison summary
-func (r *TestRunner) printSkillImpactReport(withSkills, withoutSkills *models.EvaluationOutcome) {
+func (r *EvalRunner) printSkillImpactReport(withSkills, withoutSkills *models.EvaluationOutcome) {
 	fmt.Println("\n════════════════════════════════════════════════════════════════")
 	fmt.Println("SKILL IMPACT ANALYSIS")
 	fmt.Println("════════════════════════════════════════════════════════════════")
@@ -475,7 +477,7 @@ func (r *TestRunner) printSkillImpactReport(withSkills, withoutSkills *models.Ev
 	fmt.Println("════════════════════════════════════════════════════════════════")
 }
 
-func (r *TestRunner) loadTestCases() ([]*models.TestCase, error) {
+func (r *EvalRunner) loadTestCases() ([]*models.TestCase, error) {
 	spec := r.cfg.Spec()
 
 	// CSV dataset path: generate tasks from CSV rows
@@ -488,7 +490,7 @@ func (r *TestRunner) loadTestCases() ([]*models.TestCase, error) {
 }
 
 // loadTestCasesFromCSV generates in-memory TestCases from CSV rows.
-func (r *TestRunner) loadTestCasesFromCSV() ([]*models.TestCase, error) {
+func (r *EvalRunner) loadTestCasesFromCSV() ([]*models.TestCase, error) {
 	spec := r.cfg.Spec()
 
 	// Resolve CSV path relative to spec directory
@@ -590,7 +592,7 @@ func (r *TestRunner) loadTestCasesFromCSV() ([]*models.TestCase, error) {
 		tc := &models.TestCase{
 			TestID:      testID,
 			DisplayName: displayName,
-			Stimulus: models.TestStimulus{
+			Stimulus: models.TaskStimulus{
 				Message: prompt,
 			},
 		}
@@ -601,7 +603,7 @@ func (r *TestRunner) loadTestCasesFromCSV() ([]*models.TestCase, error) {
 }
 
 // loadTestCasesFromFiles loads test cases from YAML files via glob patterns.
-func (r *TestRunner) loadTestCasesFromFiles() ([]*models.TestCase, error) {
+func (r *EvalRunner) loadTestCasesFromFiles() ([]*models.TestCase, error) {
 	spec := r.cfg.Spec()
 
 	// Get base directory for test file resolution (spec directory)
@@ -642,7 +644,7 @@ func (r *TestRunner) loadTestCasesFromFiles() ([]*models.TestCase, error) {
 }
 
 // validateRequiredSkills performs preflight validation that all required skills are present.
-func (r *TestRunner) validateRequiredSkills() error {
+func (r *EvalRunner) validateRequiredSkills() error {
 	spec := r.cfg.Spec()
 
 	// If all skills are disabled, skip validation
@@ -688,7 +690,7 @@ func (r *TestRunner) validateRequiredSkills() error {
 	return nil
 }
 
-func (r *TestRunner) runSequential(ctx context.Context, testCases []*models.TestCase) []models.TestOutcome {
+func (r *EvalRunner) runSequential(ctx context.Context, testCases []*models.TestCase) []models.TestOutcome {
 	outcomes := make([]models.TestOutcome, 0, len(testCases))
 	spec := r.cfg.Spec()
 
@@ -773,7 +775,7 @@ func (r *TestRunner) runSequential(ctx context.Context, testCases []*models.Test
 	return outcomes
 }
 
-func (r *TestRunner) runConcurrent(ctx context.Context, testCases []*models.TestCase) []models.TestOutcome {
+func (r *EvalRunner) runConcurrent(ctx context.Context, testCases []*models.TestCase) []models.TestOutcome {
 	// Simple concurrent implementation
 	spec := r.cfg.Spec()
 	workers := spec.Config.Workers
@@ -874,7 +876,7 @@ func (r *TestRunner) runConcurrent(ctx context.Context, testCases []*models.Test
 	return results
 }
 
-func (r *TestRunner) runTest(ctx context.Context, tc *models.TestCase, testNum, totalTests int) (models.TestOutcome, bool) {
+func (r *EvalRunner) runTest(ctx context.Context, tc *models.TestCase, testNum, totalTests int) (models.TestOutcome, bool) {
 	spec := r.cfg.Spec()
 
 	// Check cache if enabled
@@ -899,7 +901,7 @@ func (r *TestRunner) runTest(ctx context.Context, tc *models.TestCase, testNum, 
 	return r.runTestUncached(ctx, tc, testNum, totalTests), false
 }
 
-func (r *TestRunner) writeTaskTranscript(tc *models.TestCase, outcome models.TestOutcome, startTime time.Time) {
+func (r *EvalRunner) writeTaskTranscript(tc *models.TestCase, outcome models.TestOutcome, startTime time.Time) {
 	transcriptDir := r.cfg.TranscriptDir()
 	if transcriptDir == "" {
 		return
@@ -911,7 +913,7 @@ func (r *TestRunner) writeTaskTranscript(tc *models.TestCase, outcome models.Tes
 	}
 }
 
-func (r *TestRunner) runTestUncached(ctx context.Context, tc *models.TestCase, testNum, totalTests int) models.TestOutcome {
+func (r *EvalRunner) runTestUncached(ctx context.Context, tc *models.TestCase, testNum, totalTests int) models.TestOutcome {
 	spec := r.cfg.Spec()
 	runsPerTest := spec.Config.TrialsPerTask
 	maxAttempts := spec.Config.MaxAttempts
@@ -1007,7 +1009,7 @@ func overallStatus(runs []models.RunResult) models.Status {
 	return status
 }
 
-func (r *TestRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum int) models.RunResult {
+func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum int) models.RunResult {
 	startTime := time.Now()
 
 	// Prepare execution request
@@ -1131,7 +1133,7 @@ func (r *TestRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 	}
 }
 
-func (r *TestRunner) buildExecutionRequest(tc *models.TestCase) *execution.ExecutionRequest {
+func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) *execution.ExecutionRequest {
 	// Load resource files
 	resources := r.loadResources(tc)
 
@@ -1163,7 +1165,7 @@ func (r *TestRunner) buildExecutionRequest(tc *models.TestCase) *execution.Execu
 
 // executeFollowUps sends follow-up prompts using the same workspace and session,
 // aggregating results into the original response.
-func (r *TestRunner) executeFollowUps(ctx context.Context, tc *models.TestCase, resp *execution.ExecutionResponse) {
+func (r *EvalRunner) executeFollowUps(ctx context.Context, tc *models.TestCase, resp *execution.ExecutionResponse) {
 	for i, prompt := range tc.Stimulus.FollowUps {
 		followReq := r.buildExecutionRequest(tc)
 		followReq.Message = prompt
@@ -1206,7 +1208,7 @@ func (r *TestRunner) executeFollowUps(ctx context.Context, tc *models.TestCase, 
 	}
 }
 
-func (r *TestRunner) loadResources(tc *models.TestCase) []execution.ResourceFile {
+func (r *EvalRunner) loadResources(tc *models.TestCase) []execution.ResourceFile {
 	var resources []execution.ResourceFile
 
 	// Determine fixture directory (for loading resource files)
@@ -1290,7 +1292,7 @@ func convertMCPServers(serverConfigs map[string]any) map[string]copilot.MCPServe
 	return result
 }
 
-func (r *TestRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse) *graders.Context {
+func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse) *graders.Context {
 	// Convert events to transcript entries
 	var transcript []models.TranscriptEvent
 	for _, evt := range resp.Events {
@@ -1315,12 +1317,12 @@ func (r *TestRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 	}
 }
 
-func (r *TestRunner) runGraders(ctx context.Context, tc *models.TestCase, gradersContext *graders.Context) (map[string]models.GraderResults, error) {
+func (r *EvalRunner) runGraders(ctx context.Context, tc *models.TestCase, gradersContext *graders.Context) (map[string]models.GraderResults, error) {
 	spec := r.cfg.Spec()
 	return graders.RunAll(ctx, spec.Graders, tc, gradersContext, spec.Config.JudgeModel, r.updateSnapshots)
 }
 
-func (r *TestRunner) buildSessionDigest(resp *execution.ExecutionResponse) models.SessionDigest {
+func (r *EvalRunner) buildSessionDigest(resp *execution.ExecutionResponse) models.SessionDigest {
 	toolsUsed := make([]string, 0)
 	for _, call := range resp.ToolCalls {
 		toolsUsed = append(toolsUsed, call.Name)
@@ -1338,13 +1340,13 @@ func (r *TestRunner) buildSessionDigest(resp *execution.ExecutionResponse) model
 	return digest
 }
 
-func (r *TestRunner) buildTranscript(resp *execution.ExecutionResponse) []models.TranscriptEvent {
+func (r *EvalRunner) buildTranscript(resp *execution.ExecutionResponse) []models.TranscriptEvent {
 	return transcript.BuildFromSessionEvents(resp.Events)
 }
 
 // resolveGroup returns the group value for the current benchmark configuration.
 // Currently only "model" is supported; CSV column grouping will be added with #187.
-func (r *TestRunner) resolveGroup() string {
+func (r *EvalRunner) resolveGroup() string {
 	spec := r.cfg.Spec()
 	switch spec.Config.GroupBy {
 	case "model":
@@ -1355,4 +1357,12 @@ func (r *TestRunner) resolveGroup() string {
 		fmt.Printf("[WARN] unknown group_by value %q, grouping disabled\n", spec.Config.GroupBy)
 		return ""
 	}
+}
+
+// Deprecated: Use EvalRunner instead.
+type TestRunner = EvalRunner
+
+// Deprecated: Use NewEvalRunner instead.
+func NewTestRunner(cfg *config.EvalConfig, engine execution.AgentEngine, opts ...RunnerOption) *EvalRunner {
+	return NewEvalRunner(cfg, engine, opts...)
 }

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -63,7 +63,7 @@ graders:
         - "Mock response"
 `)
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "orchestration-sequential"},
 		SkillName:    "test-skill",
 		Config: models.Config{
@@ -84,8 +84,8 @@ graders:
 		Tasks: []string{"tasks/*.yaml"},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir), config.WithFixtureDir(fixtureDir))
-	runner := NewTestRunner(cfg, execution.NewMockEngine("mock-model"))
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir), config.WithFixtureDir(fixtureDir))
+	runner := NewEvalRunner(cfg, execution.NewMockEngine("mock-model"))
 
 	var events []ProgressEvent
 	runner.OnProgress(func(event ProgressEvent) {
@@ -159,7 +159,7 @@ inputs:
   prompt: "second"
 `)
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "orchestration-concurrent"},
 		SkillName:    "test-skill",
 		Config: models.Config{
@@ -180,8 +180,8 @@ inputs:
 		Tasks: []string{"tasks/*.yaml"},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-	runner := NewTestRunner(cfg, execution.NewMockEngine("mock-model"))
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+	runner := NewEvalRunner(cfg, execution.NewMockEngine("mock-model"))
 
 	outcome, err := runner.RunBenchmark(context.Background())
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ inputs:
   prompt: "run without grading"
 `)
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "skip-graders"},
 		SkillName:    "test-skill",
 		Config: models.Config{
@@ -213,8 +213,8 @@ inputs:
 		Tasks: []string{"tasks/*.yaml"},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-	runner := NewTestRunner(cfg, execution.NewMockEngine("mock-model"), WithSkipGraders())
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+	runner := NewEvalRunner(cfg, execution.NewMockEngine("mock-model"), WithSkipGraders())
 
 	outcome, err := runner.RunBenchmark(context.Background())
 	require.NoError(t, err)
@@ -263,7 +263,7 @@ func TestOverallStatus(t *testing.T) {
 }
 
 func TestRunGraders_WeightsAndErrors(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		Config: models.Config{ModelID: "mock-model"},
 		Graders: []models.GraderConfig{
 			{
@@ -274,7 +274,7 @@ func TestRunGraders_WeightsAndErrors(t *testing.T) {
 			},
 		},
 	}
-	runner := NewTestRunner(config.NewBenchmarkConfig(spec), nil)
+	runner := NewEvalRunner(config.NewEvalConfig(spec), nil)
 	graderCtx := &graders.Context{Output: "Mock response"}
 
 	testCase := &models.TestCase{
@@ -312,7 +312,7 @@ func TestRunGraders_DiffSnapshotUpdateOption(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(workspaceDir, "output.txt"), []byte("new snapshot"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "expected.txt"), []byte("old snapshot"), 0o644))
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		Config: models.Config{ModelID: "mock-model"},
 		Graders: []models.GraderConfig{
 			{
@@ -331,7 +331,7 @@ func TestRunGraders_DiffSnapshotUpdateOption(t *testing.T) {
 		},
 	}
 
-	runner := NewTestRunner(config.NewBenchmarkConfig(spec), nil, WithUpdateSnapshots(true))
+	runner := NewEvalRunner(config.NewEvalConfig(spec), nil, WithUpdateSnapshots(true))
 	graderCtx := &graders.Context{WorkspaceDir: workspaceDir}
 
 	results, err := runner.runGraders(context.Background(), &models.TestCase{}, graderCtx)
@@ -347,12 +347,12 @@ func TestLoadResources_PathValidation(t *testing.T) {
 	fixtureDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(fixtureDir, "ok.txt"), []byte("ok"), 0o644))
 
-	spec := &models.BenchmarkSpec{}
-	cfg := config.NewBenchmarkConfig(spec, config.WithFixtureDir(fixtureDir))
-	runner := NewTestRunner(cfg, nil)
+	spec := &models.EvalSpec{}
+	cfg := config.NewEvalConfig(spec, config.WithFixtureDir(fixtureDir))
+	runner := NewEvalRunner(cfg, nil)
 
 	testCase := &models.TestCase{
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Resources: []models.ResourceRef{
 				{Location: "inline.txt", Body: "inline"},
 				{Location: "ok.txt"},
@@ -372,8 +372,8 @@ func TestLoadResources_PathValidation(t *testing.T) {
 }
 
 func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
-	spec := &models.BenchmarkSpec{Config: models.Config{TrialsPerTask: 2}}
-	runner := NewTestRunner(config.NewBenchmarkConfig(spec), nil)
+	spec := &models.EvalSpec{Config: models.Config{TrialsPerTask: 2}}
+	runner := NewEvalRunner(config.NewEvalConfig(spec), nil)
 
 	content := "hi"
 	resp := &execution.ExecutionResponse{
@@ -454,7 +454,7 @@ func TestComputeTestStats_FlakinessPercent(t *testing.T) {
 }
 
 func TestRunTest_CacheHitAndTranscriptWrite(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SkillName: "cache-skill",
 		Config: models.Config{
 			TrialsPerTask: 1,
@@ -473,16 +473,16 @@ func TestRunTest_CacheHitAndTranscriptWrite(t *testing.T) {
 
 	transcriptDir := t.TempDir()
 	cacheDir := t.TempDir()
-	cfg := config.NewBenchmarkConfig(
+	cfg := config.NewEvalConfig(
 		spec,
 		config.WithTranscriptDir(transcriptDir),
 	)
-	runner := NewTestRunner(cfg, execution.NewMockEngine("mock-model"), WithCache(cache.New(cacheDir)))
+	runner := NewEvalRunner(cfg, execution.NewMockEngine("mock-model"), WithCache(cache.New(cacheDir)))
 
 	testCase := &models.TestCase{
 		TestID:      "cache-task",
 		DisplayName: "Cache Task",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "cache me",
 		},
 	}
@@ -574,17 +574,17 @@ func (e *errorOnCallEngine) Execute(_ context.Context, req *execution.ExecutionR
 
 func TestExecuteRun_NoFollowUps(t *testing.T) {
 	eng := &trackingEngine{}
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "no-followup-test"},
 		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
 	}
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, eng, WithSkipGraders())
 
 	tc := &models.TestCase{
 		TestID:      "t1",
 		DisplayName: "no followup",
-		Stimulus:    models.TestStimulus{Message: "initial prompt"},
+		Stimulus:    models.TaskStimulus{Message: "initial prompt"},
 	}
 
 	result := runner.executeRun(context.Background(), tc, 1)
@@ -595,17 +595,17 @@ func TestExecuteRun_NoFollowUps(t *testing.T) {
 
 func TestExecuteRun_SingleFollowUp(t *testing.T) {
 	eng := &trackingEngine{}
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "single-followup-test"},
 		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
 	}
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, eng, WithSkipGraders())
 
 	tc := &models.TestCase{
 		TestID:      "t2",
 		DisplayName: "single followup",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message:   "initial prompt",
 			FollowUps: []string{"follow-up one"},
 		},
@@ -624,17 +624,17 @@ func TestExecuteRun_SingleFollowUp(t *testing.T) {
 
 func TestExecuteRun_MultipleFollowUps(t *testing.T) {
 	eng := &trackingEngine{}
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "multi-followup-test"},
 		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
 	}
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, eng, WithSkipGraders())
 
 	tc := &models.TestCase{
 		TestID:      "t3",
 		DisplayName: "multi followup",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message:   "initial",
 			FollowUps: []string{"follow-up 1", "follow-up 2", "follow-up 3"},
 		},
@@ -655,17 +655,17 @@ func TestExecuteRun_MultipleFollowUps(t *testing.T) {
 
 func TestExecuteRun_FollowUpErrorMidSequence(t *testing.T) {
 	eng := &errorOnCallEngine{errOnCall: 2} // fail on first follow-up
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "error-followup-test"},
 		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
 	}
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, eng, WithSkipGraders())
 
 	tc := &models.TestCase{
 		TestID:      "t4",
 		DisplayName: "error followup",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message:   "initial",
 			FollowUps: []string{"fail-here", "never-reached"},
 		},
@@ -696,13 +696,13 @@ expected:
 `
 	require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "t1.yaml"), []byte(taskYAML), 0o644))
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "bench-with-followups"},
 		Config:       models.Config{TrialsPerTask: 1, TimeoutSec: 30},
 		Tasks:        []string{"tasks/*.yaml"},
 	}
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-	runner := NewTestRunner(cfg, eng, WithSkipGraders())
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+	runner := NewEvalRunner(cfg, eng, WithSkipGraders())
 
 	outcome, err := runner.RunBenchmark(context.Background())
 	require.NoError(t, err)

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -58,7 +58,7 @@ func TestBuildExecutionRequest_SkillPaths(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a minimal spec
-			spec := &models.BenchmarkSpec{
+			spec := &models.EvalSpec{
 				SpecIdentity: models.SpecIdentity{
 					Name: "test-benchmark",
 				},
@@ -72,7 +72,7 @@ func TestBuildExecutionRequest_SkillPaths(t *testing.T) {
 			}
 
 			// Create config
-			cfg := config.NewBenchmarkConfig(
+			cfg := config.NewEvalConfig(
 				spec,
 				config.WithSpecDir(tt.specDir),
 			)
@@ -81,13 +81,13 @@ func TestBuildExecutionRequest_SkillPaths(t *testing.T) {
 			tc := &models.TestCase{
 				TestID:      "test-001",
 				DisplayName: "Test Case",
-				Stimulus: models.TestStimulus{
+				Stimulus: models.TaskStimulus{
 					Message: "Test message",
 				},
 			}
 
 			// Create runner (engine can be nil for this test)
-			runner := NewTestRunner(cfg, nil)
+			runner := NewEvalRunner(cfg, nil)
 
 			// Build execution request
 			req := runner.buildExecutionRequest(tc)
@@ -110,7 +110,7 @@ func TestBuildExecutionRequest_SkillPaths(t *testing.T) {
 
 func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 	// Create a spec
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-benchmark",
 		},
@@ -122,13 +122,13 @@ func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 		},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec)
+	cfg := config.NewEvalConfig(spec)
 
 	// Create a test case
 	tc := &models.TestCase{
 		TestID:      "test-001",
 		DisplayName: "Test Case",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Hello world",
 			Metadata: map[string]any{
 				"key": "value",
@@ -136,7 +136,7 @@ func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 		},
 	}
 
-	runner := NewTestRunner(cfg, nil)
+	runner := NewEvalRunner(cfg, nil)
 	req := runner.buildExecutionRequest(tc)
 
 	// Verify basic fields
@@ -148,7 +148,7 @@ func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 
 func TestBuildExecutionRequest_TimeoutOverride(t *testing.T) {
 	// Create a spec with default timeout
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-benchmark",
 		},
@@ -160,20 +160,20 @@ func TestBuildExecutionRequest_TimeoutOverride(t *testing.T) {
 		},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec)
+	cfg := config.NewEvalConfig(spec)
 
 	// Create a test case with custom timeout
 	customTimeout := 300
 	tc := &models.TestCase{
 		TestID:      "test-001",
 		DisplayName: "Test Case",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Hello world",
 		},
 		TimeoutSec: &customTimeout,
 	}
 
-	runner := NewTestRunner(cfg, nil)
+	runner := NewEvalRunner(cfg, nil)
 	req := runner.buildExecutionRequest(tc)
 
 	// Verify timeout is overridden
@@ -183,7 +183,7 @@ func TestBuildExecutionRequest_TimeoutOverride(t *testing.T) {
 func TestBuildExecutionRequest_TaskLevelSkillPaths(t *testing.T) {
 	specDir := t.TempDir()
 
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{
 			Name: "test-benchmark",
 		},
@@ -196,14 +196,14 @@ func TestBuildExecutionRequest_TaskLevelSkillPaths(t *testing.T) {
 		},
 	}
 
-	cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(specDir))
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(specDir))
+	runner := NewEvalRunner(cfg, nil)
 
 	// Task with its own skill_directories should override eval-level
 	tc := &models.TestCase{
 		TestID:      "test-001",
 		DisplayName: "Test Case",
-		Stimulus:    models.TestStimulus{Message: "test"},
+		Stimulus:    models.TaskStimulus{Message: "test"},
 		SkillPaths:  []string{"./task-skills", "./more-skills"},
 	}
 	req := runner.buildExecutionRequest(tc)
@@ -216,7 +216,7 @@ func TestBuildExecutionRequest_TaskLevelSkillPaths(t *testing.T) {
 	tc2 := &models.TestCase{
 		TestID:      "test-002",
 		DisplayName: "Test Case 2",
-		Stimulus:    models.TestStimulus{Message: "test"},
+		Stimulus:    models.TaskStimulus{Message: "test"},
 	}
 	req2 := runner.buildExecutionRequest(tc2)
 	require.NotNil(t, req2)
@@ -279,7 +279,7 @@ description: Validate Azure config
 	require.NoError(t, os.WriteFile(filepath.Join(skill3Dir, "SKILL.md"), []byte(skill3Content), 0644))
 
 	t.Run("all required skills found", func(t *testing.T) {
-		spec := &models.BenchmarkSpec{
+		spec := &models.EvalSpec{
 			SpecIdentity: models.SpecIdentity{
 				Name: "test-benchmark",
 			},
@@ -294,15 +294,15 @@ description: Validate Azure config
 			},
 		}
 
-		cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-		runner := NewTestRunner(cfg, nil)
+		cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+		runner := NewEvalRunner(cfg, nil)
 
 		err := runner.validateRequiredSkills()
 		assert.NoError(t, err)
 	})
 
 	t.Run("some required skills missing", func(t *testing.T) {
-		spec := &models.BenchmarkSpec{
+		spec := &models.EvalSpec{
 			SpecIdentity: models.SpecIdentity{
 				Name: "test-benchmark",
 			},
@@ -317,8 +317,8 @@ description: Validate Azure config
 			},
 		}
 
-		cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-		runner := NewTestRunner(cfg, nil)
+		cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+		runner := NewEvalRunner(cfg, nil)
 
 		err := runner.validateRequiredSkills()
 		require.Error(t, err)
@@ -329,7 +329,7 @@ description: Validate Azure config
 	})
 
 	t.Run("empty required_skills list skips validation", func(t *testing.T) {
-		spec := &models.BenchmarkSpec{
+		spec := &models.EvalSpec{
 			SpecIdentity: models.SpecIdentity{
 				Name: "test-benchmark",
 			},
@@ -344,15 +344,15 @@ description: Validate Azure config
 			},
 		}
 
-		cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-		runner := NewTestRunner(cfg, nil)
+		cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+		runner := NewEvalRunner(cfg, nil)
 
 		err := runner.validateRequiredSkills()
 		assert.NoError(t, err)
 	})
 
 	t.Run("nil required_skills skips validation", func(t *testing.T) {
-		spec := &models.BenchmarkSpec{
+		spec := &models.EvalSpec{
 			SpecIdentity: models.SpecIdentity{
 				Name: "test-benchmark",
 			},
@@ -367,15 +367,15 @@ description: Validate Azure config
 			},
 		}
 
-		cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-		runner := NewTestRunner(cfg, nil)
+		cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+		runner := NewEvalRunner(cfg, nil)
 
 		err := runner.validateRequiredSkills()
 		assert.NoError(t, err)
 	})
 
 	t.Run("empty skill_directories with required_skills returns error", func(t *testing.T) {
-		spec := &models.BenchmarkSpec{
+		spec := &models.EvalSpec{
 			SpecIdentity: models.SpecIdentity{
 				Name: "test-benchmark",
 			},
@@ -390,8 +390,8 @@ description: Validate Azure config
 			},
 		}
 
-		cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-		runner := NewTestRunner(cfg, nil)
+		cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+		runner := NewEvalRunner(cfg, nil)
 
 		err := runner.validateRequiredSkills()
 		require.Error(t, err)
@@ -399,7 +399,7 @@ description: Validate Azure config
 	})
 
 	t.Run("relative skill paths are resolved correctly", func(t *testing.T) {
-		spec := &models.BenchmarkSpec{
+		spec := &models.EvalSpec{
 			SpecIdentity: models.SpecIdentity{
 				Name: "test-benchmark",
 			},
@@ -414,8 +414,8 @@ description: Validate Azure config
 			},
 		}
 
-		cfg := config.NewBenchmarkConfig(spec, config.WithSpecDir(tmpDir))
-		runner := NewTestRunner(cfg, nil)
+		cfg := config.NewEvalConfig(spec, config.WithSpecDir(tmpDir))
+		runner := NewEvalRunner(cfg, nil)
 
 		err := runner.validateRequiredSkills()
 		assert.NoError(t, err)
@@ -474,40 +474,40 @@ func TestComputeGroupStats_NoGroupSet(t *testing.T) {
 }
 
 func TestResolveGroup_Model(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		Config: models.Config{
 			ModelID: "gpt-4o",
 			GroupBy: "model",
 		},
 	}
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, nil)
 
 	assert.Equal(t, "gpt-4o", runner.resolveGroup())
 }
 
 func TestResolveGroup_Empty(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		Config: models.Config{
 			ModelID: "gpt-4o",
 			GroupBy: "",
 		},
 	}
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, nil)
 
 	assert.Equal(t, "", runner.resolveGroup())
 }
 
 func TestResolveGroup_Unknown(t *testing.T) {
-	spec := &models.BenchmarkSpec{
+	spec := &models.EvalSpec{
 		Config: models.Config{
 			ModelID: "gpt-4o",
 			GroupBy: "region",
 		},
 	}
-	cfg := config.NewBenchmarkConfig(spec)
-	runner := NewTestRunner(cfg, nil)
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, nil)
 
 	assert.Equal(t, "", runner.resolveGroup())
 }

--- a/internal/suggest/prompt.go
+++ b/internal/suggest/prompt.go
@@ -109,7 +109,7 @@ func renderImplementationPrompt(data promptData, graderDocs string) string {
 	b.WriteString("    content: |\n")
 	b.WriteString("      <fixture content>\n\n")
 	b.WriteString("Requirements:\n")
-	b.WriteString("- Ensure eval_yaml is valid waza BenchmarkSpec YAML.\n")
+	b.WriteString("- Ensure eval_yaml is valid waza EvalSpec YAML.\n")
 	b.WriteString("- Each grader entry MUST be an object with at least 'type' and 'name' fields. NEVER use bare strings like '- grader_name'. Always use '- name: grader_name' with a 'type' field.\n")
 	b.WriteString("- Include required config fields for each grader type (see grader documentation below).\n")
 	b.WriteString("- For skill_invocation graders, use config fields required_skills (list) and mode (exact_match, in_order, any_order).\n")

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -332,7 +332,7 @@ func extractYAML(raw string) string {
 }
 
 func validateEvalYAML(raw string) error {
-	var spec models.BenchmarkSpec
+	var spec models.EvalSpec
 	decoder := yaml.NewDecoder(strings.NewReader(raw))
 	decoder.KnownFields(true) // Strict parsing to catch unknown fields
 	if err := decoder.Decode(&spec); err != nil {

--- a/internal/suggest/suggest_test.go
+++ b/internal/suggest/suggest_test.go
@@ -173,7 +173,7 @@ func TestParseResponseRejectsBareStringGraders(t *testing.T) {
 }
 
 // TestEvalYAMLRoundTrip verifies that valid eval YAML can be marshaled and
-// then unmarshaled back into a BenchmarkSpec without loss.
+// then unmarshaled back into a EvalSpec without loss.
 func TestEvalYAMLRoundTrip(t *testing.T) {
 	evalYAML := `name: roundtrip-eval
 description: test round-trip
@@ -322,7 +322,7 @@ config:
 	require.Contains(t, err.Error(), "unknown_field")
 }
 
-func TestValidateInvalidBenchmarkSpecFields(t *testing.T) {
+func TestValidateInvalidEvalSpecFields(t *testing.T) {
 	invalidEvalYAML := `name: bad-eval
 description: has unknown field
 skill: test-skill

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -161,7 +161,7 @@ func TestBuildTaskTranscript(t *testing.T) {
 	tc := &models.TestCase{
 		TestID:      "tc-1",
 		DisplayName: "Code Explain",
-		Stimulus: models.TestStimulus{
+		Stimulus: models.TaskStimulus{
 			Message: "Explain this code",
 		},
 	}

--- a/internal/trigger/runner.go
+++ b/internal/trigger/runner.go
@@ -24,7 +24,7 @@ import (
 type Runner struct {
 	spec      *TestSpec
 	engine    execution.AgentEngine
-	cfg       *config.BenchmarkConfig
+	cfg       *config.EvalConfig
 	out       io.Writer
 	fixtures  []execution.ResourceFile // cached fixture files, loaded once
 	mcpConfig map[string]copilot.MCPServerConfig
@@ -45,7 +45,7 @@ type taskResult struct {
 	err        error
 }
 
-func NewRunner(spec *TestSpec, engine execution.AgentEngine, cfg *config.BenchmarkConfig, out io.Writer) *Runner {
+func NewRunner(spec *TestSpec, engine execution.AgentEngine, cfg *config.EvalConfig, out io.Writer) *Runner {
 	r := &Runner{spec: spec, engine: engine, cfg: cfg, out: out}
 	r.fixtures = loadFixtureDir(cfg.FixtureDir())
 	r.mcpConfig = convertMCPServers(cfg.Spec().Config.ServerConfigs)

--- a/internal/trigger/runner_test.go
+++ b/internal/trigger/runner_test.go
@@ -86,7 +86,7 @@ func TestDiscoverExampleFixture(t *testing.T) {
 	_ = spec // ensure it parses without error
 }
 
-func TestRunnerWithMockEngine(t *testing.T) {
+func TestEvalRunnerWithMockEngine(t *testing.T) {
 	spec := &TestSpec{
 		Skill: "mock-skill",
 		ShouldTriggerPrompts: []TestPrompt{
@@ -98,7 +98,7 @@ func TestRunnerWithMockEngine(t *testing.T) {
 	}
 
 	engine := &stubEngine{skill: "mock-skill"}
-	cfg := config.NewBenchmarkConfig(&models.BenchmarkSpec{SkillName: "mock-skill"})
+	cfg := config.NewEvalConfig(&models.EvalSpec{SkillName: "mock-skill"})
 	r := NewRunner(spec, engine, cfg, nil)
 	m, err := r.Run(t.Context())
 	if err != nil {
@@ -135,7 +135,7 @@ func (e *stubEngine) Execute(_ context.Context, req *execution.ExecutionRequest)
 	}, nil
 }
 
-func TestRunnerRunConfig(t *testing.T) {
+func TestEvalRunnerRunConfig(t *testing.T) {
 	spec := &TestSpec{
 		Skill: "my-skill",
 		ShouldTriggerPrompts: []TestPrompt{
@@ -144,8 +144,8 @@ func TestRunnerRunConfig(t *testing.T) {
 	}
 
 	engine := &capturingEngine{}
-	cfg := config.NewBenchmarkConfig(
-		&models.BenchmarkSpec{
+	cfg := config.NewEvalConfig(
+		&models.EvalSpec{
 			SkillName: "my-skill",
 			Config: models.Config{
 				TimeoutSec: 120,
@@ -187,7 +187,7 @@ func (e *capturingEngine) LastReq() *execution.ExecutionRequest {
 	return e.lastReq
 }
 
-func TestRunnerNeverTriggers(t *testing.T) {
+func TestEvalRunnerNeverTriggers(t *testing.T) {
 	spec := &TestSpec{
 		Skill: "my-skill",
 		ShouldTriggerPrompts: []TestPrompt{
@@ -199,7 +199,7 @@ func TestRunnerNeverTriggers(t *testing.T) {
 	}
 
 	engine := &noTriggerEngine{}
-	cfg := config.NewBenchmarkConfig(&models.BenchmarkSpec{SkillName: "my-skill"})
+	cfg := config.NewEvalConfig(&models.EvalSpec{SkillName: "my-skill"})
 	r := NewRunner(spec, engine, cfg, nil)
 	m, err := r.Run(t.Context())
 	if err != nil {
@@ -221,7 +221,7 @@ func TestRunnerNeverTriggers(t *testing.T) {
 	}
 }
 
-func TestRunnerPartialErrors(t *testing.T) {
+func TestEvalRunnerPartialErrors(t *testing.T) {
 	spec := &TestSpec{
 		Skill: "my-skill",
 		ShouldTriggerPrompts: []TestPrompt{
@@ -231,7 +231,7 @@ func TestRunnerPartialErrors(t *testing.T) {
 	}
 
 	engine := &errorOnPromptEngine{errorPrompt: "bad", skill: "my-skill"}
-	cfg := config.NewBenchmarkConfig(&models.BenchmarkSpec{SkillName: "my-skill"})
+	cfg := config.NewEvalConfig(&models.EvalSpec{SkillName: "my-skill"})
 	r := NewRunner(spec, engine, cfg, nil)
 	m, err := r.Run(t.Context())
 	if err != nil {
@@ -253,7 +253,7 @@ func TestRunnerPartialErrors(t *testing.T) {
 	}
 }
 
-func TestRunnerAllErrors(t *testing.T) {
+func TestEvalRunnerAllErrors(t *testing.T) {
 	spec := &TestSpec{
 		Skill: "my-skill",
 		ShouldTriggerPrompts: []TestPrompt{
@@ -262,7 +262,7 @@ func TestRunnerAllErrors(t *testing.T) {
 	}
 
 	engine := &errorOnPromptEngine{errorPrompt: "bad", skill: "my-skill"}
-	cfg := config.NewBenchmarkConfig(&models.BenchmarkSpec{SkillName: "my-skill"})
+	cfg := config.NewEvalConfig(&models.EvalSpec{SkillName: "my-skill"})
 	r := NewRunner(spec, engine, cfg, nil)
 	m, err := r.Run(t.Context())
 	if err != nil {
@@ -312,7 +312,7 @@ func (e *errorOnPromptEngine) Execute(_ context.Context, req *execution.Executio
 	}, nil
 }
 
-func TestRunnerPassesFixturesToExecutionRequest(t *testing.T) {
+func TestEvalRunnerPassesFixturesToExecutionRequest(t *testing.T) {
 	// Create a fixture directory with files
 	fixtureDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(fixtureDir, "main.go"), []byte("package main"), 0644))
@@ -327,8 +327,8 @@ func TestRunnerPassesFixturesToExecutionRequest(t *testing.T) {
 	}
 
 	engine := &capturingEngine{}
-	cfg := config.NewBenchmarkConfig(
-		&models.BenchmarkSpec{SkillName: "my-skill"},
+	cfg := config.NewEvalConfig(
+		&models.EvalSpec{SkillName: "my-skill"},
 		config.WithFixtureDir(fixtureDir),
 		config.WithSpecDir("/some/spec/dir"),
 	)
@@ -353,7 +353,7 @@ func TestRunnerPassesFixturesToExecutionRequest(t *testing.T) {
 	require.Equal(t, "/some/spec/dir", engine.LastReq().SourceDir)
 }
 
-func TestRunnerSkipsHiddenAndVendorInFixtures(t *testing.T) {
+func TestEvalRunnerSkipsHiddenAndVendorInFixtures(t *testing.T) {
 	fixtureDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(fixtureDir, "visible.txt"), []byte("ok"), 0644))
 
@@ -372,15 +372,15 @@ func TestRunnerSkipsHiddenAndVendorInFixtures(t *testing.T) {
 	require.Equal(t, "visible.txt", resources[0].Path)
 }
 
-func TestRunnerPassesMCPServers(t *testing.T) {
+func TestEvalRunnerPassesMCPServers(t *testing.T) {
 	spec := &TestSpec{
 		Skill:                "my-skill",
 		ShouldTriggerPrompts: []TestPrompt{{Prompt: "hello"}},
 	}
 
 	engine := &capturingEngine{}
-	cfg := config.NewBenchmarkConfig(
-		&models.BenchmarkSpec{
+	cfg := config.NewEvalConfig(
+		&models.EvalSpec{
 			SkillName: "my-skill",
 			Config: models.Config{
 				ServerConfigs: map[string]any{
@@ -418,7 +418,7 @@ func TestConvertMCPServers_SkipsNonMapEntries(t *testing.T) {
 	require.Contains(t, result, "good2")
 }
 
-func TestRunnerSetsCancelOnSkillInvocation(t *testing.T) {
+func TestEvalRunnerSetsCancelOnSkillInvocation(t *testing.T) {
 	spec := &TestSpec{
 		Skill:                   "my-skill",
 		ShouldTriggerPrompts:    []TestPrompt{{Prompt: "trigger me"}},
@@ -426,7 +426,7 @@ func TestRunnerSetsCancelOnSkillInvocation(t *testing.T) {
 	}
 
 	engine := &capturingEngine{}
-	cfg := config.NewBenchmarkConfig(&models.BenchmarkSpec{
+	cfg := config.NewEvalConfig(&models.EvalSpec{
 		SkillName: "my-skill",
 		Config:    models.Config{TimeoutSec: 10},
 	})

--- a/internal/validation/schema.go
+++ b/internal/validation/schema.go
@@ -57,9 +57,9 @@ func mustCompileSchema(raw string, name string) *jsonschema.Schema {
 //
 // This assumes that the schema files are up-to-date with the implementation.
 // Other YAML decoding errors may be reported if fields are removed from the implementation. Those
-// will be caught by the strict YAML parsing in LoadTestCase and LoadBenchmarkSpec, but the schema
+// will be caught by the strict YAML parsing in LoadTestCase and LoadEvalSpec, but the schema
 // validation has a much higher fidelity (better error location) than the validation in LoadTestCase
-// and LoadBenchmarkSpec.
+// and LoadEvalSpec.
 func ValidateEvalFile(evalPath string) (evalErrs []string, taskErrs map[string][]string, err error) {
 	data, err := os.ReadFile(evalPath)
 	if err != nil {


### PR DESCRIPTION
Closes #166

## Summary
Completes the vocabulary rename from Benchmark/Test terminology to Eval/Task terminology across the Go codebase.

### Renames performed
| Old Name | New Name | File |
|----------|----------|------|
| `BenchmarkSpec` | `EvalSpec` | internal/models/spec.go |
| `LoadBenchmarkSpec` | `LoadEvalSpec` | internal/models/spec.go |
| `BenchmarkConfig` | `EvalConfig` | internal/config/config.go |
| `NewBenchmarkConfig` | `NewEvalConfig` | internal/config/config.go |
| `TestRunner` | `EvalRunner` | internal/orchestration/runner.go |
| `TestStimulus` | `TaskStimulus` | internal/models/testcase.go |
| `TestExpectation` | `TaskExpectation` | internal/models/testcase.go |

### Backward compatibility
- Type aliases (`type BenchmarkSpec = EvalSpec`, etc.) provided for all renamed exports
- Wrapper functions (`LoadBenchmarkSpec`, `NewBenchmarkConfig`, `NewTestRunner`) delegate to new names
- **YAML tags unchanged** — eval YAML files remain fully compatible
- **JSON tags unchanged** — results JSON remains fully compatible
- `TestCase` intentionally NOT renamed (Go convention, deeply embedded)

### Verification
- `go build ./...` ✅
- `go test ./...` ✅ (all 48 packages pass)
- `go vet ./...` ✅
- README.md and AGENTS.md updated

35 files changed across cmd/, internal/, docs.