### PR TITLE
fix: waza serve crashes when stdin is not a terminal

### DIFF
--- a/cmd/waza/cmd_serve.go
+++ b/cmd/waza/cmd_serve.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/waza/internal/projectconfig"
 	"github.com/microsoft/waza/internal/webserver"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 func newServeCommand() *cobra.Command {
@@ -69,11 +70,15 @@ JSON-RPC methods (when using --tcp or stdin/stdout):
 				ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 				defer stop()
 
-				// Start MCP server on stdio in the background.
-				go func() {
-					logger.Info("MCP server running on stdio")
-					mcp.ServeStdio(ctx, os.Stdin, os.Stdout, logger)
-				}()
+				// Start MCP server on stdio — only when stdin is a
+				// terminal. When backgrounded or piped, the MCP reader
+				// crashes on EOF and kills the HTTP server.
+				if term.IsTerminal(int(os.Stdin.Fd())) {
+					go func() {
+						logger.Info("MCP server running on stdio")
+						mcp.ServeStdio(ctx, os.Stdin, os.Stdout, logger)
+					}()
+				}
 
 				// Prepare storage config if enabled.
 				var storageCfg *projectconfig.StorageConfig


### PR DESCRIPTION
The MCP stdio server crashed when stdin wasn't a terminal (background mode, piped input), killing the HTTP dashboard server. Now only starts MCP stdio when `term.IsTerminal()` is true.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>