### PR TITLE
docs: clarify Windows install guidance

### DIFF
--- a/DEMO-SCRIPT.md
+++ b/DEMO-SCRIPT.md
@@ -16,7 +16,7 @@
 cd ~/demo && rm -rf waza-demo
 mkdir waza-demo && cd waza-demo
 
-# Install waza
+# Install waza (macOS/Linux or Windows Git Bash/MSYS/Cygwin)
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A Go CLI for evaluating AI agent skills — scaffold eval suites, run benchmarks
 
 ### Binary Install (recommended)
 
-Download and install the latest pre-built binary with the install script:
+Download and install the latest pre-built binary with the Bash install script on macOS, Linux, or Windows Bash environments such as Git Bash, MSYS2, or Cygwin:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
-The script auto-detects your OS and architecture (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable).
+The script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable). On Windows, piping this command to `bash` from PowerShell may invoke WSL and install the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` directly from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 Or download binaries directly from the [latest release](https://github.com/microsoft/waza/releases/latest).
 

--- a/docs/DEMO-GUIDE.md
+++ b/docs/DEMO-GUIDE.md
@@ -11,7 +11,7 @@ This guide provides step-by-step instructions for 9 practical demonstrations cov
 Before any demo, ensure waza is installed:
 
 ```bash
-# Option A: Binary install (recommended)
+# Option A: Binary install (macOS/Linux or Windows Git Bash/MSYS/Cygwin)
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 
 # Option B: Build from source
@@ -841,4 +841,3 @@ See [docs/GRADERS.md](./GRADERS.md) for implementing custom script graders.
 - **[GRADERS.md](./GRADERS.md)** — Complete grader reference
 - **[DEMO-SCRIPT.md](../DEMO-SCRIPT.md)** — Presentation script for live demos
 - **[examples/README.md](../examples/README.md)** — Example descriptions
-

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -23,11 +23,13 @@ Choose one of three methods:
 
 ### 1. Binary Install (Recommended)
 
-The fastest way to get started. The script auto-detects your OS and architecture:
+The fastest way to get started on macOS, Linux, or Windows Bash environments such as Git Bash, MSYS2, or Cygwin:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
+
+The script auto-detects the environment where Bash is running. If you run this from PowerShell and `bash` resolves to WSL, it installs the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 This downloads the latest release, verifies the checksum, and installs the `waza` binary to:
 - `/usr/local/bin/waza` (if writable), or

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -8,8 +8,10 @@ This tutorial walks you through creating evaluations for your Agent Skills.
 
 - `waza` CLI installed:
   ```bash
+  # macOS/Linux or Windows Git Bash/MSYS/Cygwin
   curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
   ```
+  For native Windows, download the Windows binary from the [latest release](https://github.com/microsoft/waza/releases/latest).
 - An existing skill to evaluate
 
 ## Step 1: Initialize Your Eval Suite
@@ -389,6 +391,7 @@ Add to your GitHub Actions workflow:
 ```yaml
 - name: Run Skill Evals
   run: |
+    # Linux runner
     curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
     waza run ./my-skill/eval.yaml \
       --output results.json \

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,12 @@ detect_arch() {
   esac
 }
 
+# Detect whether Linux is actually WSL. In that case the Linux binary is the
+# right install target for this shell, but users often expected native Windows.
+is_wsl() {
+  [ -r /proc/sys/kernel/osrelease ] && grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease
+}
+
 # Determine install directory
 install_dir() {
   if [ -w /usr/local/bin ]; then
@@ -51,6 +57,10 @@ main() {
   arch="$(detect_arch)"
 
   echo "Detected platform: ${os}/${arch}"
+  if [ "$os" = "linux" ] && is_wsl; then
+    echo "Note: Detected WSL; installing the Linux binary inside WSL."
+    echo "For native Windows, download waza-windows-${arch}.exe from https://github.com/${REPO}/releases/latest."
+  fi
 
   # Get latest binary release tag (filter for v* tags; skip azd extension releases)
   tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -15,11 +15,13 @@ Choose one of three methods:
 
 ### 1. Binary Install (Recommended)
 
-The fastest way to get started. The script auto-detects your OS and architecture:
+The fastest way to get started on macOS, Linux, or Windows Bash environments such as Git Bash, MSYS2, or Cygwin:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
+
+The script auto-detects the environment where Bash is running. If you run this from PowerShell and `bash` resolves to WSL, it installs the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 This downloads the latest release, verifies the checksum, and installs the `waza` binary to:
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -40,6 +40,7 @@ Perfect for skill authors, platform teams, and developers building AI-powered ap
 Get from zero to your first evaluation benchmark in **5 minutes**:
 
 ```bash
+# macOS/Linux or Windows Git Bash/MSYS/Cygwin
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 waza init my-eval-suite
 cd my-eval-suite

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -21,9 +21,18 @@ Waza evaluates both `SKILL.md`-based skills and `.agent.md` custom agents. This 
 Choose one method:
 
 <Tabs>
-<TabItem label="Binary (Recommended)">
+<TabItem label="macOS / Linux / Bash">
 ```bash
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
+waza --version
+```
+The Bash installer detects the environment where Bash is running. From PowerShell, `bash` may resolve to WSL and install the Linux binary inside WSL.
+</TabItem>
+
+<TabItem label="Windows">
+Download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+
+```powershell
 waza --version
 ```
 </TabItem>

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -8,9 +8,12 @@ Complete reference for all `waza` CLI commands and their options.
 ## Installation
 
 ```bash
+# macOS/Linux or Windows Git Bash/MSYS/Cygwin
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 waza --version
 ```
+
+For native Windows PowerShell, download the Windows binary from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 ## waza run
 

--- a/site/src/content/docs/reference/releases.mdx
+++ b/site/src/content/docs/reference/releases.mdx
@@ -53,12 +53,12 @@ Pre-built binaries for all major platforms:
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
+On Windows, use this command only from Git Bash, MSYS2, or Cygwin. If PowerShell pipes to WSL's `bash.exe`, the script installs the Linux binary inside WSL.
+
 </TabItem>
 <TabItem label="Windows (PowerShell)">
 
-```powershell
-iwr -useb https://raw.githubusercontent.com/microsoft/waza/main/install.ps1 | iex
-```
+Download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary
- clarify that `install.sh` detects the Bash environment where it runs
- warn WSL users that the script installs the Linux binary inside WSL
- update README/docs install guidance for native Windows and remove the missing `install.ps1` reference

Closes #241

## Validation
- `bash -n install.sh`
- `cd site && npm ci --quiet && npm run build`