### PR TITLE
docs: fix unsupported go install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or download binaries directly from the [latest release](https://github.com/micro
 
 Requires Go 1.26+:
 
-NOTE, due to the use of LFS artifacts you cannot install waza using `go install`. To install waza, outside of a normal release, you'll need to clone the repository:
+Note: due to the use of LFS artifacts you cannot install waza using `go install`. To install waza outside of a normal release, clone the repository:
 
 ```bash
 git clone https://github.com/microsoft/waza.git
@@ -1113,8 +1113,12 @@ curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | ba
 
 **Option 2: Install from source**
 ```bash
-# Requires Go 1.26+
-go install github.com/microsoft/waza/cmd/waza@latest
+# Requires Go 1.26+ and Git LFS
+git clone https://github.com/microsoft/waza.git
+cd waza
+git lfs install
+git lfs pull
+go build -o waza ./cmd/waza
 ```
 
 **Option 3: Use Docker**

--- a/docs/CI-CD-GUIDE.md
+++ b/docs/CI-CD-GUIDE.md
@@ -14,7 +14,7 @@ Running waza evaluations in CI/CD allows you to:
 
 ## Prerequisites
 
-- Go 1.26+ or waza binary in your PATH
+- waza binary in your PATH (install with the script below)
 - A skill repository with an `eval.yaml` file
 - Credentials for LLM APIs (Copilot SDK, OpenAI, etc.) — usually stored as GitHub Actions secrets
 
@@ -24,20 +24,13 @@ Running waza evaluations in CI/CD allows you to:
 
 ```yaml
 - name: Install waza
-  run: go install github.com/microsoft/waza/cmd/waza@latest
-```
-
-Or use the official installer:
-
-```yaml
-- name: Install waza
   run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
 ### Azure DevOps Pipelines
 
 ```yaml
-- script: go install github.com/microsoft/waza/cmd/waza@latest
+- script: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
   displayName: Install waza
 ```
 
@@ -63,13 +56,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.26'
-
       - name: Install waza
-        run: go install github.com/microsoft/waza/cmd/waza@latest
+        run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 
       - name: Run evaluation
         run: waza run evals/my-skill/eval.yaml \
@@ -118,13 +106,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.26'
-
       - name: Install waza
-        run: go install github.com/microsoft/waza/cmd/waza@latest
+        run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 
       - name: Run evaluation with ${{ matrix.model }}
         run: waza run evals/my-skill/eval.yaml \
@@ -160,13 +143,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.26'
-
       - name: Install waza
-        run: go install github.com/microsoft/waza/cmd/waza@latest
+        run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 
       - name: Run evaluation (current)
         run: waza run evals/my-skill/eval.yaml \
@@ -215,12 +193,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-  - task: GoTool@0
-    inputs:
-      version: '1.26'
-    displayName: Set up Go
-
-  - script: go install github.com/microsoft/waza/cmd/waza@latest
+  - script: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
     displayName: Install waza
 
   - script: |
@@ -272,11 +245,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-  - task: GoTool@0
-    inputs:
-      version: '1.26'
-
-  - script: go install github.com/microsoft/waza/cmd/waza@latest
+  - script: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
     displayName: Install waza
 
   - script: |
@@ -422,12 +391,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.26'
       - name: Install waza
-        run: go install github.com/microsoft/waza/cmd/waza@latest
+        run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
       - name: Run smoke tests
         run: waza run evals/my-skill/eval.yaml \
           --context-dir evals/my-skill/fixtures \
@@ -439,12 +404,8 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.26'
       - name: Install waza
-        run: go install github.com/microsoft/waza/cmd/waza@latest
+        run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
       - name: Run full test suite
         run: waza run evals/my-skill/eval.yaml \
           --context-dir evals/my-skill/fixtures \

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -47,16 +47,20 @@ export PATH="$HOME/bin:$PATH"
 
 ### 2. Install from Source
 
-Requires **Go 1.26 or later**:
+Requires **Go 1.26 or later** and **Git LFS**:
 
 ```bash
-go install github.com/microsoft/waza/cmd/waza@latest
+git clone https://github.com/microsoft/waza.git
+cd waza
+git lfs install
+git lfs pull
+go build -o waza ./cmd/waza
 ```
 
 Verify installation:
 
 ```bash
-waza --version
+./waza --version
 ```
 
 ### 3. Azure Developer CLI Extension

--- a/docs/SKILLS_CI_INTEGRATION.md
+++ b/docs/SKILLS_CI_INTEGRATION.md
@@ -8,19 +8,19 @@ Waza is a Go CLI tool for running evaluations on AI agent skills. It's designed 
 
 ## Prerequisites
 
-- **Go 1.26+**: Required for building/installing waza
+- **Go 1.26+**: Required only if building waza from source
 - **Git**: For cloning repositories
 - **GitHub Actions** (for CI): Standard ubuntu-latest runner
 
 ## Installation Methods
 
-### Option 1: Install from Source (Recommended for CI)
+### Option 1: Binary Install (Recommended for CI)
 
 This is the recommended approach for CI/CD pipelines:
 
 ```bash
 # Install latest version
-go install github.com/microsoft/waza/cmd/waza@latest
+curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 
 # Verify installation
 waza --version
@@ -28,8 +28,8 @@ waza --version
 
 Benefits:
 - No Docker required
-- Fast installation (~30 seconds)
-- Always gets the latest version
+- No Go toolchain required on the runner
+- Downloads the latest release binary
 - Works on all platforms
 
 ### Option 2: Docker
@@ -216,13 +216,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
-      
       - name: Install Waza
-        run: go install github.com/microsoft/waza/cmd/waza@latest
+        run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
       
       - name: Run Evaluation
         run: waza run eval/eval.yaml --verbose --output results.json
@@ -452,15 +447,9 @@ Check:
 - Task descriptions are clear
 - Fixtures contain necessary context
 
-### "Go version too old"
+### "Install script failed"
 
-Waza requires Go 1.26+:
-
-```yaml
-- uses: actions/setup-go@v5
-  with:
-    go-version: '1.26'  # Not 1.22 or earlier
-```
+Check that the runner can reach GitHub releases and that `curl`, `bash`, and `tar` are available. If you choose to build from source instead, install Go 1.26+ and Git LFS before running `go build`.
 
 ## Example Workflows
 
@@ -477,10 +466,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
-      - run: go install github.com/microsoft/waza/cmd/waza@latest
+      - run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
       - run: waza run eval/eval.yaml --verbose
 ```
 
@@ -495,10 +481,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
-      - run: go install github.com/microsoft/waza/cmd/waza@latest
+      - run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
       - run: |
           sed -i "s/model: .*/model: ${{ matrix.model }}/" eval/eval.yaml
           waza run eval/eval.yaml --output results-${{ matrix.model }}.json
@@ -516,10 +499,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
-      - run: go install github.com/microsoft/waza/cmd/waza@latest
+      - run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
       - run: waza run eval/eval.yaml --verbose --output nightly-results.json
       - uses: actions/upload-artifact@v4
         with:

--- a/examples/ci/README.md
+++ b/examples/ci/README.md
@@ -9,7 +9,7 @@ If you're contributing a skill to [microsoft/skills](https://github.com/microsof
 **📖 [microsoft/skills CI Integration Guide](../../docs/SKILLS_CI_INTEGRATION.md)**
 
 The guide covers:
-- Installation methods (go install, Docker)
+- Installation methods (binary installer, Docker)
 - Skill repository structure
 - Creating evaluation suites
 - CI/CD workflow setup

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -34,10 +34,15 @@ waza --version
 
 ### 2. Install from Source
 
-Requires **Go 1.26 or later**:
+Requires **Go 1.26 or later** and **Git LFS**:
 
 ```bash
-go install github.com/microsoft/waza/cmd/waza@latest
+git clone https://github.com/microsoft/waza.git
+cd waza
+git lfs install
+git lfs pull
+go build -o waza ./cmd/waza
+./waza --version
 ```
 
 ### 3. Azure Developer CLI Extension

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -13,8 +13,8 @@ Waza evaluates both `SKILL.md`-based skills and `.agent.md` custom agents. This 
 
 ## Prerequisites
 
-- **Go 1.26 or later** (for binary install), or
 - **GitHub Copilot access** (for `copilot login`)
+- **Go 1.26 or later** and **Git LFS** only if installing from source
 
 ## 1. Install
 
@@ -30,8 +30,12 @@ waza --version
 
 <TabItem label="From Source">
 ```bash
-go install github.com/microsoft/waza/cmd/waza@latest
-waza --version
+git clone https://github.com/microsoft/waza.git
+cd waza
+git lfs install
+git lfs pull
+go build -o waza ./cmd/waza
+./waza --version
 ```
 </TabItem>
 


### PR DESCRIPTION
Closes #242

## Summary
- Replace stale `go install` guidance with LFS-aware source build steps
- Prefer the official binary installer in CI docs
- Keep the README warning that `go install` is unsupported due to LFS artifacts

## Validation
- `rg "go install"` across user-facing docs now only finds the README warning
- `git diff --check`
- `cd site && npm ci && npm run build`

Note: I also found `.github/workflows/skills-ci-example.yml` contains stale `go install` guidance, but GitHub rejected pushes that modify workflow files because this OAuth token lacks the `workflow` scope. This PR fixes the README, published docs site sources, and non-workflow docs surfaces covered by the issue.