### PR TITLE
feat: wire BYOK providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Generate a skill-to-eval coverage grid showing which skills are fully covered, p
 
 List models available for evaluation via the Copilot SDK. Shows model IDs and metadata that can be used with `--model` flags in `waza run`, `waza quality`, and other commands.
 
-Requires authentication via `copilot login`.
+Requires authentication via `copilot login`. Custom provider configuration only applies when creating or resuming Copilot SDK sessions.
 
 | Flag | Description |
 |------|-------------|
@@ -1175,7 +1175,7 @@ jobs:
 |-------------|---------|
 | **Go Version** | 1.26 or higher |
 | **Executor** | Use `mock` executor for CI (no API keys needed) |
-| **GitHub Token** | Only required for `copilot-sdk` executor: set `GITHUB_TOKEN` env var |
+| **Copilot Auth** | Required for the default `copilot-sdk` route. Custom providers can be configured with `COPILOT_BASE_URL` or `COPILOT_PROVIDER_BASE_URL` instead. |
 | **Exit Codes** | 0=success, 1=test failure, 2=config error |
 
 #### Expected Skill Structure
@@ -1193,6 +1193,29 @@ your-skill/
         │       └── project.instructions.md
         └── *.txt
 ```
+
+#### Custom Copilot SDK Providers
+
+By default, the `copilot-sdk` executor uses GitHub Copilot and requires Copilot authentication. To route sessions through a custom provider supported by the Copilot SDK, set a provider base URL before running Waza:
+
+```bash
+COPILOT_BASE_URL=https://waza-test-resource.openai.azure.com \
+COPILOT_PROVIDER=azure \
+COPILOT_WIRE_API=responses \
+waza run eval/eval.yaml --executor copilot-sdk --model my-model
+```
+
+Supported environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `COPILOT_BASE_URL` or `COPILOT_PROVIDER_BASE_URL` | Custom provider endpoint. When set, Waza skips the Copilot auth check and passes provider config to the SDK. |
+| `COPILOT_PROVIDER` or `COPILOT_PROVIDER_TYPE` | Provider type passed through to the SDK. |
+| `COPILOT_WIRE_API` or `COPILOT_PROVIDER_WIRE_API` | Wire format passed through to the SDK, for example `responses` or `completions`, depending on provider. |
+| `COPILOT_API_KEY` or `COPILOT_PROVIDER_API_KEY` | API key for the custom provider, if required. |
+| `COPILOT_BEARER_TOKEN` or `COPILOT_PROVIDER_BEARER_TOKEN` | Bearer token for the custom provider, if required. |
+
+When a custom provider is active, the CLI usage summary labels the SDK request counter as `Provider Requests` instead of `Premium Requests`. Result JSON records `usage.provider: "custom"` and a sanitized `usage.provider_host`; it does not store the full provider URL.
 
 ### For Waza Repository
 

--- a/README.md
+++ b/README.md
@@ -1175,7 +1175,7 @@ jobs:
 |-------------|---------|
 | **Go Version** | 1.26 or higher |
 | **Executor** | Use `mock` executor for CI (no API keys needed) |
-| **Copilot Auth** | Required for the default `copilot-sdk` route. Custom providers can be configured with `COPILOT_BASE_URL` or `COPILOT_PROVIDER_BASE_URL` instead. |
+| **Copilot Auth** | Required for the default `copilot-sdk` route; set `GITHUB_TOKEN` in CI. Custom providers can be configured with `COPILOT_BASE_URL` or `COPILOT_PROVIDER_BASE_URL` instead. |
 | **Exit Codes** | 0=success, 1=test failure, 2=config error |
 
 #### Expected Skill Structure

--- a/cmd/waza/cmd_run.go
+++ b/cmd/waza/cmd_run.go
@@ -1261,8 +1261,26 @@ func printUsageSummary(usage *models.UsageStats) {
 	fmt.Println(" USAGE SUMMARY")
 	fmt.Println("-" + strings.Repeat("-", 50))
 
+	switch usage.Provider {
+	case models.UsageProviderCustom:
+		if usage.ProviderHost != "" {
+			fmt.Printf("  Provider:                 custom (%s)\n", usage.ProviderHost)
+		} else {
+			fmt.Println("  Provider:                 custom")
+		}
+	case models.UsageProviderMixed:
+		fmt.Println("  Provider:                 mixed")
+	}
+
 	if usage.PremiumRequests > 0 {
-		fmt.Printf("  Premium Requests:         %.0f\n", usage.PremiumRequests)
+		label := "Premium Requests"
+		switch usage.Provider {
+		case models.UsageProviderCustom:
+			label = "Provider Requests"
+		case models.UsageProviderMixed:
+			label = "Requests"
+		}
+		fmt.Printf("  %-25s %.0f\n", label+":", usage.PremiumRequests)
 	}
 	if usage.Turns > 0 {
 		fmt.Printf("  Turns:                    %s\n", printer.Sprint(usage.Turns))

--- a/cmd/waza/tokens/compare_test.go
+++ b/cmd/waza/tokens/compare_test.go
@@ -34,6 +34,7 @@ func initRepo(t *testing.T) string {
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test"},
 		{"git", "config", "core.safecrlf", "false"},
+		{"git", "config", "commit.gpgsign", "false"},
 	}
 	for _, args := range cmds {
 		cmd := exec.Command(args[0], args[1:]...)

--- a/cmd/waza/tokens/internal/git/git_test.go
+++ b/cmd/waza/tokens/internal/git/git_test.go
@@ -38,6 +38,7 @@ func initTestRepo(t *testing.T) string {
 	runGit(t, dir, "init")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
 	return dir
 }
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -521,7 +521,7 @@ And that you have `.yaml` files in `tasks/` directory.
 
 ### "Mock executor always passes"
 
-The `mock` executor is meant for local iteration without API calls. For real evaluation, use `executor: copilot-sdk` and set `GITHUB_TOKEN`.
+The `mock` executor is meant for local iteration without API calls. For real evaluation, use `executor: copilot-sdk` with the default Copilot route or configure a custom Copilot SDK provider with `COPILOT_BASE_URL` / `COPILOT_PROVIDER_BASE_URL`.
 
 ---
 

--- a/docs/SKILLS_CI_INTEGRATION.md
+++ b/docs/SKILLS_CI_INTEGRATION.md
@@ -249,7 +249,7 @@ config:
   model: claude-sonnet-4-20250514  # or gpt-4o, etc.
 ```
 
-And set the `GITHUB_TOKEN` environment variable in your workflow:
+For the default Copilot route, set the `GITHUB_TOKEN` environment variable in your workflow. If your Copilot SDK setup uses a custom provider, configure the provider environment variables instead.
 
 ```yaml
 - name: Run Evaluation with Copilot

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,6 +43,103 @@ type CopilotEngine struct {
 
 	shutdownOnce sync.Once
 	shutdownErr  error
+
+	provider customProviderConfig
+}
+
+type customProviderConfig struct {
+	config *copilot.ProviderConfig
+	host   string
+}
+
+func (p customProviderConfig) enabled() bool {
+	return p.config != nil
+}
+
+func (p customProviderConfig) sessionConfig() *copilot.ProviderConfig {
+	if p.config == nil {
+		return nil
+	}
+	clone := *p.config
+	return &clone
+}
+
+func (p customProviderConfig) applyToUsage(usage *models.UsageStats) {
+	if usage == nil || !p.enabled() {
+		return
+	}
+	usage.Provider = models.UsageProviderCustom
+	usage.ProviderHost = p.host
+}
+
+// providerFromEnv assembles a BYOK ProviderConfig from environment variables.
+// Returns an empty config when no custom provider base URL is set, leaving sessions on the
+// default Copilot MaaS path. When set, fields are populated only when the
+// matching env var is non-empty; the SDK supplies its own documented defaults
+// for unset fields, so the executor does not hardcode provider-specific
+// values.
+//
+// Each field accepts a short canonical name and a longer COPILOT_PROVIDER_*
+// alias for backward compatibility. The short name wins when both are set.
+//
+//	COPILOT_BASE_URL      or COPILOT_PROVIDER_BASE_URL        - endpoint URL.
+//	COPILOT_PROVIDER      or COPILOT_PROVIDER_TYPE            - provider type.
+//	COPILOT_WIRE_API      or COPILOT_PROVIDER_WIRE_API        - wire format.
+//	COPILOT_API_KEY       or COPILOT_PROVIDER_API_KEY         - API key.
+//	COPILOT_BEARER_TOKEN  or COPILOT_PROVIDER_BEARER_TOKEN    - bearer token.
+func providerFromEnv() customProviderConfig {
+	base := envFirst("COPILOT_BASE_URL", "COPILOT_PROVIDER_BASE_URL")
+	if base == "" {
+		return customProviderConfig{}
+	}
+	p := &copilot.ProviderConfig{BaseURL: base}
+	if v := envFirst("COPILOT_PROVIDER", "COPILOT_PROVIDER_TYPE"); v != "" {
+		p.Type = v
+	}
+	if v := envFirst("COPILOT_WIRE_API", "COPILOT_PROVIDER_WIRE_API"); v != "" {
+		p.WireApi = v
+	}
+	if v := envFirst("COPILOT_API_KEY", "COPILOT_PROVIDER_API_KEY"); v != "" {
+		p.APIKey = v
+	}
+	if v := envFirst("COPILOT_BEARER_TOKEN", "COPILOT_PROVIDER_BEARER_TOKEN"); v != "" {
+		p.BearerToken = v
+	}
+	return customProviderConfig{
+		config: p,
+		host:   providerHost(base),
+	}
+}
+
+func providerHost(base string) string {
+	host := parsedProviderHost(base)
+	if host != "" {
+		return host
+	}
+	host = parsedProviderHost("http://" + base)
+	if host != "" {
+		return host
+	}
+	return ""
+}
+
+func parsedProviderHost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// envFirst returns the value of the first non-empty environment variable
+// among the provided names, or "" when none are set.
+func envFirst(names ...string) string {
+	for _, name := range names {
+		if v := os.Getenv(name); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // CopilotEngineBuilder builds a CopilotEngine with options
@@ -76,6 +174,7 @@ func NewCopilotEngineBuilder(defaultModelID string, options *CopilotEngineBuilde
 	builder := &CopilotEngineBuilder{
 		engine: &CopilotEngine{
 			defaultModelID: defaultModelID,
+			provider:       providerFromEnv(),
 		},
 	}
 
@@ -104,6 +203,12 @@ func (e *CopilotEngine) Initialize(ctx context.Context) error {
 		startErr = e.client.Start(context.Background())
 
 		if startErr != nil {
+			return
+		}
+
+		// BYOK mode: a custom provider redirects model traffic away from
+		// GitHub Copilot MaaS, so the Copilot auth check is irrelevant.
+		if e.provider.enabled() {
 			return
 		}
 
@@ -209,6 +314,7 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 			SystemMessage:    systemMessage,
 			Streaming:        req.Streaming,
 			MCPServers:       req.MCPServers,
+			Provider:         e.provider.sessionConfig(),
 		})
 
 		if err != nil {
@@ -227,6 +333,7 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 			SystemMessage:    systemMessage,
 			Streaming:        req.Streaming,
 			MCPServers:       req.MCPServers,
+			Provider:         e.provider.sessionConfig(),
 		})
 
 		if err != nil {
@@ -327,6 +434,8 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	}
 
 	// Build response
+	usage := usageCollector.UsageStats()
+	e.provider.applyToUsage(usage)
 	resp := &ExecutionResponse{
 		FinalOutput:      joinStrings(eventsCollector.OutputParts()),
 		Events:           eventsCollector.SessionEvents(),
@@ -339,7 +448,7 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 		WorkspaceDir:     workspaceDir,
 		WorkspaceFiles:   workspaceFiles,
 		SessionID:        sessionID,
-		Usage:            usageCollector.UsageStats(),
+		Usage:            usage,
 	}
 
 	return resp, nil
@@ -401,6 +510,9 @@ func (e *CopilotEngine) doShutdown(ctx context.Context) error {
 
 // SessionUsage returns the final usage stats for a session. Call after Shutdown()
 // to get data from session.shutdown events (ModelMetrics, TotalPremiumRequests).
+// When BYOK was active for this session, the returned stats include sanitized
+// provider metadata so downstream consumers can label PremiumRequests accurately
+// (custom endpoint vs Copilot MaaS).
 func (e *CopilotEngine) SessionUsage(sessionID string) *models.UsageStats {
 	e.usageCollectorsMu.RLock()
 	defer e.usageCollectorsMu.RUnlock()
@@ -408,6 +520,7 @@ func (e *CopilotEngine) SessionUsage(sessionID string) *models.UsageStats {
 	var usage *models.UsageStats
 	if u := e.usageCollectors[sessionID]; u != nil {
 		usage = u.UsageStats()
+		e.provider.applyToUsage(usage)
 	}
 	return usage
 }

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -50,10 +50,11 @@ type CopilotEngine struct {
 type customProviderConfig struct {
 	config *copilot.ProviderConfig
 	host   string
+	err    error
 }
 
 func (p customProviderConfig) enabled() bool {
-	return p.config != nil
+	return p.config != nil && p.err == nil
 }
 
 func (p customProviderConfig) sessionConfig() *copilot.ProviderConfig {
@@ -92,6 +93,10 @@ func providerFromEnv() customProviderConfig {
 	if base == "" {
 		return customProviderConfig{}
 	}
+	host, err := providerHost(base)
+	if err != nil {
+		return customProviderConfig{err: err}
+	}
 	p := &copilot.ProviderConfig{BaseURL: base}
 	if v := envFirst("COPILOT_PROVIDER", "COPILOT_PROVIDER_TYPE"); v != "" {
 		p.Type = v
@@ -107,28 +112,19 @@ func providerFromEnv() customProviderConfig {
 	}
 	return customProviderConfig{
 		config: p,
-		host:   providerHost(base),
+		host:   host,
 	}
 }
 
-func providerHost(base string) string {
-	host := parsedProviderHost(base)
-	if host != "" {
-		return host
-	}
-	host = parsedProviderHost("http://" + base)
-	if host != "" {
-		return host
-	}
-	return ""
-}
-
-func parsedProviderHost(raw string) string {
-	u, err := url.Parse(raw)
+func providerHost(base string) (string, error) {
+	u, err := url.Parse(base)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("invalid custom Copilot provider base URL: could not parse URL")
 	}
-	return u.Host
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid custom Copilot provider base URL: must include scheme and host")
+	}
+	return u.Host, nil
 }
 
 // envFirst returns the value of the first non-empty environment variable
@@ -196,6 +192,11 @@ func (e *CopilotEngine) Initialize(ctx context.Context) error {
 	var startErr error
 
 	e.startOnce.Do(func() {
+		if e.provider.err != nil {
+			startErr = e.provider.err
+			return
+		}
+
 		// NOTE: we _have_ to use context.Background() - the copilot SDK is using exec.CommandContext() to run
 		// the background process which means we _cannot_ cancel the context passed to this function or else
 		// it'll kill the copilot process.

--- a/internal/execution/copilot_test.go
+++ b/internal/execution/copilot_test.go
@@ -306,8 +306,25 @@ func TestProviderFromEnv_SanitizesHost(t *testing.T) {
 	t.Setenv("COPILOT_BASE_URL", "https://user:secret@example.test:8443/v1?token=abc")
 
 	provider := providerFromEnv()
+	require.NoError(t, provider.err)
 	require.True(t, provider.enabled())
 	require.Equal(t, "example.test:8443", provider.host)
+}
+
+func TestCopilotInitialize_CustomProviderRejectsInvalidBaseURL(t *testing.T) {
+	t.Setenv("COPILOT_BASE_URL", "waza-test-resource.openai.azure.com/openai/v1")
+	t.Setenv("COPILOT_PROVIDER_BASE_URL", "")
+
+	ctrl := gomock.NewController(t)
+	clientMock := NewMockCopilotClient(ctrl)
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(clientOptions *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+
+	err := engine.Initialize(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid custom Copilot provider base URL")
 }
 
 func TestCopilotResumeSessionID_Live(t *testing.T) {

--- a/internal/execution/copilot_test.go
+++ b/internal/execution/copilot_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/errgroup"
@@ -130,6 +131,183 @@ func TestCopilotResumeSessionID(t *testing.T) {
 	require.Equal(t, "session-1", resp.SessionID)
 	require.Empty(t, resp.ErrorMsg)
 	require.True(t, resp.Success)
+}
+
+func TestCopilotInitialize_CustomProviderSkipsAuth(t *testing.T) {
+	t.Setenv("COPILOT_BASE_URL", "https://waza-test-resource.openai.azure.com/openai/v1")
+	t.Setenv("COPILOT_PROVIDER_BASE_URL", "")
+
+	ctrl := gomock.NewController(t)
+	clientMock := NewMockCopilotClient(ctrl)
+
+	clientMock.EXPECT().Start(gomock.Any()).Times(1)
+	clientMock.EXPECT().Stop().Times(1)
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(clientOptions *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+	defer func() {
+		require.NoError(t, engine.Shutdown(context.Background()))
+	}()
+
+	require.NoError(t, engine.Initialize(context.Background()))
+}
+
+func TestCopilotCreateSession_PassesCustomProvider(t *testing.T) {
+	t.Setenv("COPILOT_BASE_URL", "https://waza-test-resource.openai.azure.com/openai/v1")
+	t.Setenv("COPILOT_PROVIDER_BASE_URL", "")
+	t.Setenv("COPILOT_PROVIDER", "openai")
+	t.Setenv("COPILOT_PROVIDER_TYPE", "")
+	t.Setenv("COPILOT_WIRE_API", "chat_completions")
+	t.Setenv("COPILOT_PROVIDER_WIRE_API", "")
+	t.Setenv("COPILOT_API_KEY", "test-key")
+	t.Setenv("COPILOT_PROVIDER_API_KEY", "")
+	t.Setenv("COPILOT_BEARER_TOKEN", "token")
+	t.Setenv("COPILOT_PROVIDER_BEARER_TOKEN", "")
+
+	ctrl := gomock.NewController(t)
+	clientMock := NewMockCopilotClient(ctrl)
+	sessionMock := NewMockCopilotSession(ctrl)
+
+	clientMock.EXPECT().Start(gomock.Any()).Times(1)
+	clientMock.EXPECT().Stop().Times(1)
+
+	sourceDir := t.TempDir()
+	expectedConfig := sessionConfigMatcher{
+		t:         t,
+		sourceDir: sourceDir,
+		expected: copilot.SessionConfig{
+			Model:               "gpt-4o-mini",
+			SkillDirectories:    []string{sourceDir},
+			OnPermissionRequest: allowAllTools,
+			Provider: &copilot.ProviderConfig{
+				Type:        "openai",
+				BaseURL:     "https://waza-test-resource.openai.azure.com/openai/v1",
+				WireApi:     "chat_completions",
+				APIKey:      "test-key",
+				BearerToken: "token",
+			},
+		},
+	}
+
+	clientMock.EXPECT().CreateSession(gomock.Any(), expectedConfig).Return(sessionMock, nil)
+	sessionMock.EXPECT().Disconnect()
+	clientMock.EXPECT().DeleteSession(gomock.Any(), "session-1")
+
+	var eventHandlers []func(copilot.SessionEvent)
+	sessionMock.EXPECT().On(gomock.Any()).Times(3).DoAndReturn(func(handler func(copilot.SessionEvent)) func() {
+		eventHandlers = append(eventHandlers, handler)
+		return func() {}
+	})
+	sessionMock.EXPECT().SendAndWait(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ copilot.MessageOptions) (*copilot.SessionEvent, error) {
+			in, out, cost := float64(10), float64(2), float64(1)
+			for _, handler := range eventHandlers {
+				handler(copilot.SessionEvent{
+					Type: copilot.SessionEventTypeAssistantUsage,
+					Data: &copilot.AssistantUsageData{
+						InputTokens:  &in,
+						OutputTokens: &out,
+						Cost:         &cost,
+						Model:        "gpt-4o-mini",
+					},
+				})
+			}
+			return &copilot.SessionEvent{}, nil
+		},
+	)
+	sessionMock.EXPECT().SessionID().Return("session-1")
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(clientOptions *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+	t.Setenv("COPILOT_BASE_URL", "http://changed.invalid/v1")
+	defer func() {
+		require.NoError(t, engine.Shutdown(context.Background()))
+	}()
+
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message:   "hello?",
+		Timeout:   time.Minute,
+		SourceDir: sourceDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Usage)
+	require.Equal(t, models.UsageProviderCustom, resp.Usage.Provider)
+	require.Equal(t, "waza-test-resource.openai.azure.com", resp.Usage.ProviderHost)
+}
+
+func TestCopilotResumeSession_PassesCustomProvider(t *testing.T) {
+	t.Setenv("COPILOT_PROVIDER_BASE_URL", "https://waza-test-resource.openai.azure.com/openai/v1")
+	t.Setenv("COPILOT_BASE_URL", "")
+	t.Setenv("COPILOT_PROVIDER", "")
+	t.Setenv("COPILOT_PROVIDER_TYPE", "openai")
+	t.Setenv("COPILOT_WIRE_API", "")
+	t.Setenv("COPILOT_PROVIDER_WIRE_API", "responses")
+	t.Setenv("COPILOT_API_KEY", "")
+	t.Setenv("COPILOT_PROVIDER_API_KEY", "")
+	t.Setenv("COPILOT_BEARER_TOKEN", "")
+	t.Setenv("COPILOT_PROVIDER_BEARER_TOKEN", "")
+
+	ctrl := gomock.NewController(t)
+	clientMock := NewMockCopilotClient(ctrl)
+	sessionMock := NewMockCopilotSession(ctrl)
+
+	clientMock.EXPECT().Start(gomock.Any()).Times(1)
+	clientMock.EXPECT().Stop().Times(1)
+
+	sourceDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	expectedConfig := sessionConfigMatcher{
+		t:         t,
+		sourceDir: sourceDir,
+		expected: copilot.ResumeSessionConfig{
+			Model:               "gpt-4o-mini",
+			SkillDirectories:    []string{sourceDir},
+			OnPermissionRequest: allowAllTools,
+			Provider: &copilot.ProviderConfig{
+				Type:    "openai",
+				BaseURL: "https://waza-test-resource.openai.azure.com/openai/v1",
+				WireApi: "responses",
+			},
+		},
+	}
+
+	clientMock.EXPECT().ResumeSessionWithOptions(gomock.Any(), "session-1", expectedConfig).Return(sessionMock, nil)
+	sessionMock.EXPECT().Disconnect()
+	clientMock.EXPECT().DeleteSession(gomock.Any(), "session-1")
+
+	sessionMock.EXPECT().On(gomock.Any()).Times(3).Return(func() {})
+	sessionMock.EXPECT().SendAndWait(gomock.Any(), gomock.Any()).Return(&copilot.SessionEvent{}, nil)
+	sessionMock.EXPECT().SessionID().Return("session-1")
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(clientOptions *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+	defer func() {
+		require.NoError(t, engine.Shutdown(context.Background()))
+	}()
+
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message:   "hello?",
+		SessionID: "session-1",
+		Timeout:   time.Minute,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+}
+
+func TestProviderFromEnv_SanitizesHost(t *testing.T) {
+	t.Setenv("COPILOT_BASE_URL", "https://user:secret@example.test:8443/v1?token=abc")
+
+	provider := providerFromEnv()
+	require.True(t, provider.enabled())
+	require.Equal(t, "example.test:8443", provider.host)
 }
 
 func TestCopilotResumeSessionID_Live(t *testing.T) {

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -179,7 +179,21 @@ type SessionDigest struct {
 	SessionID     string      `json:"session_id,omitempty"`
 }
 
+const (
+	// UsageProviderCustom indicates request counters came from a BYOK/custom provider.
+	UsageProviderCustom = "custom"
+
+	// UsageProviderMixed indicates aggregate usage spans different provider routes.
+	UsageProviderMixed = "mixed"
+)
+
 // UsageStats holds token and premium request usage data from a Copilot SDK session.
+//
+// Provider is empty for the default Copilot MaaS path. When it is "custom",
+// PremiumRequests should be read as custom-provider request count rather than
+// GitHub Copilot premium billing. ProviderHost may contain a sanitized host
+// from the custom provider base URL; it intentionally omits scheme, path, query,
+// and credentials.
 type UsageStats struct {
 	Turns            int                   `json:"turns"`
 	InputTokens      int                   `json:"input_tokens"`
@@ -187,6 +201,8 @@ type UsageStats struct {
 	CacheReadTokens  int                   `json:"cache_read_tokens"`
 	CacheWriteTokens int                   `json:"cache_write_tokens"`
 	PremiumRequests  float64               `json:"premium_requests"`
+	Provider         string                `json:"provider,omitempty"`
+	ProviderHost     string                `json:"provider_host,omitempty"`
 	ModelMetrics     map[string]ModelUsage `json:"model_metrics,omitempty"`
 }
 
@@ -208,13 +224,27 @@ type ModelUsage struct {
 }
 
 // AggregateUsageStats sums usage across multiple UsageStats (e.g. across runs).
+// Provider metadata is preserved when all aggregated stats share the same route.
+// If usage spans multiple provider routes, Provider is set to "mixed" so
+// consumers avoid labeling the aggregate as purely Copilot premium or BYOK.
 func AggregateUsageStats(stats []*UsageStats) *UsageStats {
 	agg := &UsageStats{
 		ModelMetrics: make(map[string]ModelUsage),
 	}
+	var provider string
+	var providerHost string
+	providerSet := false
+	providerConsistent := true
 	for _, s := range stats {
 		if s == nil {
 			continue
+		}
+		if !providerSet {
+			provider = s.Provider
+			providerHost = s.ProviderHost
+			providerSet = true
+		} else if provider != s.Provider || providerHost != s.ProviderHost {
+			providerConsistent = false
 		}
 		agg.Turns += s.Turns
 		agg.InputTokens += s.InputTokens
@@ -235,6 +265,12 @@ func AggregateUsageStats(stats []*UsageStats) *UsageStats {
 	}
 	if agg.IsZero() && len(agg.ModelMetrics) == 0 {
 		return nil
+	}
+	if providerConsistent {
+		agg.Provider = provider
+		agg.ProviderHost = providerHost
+	} else {
+		agg.Provider = UsageProviderMixed
 	}
 	return agg
 }

--- a/internal/models/outcome_test.go
+++ b/internal/models/outcome_test.go
@@ -177,6 +177,48 @@ func TestAggregateUsageStats(t *testing.T) {
 	require.Equal(t, 1400, agg.ModelMetrics["gpt-4o"].InputTokens)
 }
 
+func TestAggregateUsageStats_PreservesCustomProviderWhenConsistent(t *testing.T) {
+	stats := []*UsageStats{
+		{
+			InputTokens:     100,
+			PremiumRequests: 1,
+			Provider:        UsageProviderCustom,
+			ProviderHost:    "waza-test-resource.openai.azure.com",
+		},
+		{
+			OutputTokens:    50,
+			PremiumRequests: 1,
+			Provider:        UsageProviderCustom,
+			ProviderHost:    "waza-test-resource.openai.azure.com",
+		},
+	}
+
+	agg := AggregateUsageStats(stats)
+	require.NotNil(t, agg)
+	require.Equal(t, UsageProviderCustom, agg.Provider)
+	require.Equal(t, "waza-test-resource.openai.azure.com", agg.ProviderHost)
+}
+
+func TestAggregateUsageStats_MarksProviderMixedWhenInconsistent(t *testing.T) {
+	stats := []*UsageStats{
+		{
+			InputTokens:     100,
+			PremiumRequests: 1,
+		},
+		{
+			OutputTokens:    50,
+			PremiumRequests: 1,
+			Provider:        UsageProviderCustom,
+			ProviderHost:    "waza-test-resource.openai.azure.com",
+		},
+	}
+
+	agg := AggregateUsageStats(stats)
+	require.NotNil(t, agg)
+	require.Equal(t, UsageProviderMixed, agg.Provider)
+	require.Empty(t, agg.ProviderHost)
+}
+
 func TestAggregateUsageStats_AllNil(t *testing.T) {
 	require.Nil(t, AggregateUsageStats([]*UsageStats{nil, nil}))
 }

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -13,8 +13,8 @@ Waza evaluates both `SKILL.md`-based skills and `.agent.md` custom agents. This 
 
 ## Prerequisites
 
-- **GitHub Copilot access** (for `copilot login`)
-- **Go 1.26 or later** and **Git LFS** only if installing from source
+- **GitHub Copilot access** for the default provider, or custom Copilot SDK provider environment variables.
+- **Go 1.26 or later** and **Git LFS** only if installing from source.
 
 ## 1. Install
 
@@ -60,13 +60,17 @@ All commands below use `waza` — with azd extension, replace with `azd waza`.
 
 ## 2. Authenticate
 
-Waza needs GitHub Copilot access for running evaluations:
+By default, Waza uses the `copilot-sdk` executor and needs GitHub Copilot access for running evaluations:
 
 ```bash
 copilot login
 ```
 
 This opens your browser to authenticate. After login, you're ready to go.
+
+<Aside type="note" title="Custom Provider">
+If your Copilot SDK setup uses a custom provider, set `COPILOT_BASE_URL` or `COPILOT_PROVIDER_BASE_URL` instead. Waza will pass the provider configuration to the SDK and skip the default Copilot auth check.
+</Aside>
 
 ## 3. Create Your First Skill
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -858,7 +858,7 @@ A solid skill with good clarity and triggers.
 
 ### Authentication
 
-Requires Copilot authentication. If not authenticated, you will see:
+Requires Copilot authentication when using the default provider. If not authenticated, you will see:
 
 ```
 Error: not authenticated — run "copilot login" first
@@ -906,7 +906,7 @@ gpt-4o            GPT-4o            yes       128k
 
 ### Authentication
 
-Requires Copilot authentication. If not authenticated, you will see:
+Requires Copilot authentication when using the default provider. If not authenticated, you will see:
 
 ```
 Error: not authenticated — run "copilot login" first
@@ -956,9 +956,16 @@ A newer version of waza is available: v0.24.0 → v0.28.0. Run: curl -fsSL ... |
 | Variable | Description |
 |----------|-------------|
 | `GITHUB_TOKEN` | Token for Copilot SDK execution |
+| `COPILOT_BASE_URL` / `COPILOT_PROVIDER_BASE_URL` | Custom Copilot SDK provider endpoint. When set, Waza skips the default Copilot auth check and passes provider config to the SDK. |
+| `COPILOT_PROVIDER` / `COPILOT_PROVIDER_TYPE` | Provider type passed through to the Copilot SDK. |
+| `COPILOT_WIRE_API` / `COPILOT_PROVIDER_WIRE_API` | Wire format passed through to the Copilot SDK, for example `responses` or `completions`, depending on provider. |
+| `COPILOT_API_KEY` / `COPILOT_PROVIDER_API_KEY` | API key for the custom provider, if required. |
+| `COPILOT_BEARER_TOKEN` / `COPILOT_PROVIDER_BEARER_TOKEN` | Bearer token for the custom provider, if required. |
 | `WAZA_HOME` | Config directory (default: `~/.waza`) |
 | `WAZA_CACHE` | Cache directory (default: `.waza-cache`) |
 | `WAZA_NO_UPDATE_CHECK` | Set to `1` to disable automatic version check |
+
+When a custom provider is active, usage output labels the SDK request counter as `Provider Requests` instead of `Premium Requests`. Result JSON records `usage.provider: "custom"` and a sanitized `usage.provider_host`; the full provider URL is not stored.
 
 ## Next Steps
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -906,7 +906,7 @@ gpt-4o            GPT-4o            yes       128k
 
 ### Authentication
 
-Requires Copilot authentication when using the default provider. If not authenticated, you will see:
+Requires Copilot authentication. Custom provider configuration only applies when creating or resuming Copilot SDK sessions. If not authenticated, you will see:
 
 ```
 Error: not authenticated — run "copilot login" first


### PR DESCRIPTION
  ## Summary

  Adds a clean custom-provider lane for the Copilot SDK executor:

  - passes `COPILOT_*` provider env vars into session create/resume
  - skips default Copilot auth checks when a custom provider is configured
  - labels custom-provider request counts as `Provider Requests`
  - records only sanitized provider metadata in result JSON
  - updates docs for the new env vars and usage semantics

  Also disables GPG signing in temp git repos used by token tests.

  ## Validation

  - `go test ./...`
  - `cd site && npm ci --include=optional`
  - `cd site && npm run build`