### PR TITLE
fix: mock engine echoes file content for CI evals (#227)

### DIFF
--- a/.github/workflows/waza-eval.yml
+++ b/.github/workflows/waza-eval.yml
@@ -68,6 +68,9 @@ on:
       - 'examples/**/*.yaml'
       - 'examples/**/*.yml'
       - 'skills/**'
+      - 'internal/execution/**'
+      - 'internal/orchestration/**'
+      - 'internal/graders/**'
       - '.github/workflows/waza-eval.yml'
   
   # Trigger on push to main branches
@@ -77,6 +80,9 @@ on:
       - 'examples/**/*.yaml'
       - 'examples/**/*.yml'
       - 'skills/**'
+      - 'internal/execution/**'
+      - 'internal/orchestration/**'
+      - 'internal/graders/**'
       - '.github/workflows/waza-eval.yml'
 
 jobs:

--- a/.squad/agents/linus/history.md
+++ b/.squad/agents/linus/history.md
@@ -103,3 +103,4 @@ All code roles now use `claude-opus-4.6`. Docs/Scribe/diversity use `gemini-3-pr
 ## Learnings
 - Windows local test runs can fail in `cmd/waza/tokens/internal/git` when temporary repos inherit strict CRLF behavior; setting `core.autocrlf=false` and `core.safecrlf=false` inside test repo setup makes these tests cross-platform stable.
 - PR conflict resolution for `copilot/migrate-copilot-client-usage` in `internal/execution/copilot_test.go` should keep the `TestCopilotExecute_InitializePropagatesStartError` variant from main to preserve startup error propagation coverage.
+- Mock engine contract: the mock must echo task metadata (name, description), context values, and file content (capped at 1KB) in its response. Without this, `output_contains` graders can't validate anything meaningful in CI since the mock doesn't reason about code. The `ExecutionRequest` now carries `TaskName` and `TaskDescription` fields to support this.

--- a/.squad/decisions/inbox/linus-mock-includes-resources.md
+++ b/.squad/decisions/inbox/linus-mock-includes-resources.md
@@ -1,0 +1,31 @@
+# Decision: Mock engine echoes full request context
+
+**Date:** 2026-02-22
+**Author:** Linus (Backend Developer)
+**Issue:** #227
+
+## Context
+
+The `Run Waza Evaluation` CI job runs `examples/code-explainer/eval.yaml` with the mock engine. The mock returned only `"Mock response for: <prompt>"` plus a file count — a near-empty stub. This made every `_output_contains` grader fail because expected substrings (e.g., "async", "fetch", "recursive") never appeared in the output.
+
+## Decision
+
+The mock engine now echoes all available request data in its response:
+
+1. **Task name and description** — via new `TaskName`/`TaskDescription` fields on `ExecutionRequest`
+2. **Context metadata** — key/value pairs from the task's `context:` block
+3. **File paths and content** — each resource file's path and up to 1KB of content
+
+This makes the mock a "saw the files" echo agent rather than a no-op stub. The CI eval pipeline can now validate the full path (discovery → execution → grading) without a real model.
+
+## Trade-offs
+
+- **Pro:** CI evals pass without a real model; eval authors can write realistic `output_contains` expectations
+- **Pro:** No changes needed to example eval files — the mock adapts
+- **Con:** Mock output is now coupled to request shape; adding new `ExecutionRequest` fields may need mock updates
+- **Con:** Content preview capped at 1KB per file — very large fixture tests may still need adjustment
+
+## Alternatives considered
+
+- **Relax eval expectations:** Rejected — the issue said "fix the mock, not the example"
+- **Only echo file content:** Insufficient — some expected strings (e.g., "recursive") come from task descriptions, not file content

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -45,6 +45,12 @@ type ExecutionRequest struct {
 	WorkspaceDir string // Reuse an existing workspace directory (for follow-up prompts)
 	SkillName    string
 
+	// TaskName and TaskDescription carry test-case metadata so mock engines can
+	// echo them, enabling output_contains expectations that reference task-level
+	// concepts (e.g., "recursive") without a real model.
+	TaskName        string
+	TaskDescription string
+
 	SourceDir  string   // used when looking for workspace items via relative path, like skills.
 	SkillPaths []string // Directories to search for skills
 	NoSkills   bool     // When true, skip all skill loading

--- a/internal/execution/mock.go
+++ b/internal/execution/mock.go
@@ -78,9 +78,37 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 	// Simple mock response
 	output := fmt.Sprintf("Mock response for: %s", req.Message)
 
-	// Add some context if files are present
+	// Echo task metadata so output_contains expectations that reference
+	// task-level concepts (e.g., "recursive", "list") can match.
+	if req.TaskName != "" {
+		output += fmt.Sprintf("\nTask: %s", req.TaskName)
+	}
+	if req.TaskDescription != "" {
+		output += fmt.Sprintf("\nDescription: %s", req.TaskDescription)
+	}
+
+	// Echo context metadata
+	if len(req.Context) > 0 {
+		output += "\nContext:"
+		for k, v := range req.Context {
+			output += fmt.Sprintf("\n  %s: %v", k, v)
+		}
+	}
+
+	// Echo file paths and a content preview so output_contains expectations
+	// against file content can match without needing a real model.
 	if len(req.Resources) > 0 {
-		output += fmt.Sprintf("\nAnalyzed %d file(s)", len(req.Resources))
+		output += fmt.Sprintf("\nAnalyzed %d file(s):", len(req.Resources))
+		for _, r := range req.Resources {
+			output += fmt.Sprintf("\n  - %s", r.Path)
+			if len(r.Content) > 0 {
+				preview := string(r.Content)
+				if len(preview) > 1024 {
+					preview = preview[:1024] + "...(truncated)"
+				}
+				output += "\n" + preview
+			}
+		}
 	}
 
 	// Pass through session ID for follow-up continuity

--- a/internal/execution/mock_engine_test.go
+++ b/internal/execution/mock_engine_test.go
@@ -37,7 +37,8 @@ func TestMockEngine_Execute_WritesResources(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.True(t, resp.Success)
 	assert.Contains(t, resp.FinalOutput, "Mock response for: hello")
-	assert.Contains(t, resp.FinalOutput, "Analyzed 1 file(s)")
+	assert.Contains(t, resp.FinalOutput, "Analyzed 1 file(s):")
+	assert.Contains(t, resp.FinalOutput, "test-content")
 
 	content, err := os.ReadFile(filepath.Join(resp.WorkspaceDir, "fixtures", "input.txt"))
 	require.NoError(t, err)
@@ -88,6 +89,52 @@ func TestMockEngine_Execute_SetupResourcesError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "failed to setup mock workspace resources")
+
+	require.NoError(t, engine.Shutdown(context.Background()))
+}
+
+func TestMockEngine_Execute_IncludesResourceContent(t *testing.T) {
+	engine := NewMockEngine("test-model")
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	jsContent := "async function fetchUser(id) {\n  const resp = await fetch(`/api/users/${id}`);\n  return resp.json();\n}"
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message: "What does this code do?",
+		Resources: []ResourceFile{
+			{Path: "fetch_user.js", Content: []byte(jsContent)},
+			{Path: "empty.txt", Content: nil},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// File content should appear in output so output_contains graders can match
+	assert.Contains(t, resp.FinalOutput, "async function fetchUser")
+	assert.Contains(t, resp.FinalOutput, "await fetch")
+	assert.Contains(t, resp.FinalOutput, "fetch_user.js")
+	assert.Contains(t, resp.FinalOutput, "Analyzed 2 file(s):")
+	// Empty file should still list path but no content
+	assert.Contains(t, resp.FinalOutput, "empty.txt")
+
+	require.NoError(t, engine.Shutdown(context.Background()))
+}
+
+func TestMockEngine_Execute_TruncatesLargeContent(t *testing.T) {
+	engine := NewMockEngine("test-model")
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	largeContent := make([]byte, 2048)
+	for i := range largeContent {
+		largeContent[i] = 'x'
+	}
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message:   "analyze",
+		Resources: []ResourceFile{{Path: "big.txt", Content: largeContent}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, resp.FinalOutput, "...(truncated)")
 
 	require.NoError(t, engine.Shutdown(context.Background()))
 }

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1152,14 +1152,16 @@ func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) *execution.Execu
 	noSkills := spec.Config.AllSkillsDisabled()
 
 	return &execution.ExecutionRequest{
-		Message:    tc.Stimulus.Message,
-		Context:    tc.Stimulus.Metadata,
-		Resources:  resources,
-		SkillName:  spec.SkillName,
-		SkillPaths: resolvedSkillPaths,
-		NoSkills:   noSkills,
-		Timeout:    time.Duration(timeout) * time.Second,
-		MCPServers: convertMCPServers(spec.Config.ServerConfigs),
+		Message:         tc.Stimulus.Message,
+		Context:         tc.Stimulus.Metadata,
+		Resources:       resources,
+		SkillName:       spec.SkillName,
+		TaskName:        tc.DisplayName,
+		TaskDescription: tc.Summary,
+		SkillPaths:      resolvedSkillPaths,
+		NoSkills:        noSkills,
+		Timeout:         time.Duration(timeout) * time.Second,
+		MCPServers:      convertMCPServers(spec.Config.ServerConfigs),
 	}
 }
 


### PR DESCRIPTION
Closes #227

## Summary

The `Run Waza Evaluation` CI job runs `examples/code-explainer/eval.yaml` with the mock engine. The mock previously returned only `Mock response for: <prompt>` plus a file count, so `_output_contains` expectations against file contents (e.g., "async", "fetch", "recursive") failed every time — 0/4 tasks passed.

## What Changed

- **`internal/execution/engine.go`** — Added `TaskName` and `TaskDescription` fields to `ExecutionRequest` so task metadata flows to engines.
- **`internal/execution/mock.go`** — Mock response now echoes: task name/description, context metadata key/values, file paths, and up to 1KB of file content per resource.
- **`internal/orchestration/runner.go`** — Populates the new `TaskName`/`TaskDescription` fields from `TestCase`.
- **`internal/execution/mock_engine_test.go`** — Updated existing test for new format; added `TestMockEngine_Execute_IncludesResourceContent` and `TestMockEngine_Execute_TruncatesLargeContent`.

## Testing

- All unit tests pass (`go test ./...`)
- `go vet ./...` clean
- `examples/code-explainer/eval.yaml` now passes 4/4 tasks (was 0/4)
- No changes to example files — only the mock engine was modified
