### PR TITLE
docs: cross-reference audit for recent renames and feature additions

### DIFF
--- a/.squad/agents/saul/history.md
+++ b/.squad/agents/saul/history.md
@@ -50,3 +50,11 @@ All code roles now use `claude-opus-4.6`. Docs/Scribe/diversity use `gemini-3-pr
 - azd extension section includes full install command with versioned tar.gz URL
 - Sidebar updated in astro.config.mjs under Reference group
 - Pattern: release pages should link to GitHub Releases for history rather than duplicating old changelogs
+
+### Cross-Reference Audit (#222/#226/#228)
+
+- **#222 rename was thorough** — no stale `BenchmarkSpec`/`TestRunner` references found in any auditable docs. The rename PR updated all code-facing references correctly.
+- **#226 custom agent coverage** had gaps in onboarding paths — quick-start, getting-started (both site and docs/), GUIDE, TUTORIAL, and examples/README all lacked `.agent.md` mentions. Pattern: when adding a new target type, check all "getting started" entry points, not just the feature-specific guide.
+- **#228 mock engine** — the mock description in INTEGRATION-TESTING.md and eval-yaml.mdx was outdated (said "Simulates responses" when it now echoes task metadata and file content). Pattern: executor behavior changes need doc updates in the executor reference table.
+- **Design docs** (`docs/design/194-baseline-skill-impact.md`) still reference `BenchmarkSpec`/`TestRunner` — correct, these are historical point-in-time design documents.
+- **examples/README.md** was missing 3 example directories that had been added over time (custom-agent, required-skills-demo, rubrics).

--- a/.squad/decisions/inbox/saul-doc-audit-2025-07-15.md
+++ b/.squad/decisions/inbox/saul-doc-audit-2025-07-15.md
@@ -1,0 +1,16 @@
+# Decision: New feature types must update all onboarding entry points
+
+**By:** Saul (Documentation Lead)
+**Date:** 2025-07-15
+
+**What:** When a new evaluation target type is added (like `.agent.md` in #226), the following entry points must all be checked and updated:
+- `site/src/content/docs/quick-start.mdx`
+- `site/src/content/docs/getting-started.mdx`
+- `docs/GETTING-STARTED.md`
+- `docs/GUIDE.md`
+- `docs/TUTORIAL.md`
+- `examples/README.md`
+
+A dedicated guide page is not sufficient — users discover features through onboarding paths, not just reference docs.
+
+**Why:** The #226 custom agent PR correctly added a dedicated guide and updated 5 files, but missed 6 onboarding entry points. Users reading quick-start or getting-started would not learn that `.agent.md` is a valid target. This audit pattern should be part of the Documentation Impact Matrix.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -2,6 +2,8 @@
 
 A complete walkthrough for creating, testing, and validating AI agent skills.
 
+> **Custom Agents:** Waza also supports evaluating VS Code custom agents (`.agent.md` files) with automatic tool constraint validation. This guide focuses on `SKILL.md`-based skills — see the [Custom Agents guide](https://microsoft.github.io/waza/guides/custom-agents/) for `.agent.md` evaluation.
+
 ## Prerequisites
 
 - **waza** installed (see [Installation](../README.md#installation))

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -7,6 +7,7 @@ Welcome to **Waza**, a CLI tool for evaluating AI agent skills. This guide cover
 Waza helps you:
 
 - **Define agent skills** with comprehensive documentation and behavioral requirements
+- **Evaluate custom agents** (`.agent.md` files) with automatic tool constraint validation
 - **Create test suites** with realistic test cases and validation rules  
 - **Run evaluations** against different AI models to measure skill effectiveness
 - **Compare results** across models and versions to track improvement
@@ -319,6 +320,7 @@ Run an evaluation benchmark.
 **Arguments:**
 - `[eval.yaml]` — Path to evaluation spec file
 - `[skill-name]` — Skill name (auto-detects eval.yaml)
+- `[agent-name]` — Custom agent name (auto-detects eval.yaml for `.agent.md` files)
 - *(none)* — Auto-detect using workspace detection
 
 **Flags:**

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -81,7 +81,7 @@ waza compare results-gpt4o.json results-claude.json
 
 | Executor | Description | Use Case |
 |----------|-------------|----------|
-| `mock` | Simulates responses | Unit tests, CI without API keys |
+| `mock` | Echoes task metadata, context, and file content previews (up to 1KB per file) | Unit tests, CI without API keys |
 | `copilot-sdk` | Real Copilot agent sessions | Integration tests, benchmarking |
 
 ## CopilotExecutor Features

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -2,6 +2,8 @@
 
 This tutorial walks you through creating evaluations for your Agent Skills.
 
+> **Evaluating custom agents?** Waza also supports `.agent.md` files as evaluation targets. The workflow is similar — see [Evaluating Custom Agents](https://microsoft.github.io/waza/guides/custom-agents/) for the differences.
+
 ## Prerequisites
 
 - `waza` CLI installed:

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,47 @@ See [ci/README.md](./ci/README.md) for integration instructions.
 
 ---
 
+### 4. [custom-agent](./custom-agent/)
+**Purpose**: Evaluate a VS Code custom agent (`.agent.md`) with automatic tool constraint validation
+
+**Demonstrates**:
+- Targeting a `.agent.md` file instead of `SKILL.md`
+- Auto-injected `tool_constraint` grader from agent frontmatter
+- Security-focused agent evaluation tasks
+
+**Quick Start**:
+```bash
+waza run examples/custom-agent/eval.yaml --context-dir examples/custom-agent/fixtures -v
+```
+
+---
+
+### 5. [required-skills-demo](./required-skills-demo/)
+**Purpose**: Demonstrate `required_skills` preflight validation
+
+**Demonstrates**:
+- Declaring skill dependencies in eval config
+- Preflight validation before eval execution
+- Orchestration skill evaluation patterns
+
+**Quick Start**:
+See [required-skills-demo/README.md](./required-skills-demo/README.md) for details.
+
+---
+
+### 6. [rubrics](./rubrics/)
+**Purpose**: Pre-built evaluation rubrics adapted from Azure ML built-in evaluators
+
+**Demonstrates**:
+- `prompt` grader rubric configurations
+- Tool call accuracy, selection, and output utilization rubrics
+- Task adherence and intent resolution scoring
+
+**Quick Start**:
+See [rubrics/README.md](./rubrics/README.md) for available rubrics and usage.
+
+---
+
 ## Usage Patterns
 
 ### Running Examples
@@ -107,6 +148,9 @@ waza run examples/<example-name>/eval.yaml -o results.json
 | **code-explainer** | Complete real-world eval | Medium | code, regex, script |
 | **grader-showcase** | Learning grader types | Low | All types |
 | **ci** | GitHub Actions integration | Low | N/A (workflow examples) |
+| **custom-agent** | `.agent.md` evaluation | Low | tool_constraint, output_contains |
+| **required-skills-demo** | Skill dependency validation | Low | Preflight checks |
+| **rubrics** | Prompt grader rubrics | Low | prompt (rubric-based) |
 
 ## Learning Path
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -5,6 +5,10 @@ description: Complete walkthrough for installing and running waza.
 
 A complete walkthrough for installing waza and running your first evaluation.
 
+:::tip[Custom Agents]
+Waza can also evaluate VS Code custom agents defined in `.agent.md` files. This guide focuses on `SKILL.md`-based skills. For custom agents, see [Evaluating Custom Agents](/waza/guides/custom-agents/) after completing this walkthrough.
+:::
+
 ## Installation
 
 Choose one of three methods:

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -109,7 +109,7 @@ config:
 | `workers`           | int       | 4                 | Number of parallel workers                                  |
 | `model`             | string    | _required_        | Default model for tasks (override with `--model` flag)      |
 | `judge_model`       | string    | (same as `model`) | Model for `prompt`-type graders (LLM-as-judge)              |
-| `executor`          | string    | `copilot-sdk`     | Executor: `mock` (local, fast) or `copilot-sdk` (real API)  |
+| `executor`          | string    | `copilot-sdk`     | Executor: `mock` (local, echoes task metadata and file content) or `copilot-sdk` (real API)  |
 | `max_attempts`      | int       | 0                 | Maximum retry attempts per task on failure (0 = no retries) |
 | `group_by`          | string    | —                 | Group results by a field (e.g., `tags`, `task_id`)          |
 | `fail_fast`         | bool      | false             | Stop the entire run on first task failure                   |

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -7,6 +7,10 @@ import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 Get from zero to running your first evaluation benchmark in 5 minutes.
 
+<Aside type="tip" title="Skills and Custom Agents">
+Waza evaluates both `SKILL.md`-based skills and `.agent.md` custom agents. This guide uses a skill — see [Evaluating Custom Agents](/waza/guides/custom-agents/) if you're targeting a `.agent.md` agent instead.
+</Aside>
+
 ## Prerequisites
 
 - **Go 1.26 or later** (for binary install), or
@@ -164,6 +168,7 @@ graph LR
 - **[Eval YAML Reference](/waza/guides/eval-yaml/)** — Full spec for writing eval files
 - **[Validators & Graders](/waza/guides/graders/)** — All 11 grader types with examples
 - **[Web Dashboard Guide](/waza/guides/dashboard/)** — Features and navigation
+- **[Evaluating Custom Agents](/waza/guides/custom-agents/)** — Evaluate `.agent.md` files with automatic tool constraint validation
 - **[CI/CD Integration](/waza/guides/ci-cd/)** — Automate evaluations in GitHub Actions
 
 ---


### PR DESCRIPTION
## Summary

Comprehensive documentation audit triggered by three recent merges: #222 (BenchmarkSpec/TestRunner rename), #226 (custom agent support), and #228 (mock engine file echo).

## What changed

### .agent.md coverage gaps (#226)
Added custom agent mentions to 6 onboarding entry points that were missed:
- `site/src/content/docs/quick-start.mdx` — added Aside tip + link to custom-agents guide
- `site/src/content/docs/getting-started.mdx` — added tip callout
- `docs/GETTING-STARTED.md` — added blockquote note
- `docs/GUIDE.md` — added bullet to feature list + agent argument to `waza run`
- `docs/TUTORIAL.md` — added note linking to custom agents guide

### Missing examples (#226)
- `examples/README.md` — added entries for `custom-agent`, `required-skills-demo`, and `rubrics` directories

### Mock engine description (#228)
- `docs/INTEGRATION-TESTING.md` — updated mock description from 'Simulates responses' to accurately describe task metadata + file content echo behavior
- `site/src/content/docs/guides/eval-yaml.mdx` — updated executor table description

## What was deliberately NOT changed

- **#222 rename:** No stale `BenchmarkSpec`/`TestRunner` references found in any auditable docs — the rename PR was thorough
- **`docs/design/194-baseline-skill-impact.md`** — contains historical `BenchmarkSpec`/`TestRunner` references; this is a point-in-time design doc, left as-is
- **`docs/images/*`** — not touched per audit scope (separate screenshot workflow)
- **Files already updated by #226** (custom-agents.mdx, eval-yaml.mdx, graders.mdx, cli.mdx, astro.config.mjs) — verified correct, not re-touched

## Verification

- Site builds successfully: 18 pages, 0 errors
