### PR TITLE
fix: align check eval discovery

### DIFF
--- a/cmd/waza/cmd_check.go
+++ b/cmd/waza/cmd_check.go
@@ -423,7 +423,7 @@ func checkReadiness(skillDir string, wsCtx *workspace.WorkspaceContext) (*readin
 	if !report.hasEval {
 		// Try workspace detection from the working directory
 		if wd, wdErr := os.Getwd(); wdErr == nil {
-			if autoCtx, ctxErr := workspace.DetectContext(wd); ctxErr == nil {
+			if autoCtx, ctxErr := workspace.DetectContext(wd, configDetectOptions()...); ctxErr == nil {
 				if evalPath, findErr := workspace.FindEval(autoCtx, sk.Frontmatter.Name); findErr == nil && evalPath != "" {
 					report.hasEval = true
 					report.evalPath = evalPath

--- a/cmd/waza/cmd_check_workspace_test.go
+++ b/cmd/waza/cmd_check_workspace_test.go
@@ -145,3 +145,60 @@ func TestCheckCommand_WorkspaceWithSeparatedEval(t *testing.T) {
 	result := output.String()
 	assert.Contains(t, result, "Evaluation Suite: Found")
 }
+
+func TestCheckCommand_WorkspaceByNameNestedSkillWithSeparatedEval(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".waza.yaml"), []byte("paths:\n  skills: skills/\n  evals: evals/\n"), 0o644))
+
+	skillDir := filepath.Join(dir, "skills", "development", "skill-creator")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	content := "---\nname: skill-creator\ndescription: \"Testing nested eval detection.\"\n---\n# Body\n"
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644))
+
+	evalsDir := filepath.Join(dir, "evals", "skill-creator")
+	require.NoError(t, os.MkdirAll(evalsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(evalsDir, "eval.yaml"), []byte("name: test\nskill: skill-creator\n"), 0o644))
+	t.Chdir(dir)
+
+	cmd := newCheckCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"skill-creator"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	result := output.String()
+	assert.Contains(t, result, "skill-creator")
+	assert.Contains(t, result, "Evaluation Suite: Found")
+	assert.NotContains(t, result, "no SKILL.md found")
+}
+
+func TestCheckCommand_ExplicitNestedPathWithSeparatedEval(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".waza.yaml"), []byte("paths:\n  skills: skills/\n  evals: evals/\n"), 0o644))
+
+	skillDir := filepath.Join(dir, "skills", "development", "skill-creator")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	content := "---\nname: skill-creator\ndescription: \"Testing explicit nested path eval detection.\"\n---\n# Body\n"
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644))
+
+	evalsDir := filepath.Join(dir, "evals", "skill-creator")
+	require.NoError(t, os.MkdirAll(evalsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(evalsDir, "eval.yaml"), []byte("name: test\nskill: skill-creator\n"), 0o644))
+	t.Chdir(dir)
+
+	cmd := newCheckCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{filepath.Join("skills", "development", "skill-creator")})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	result := output.String()
+	assert.Contains(t, result, "skill-creator")
+	assert.Contains(t, result, "Evaluation Suite: Found")
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -5,6 +5,7 @@ package workspace
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +76,7 @@ type WorkspaceContext struct {
 // It checks:
 // 1. CWD for SKILL.md → single-skill
 // 2. Walk up parents for SKILL.md → single-skill (nested inside skill dir)
-// 3. Check for skills/ directory with SKILL.md children → multi-skill
+// 3. Check for skills/ directory with SKILL.md descendants → multi-skill
 // 4. Scan CWD for child dirs containing SKILL.md → multi-skill
 func DetectContext(dir string, opts ...DetectOption) (*WorkspaceContext, error) {
 	o := defaultDetectOptions()
@@ -130,13 +131,19 @@ func DetectContext(dir string, opts ...DetectOption) (*WorkspaceContext, error) 
 
 	var skills []SkillInfo
 	if isDir(skillsDir) {
-		skills = scanForSkills(skillsDir)
+		skills, err = scanForSkills(skillsDir, true)
+		if err != nil {
+			return nil, fmt.Errorf("scanning skills directory %s: %w", skillsDir, err)
+		}
 	}
 
 	// 3b. Also check .github/skills/ directory (GitHub Copilot convention)
 	githubSkillsDir := filepath.Join(absDir, ".github", "skills")
 	if isDir(githubSkillsDir) && !samePath(skillsDir, githubSkillsDir) {
-		githubSkills := scanForSkills(githubSkillsDir)
+		githubSkills, err := scanForSkills(githubSkillsDir, true)
+		if err != nil {
+			return nil, fmt.Errorf("scanning GitHub skills directory %s: %w", githubSkillsDir, err)
+		}
 		skills = mergeSkillsByName(skills, githubSkills)
 	}
 
@@ -150,7 +157,10 @@ func DetectContext(dir string, opts ...DetectOption) (*WorkspaceContext, error) 
 	}
 
 	// 4. Scan immediate children of dir for SKILL.md
-	skills = scanForSkills(absDir)
+	skills, err = scanForSkills(absDir, false)
+	if err != nil {
+		return nil, fmt.Errorf("scanning directory %s: %w", absDir, err)
+	}
 	if len(skills) > 0 {
 		return &WorkspaceContext{
 			Type:     ContextMultiSkill,
@@ -282,16 +292,20 @@ func parseAgentNameFromFile(path string) string {
 	return name
 }
 
-// scanForSkills scans immediate child directories of parentDir for SKILL.md files.
-func scanForSkills(parentDir string) []SkillInfo {
+// scanForSkills scans directories under parentDir for skill definitions.
+func scanForSkills(parentDir string, recursive bool) ([]SkillInfo, error) {
+	if recursive {
+		return scanForSkillsRecursive(parentDir)
+	}
+
 	entries, err := os.ReadDir(parentDir)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	var skills []SkillInfo
 	for _, entry := range entries {
-		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+		if !entry.IsDir() || shouldSkipSkillScanDir(entry.Name()) {
 			continue
 		}
 		childDir := filepath.Join(parentDir, entry.Name())
@@ -299,7 +313,38 @@ func scanForSkills(parentDir string) []SkillInfo {
 			skills = append(skills, info)
 		}
 	}
-	return skills
+	return skills, nil
+}
+
+func scanForSkillsRecursive(parentDir string) ([]SkillInfo, error) {
+	var skills []SkillInfo
+	err := filepath.WalkDir(parentDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("error walking %s: %w", path, err)
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path == parentDir {
+			return nil
+		}
+		if shouldSkipSkillScanDir(d.Name()) {
+			return fs.SkipDir
+		}
+		if info, ok := tryParseSkill(path); ok {
+			skills = append(skills, info)
+			return fs.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return skills, nil
+}
+
+func shouldSkipSkillScanDir(name string) bool {
+	return strings.HasPrefix(name, ".") || name == "node_modules" || name == "vendor"
 }
 
 // parseSkillName reads a SKILL.md file and extracts the skill name from frontmatter.

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -94,6 +94,32 @@ func TestDetectContext_MultiSkillWithSkillsDir(t *testing.T) {
 	}
 }
 
+func TestDetectContext_MultiSkillNestedCategories(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "skills", "development", "skill-creator", "SKILL.md"), skillMD("skill-creator"))
+	writeFile(t, filepath.Join(root, "skills", "testing", "eval-harness", "SKILL.md"), skillMD("eval-harness"))
+	writeFile(t, filepath.Join(root, "skills", "vendor", "ignored", "SKILL.md"), skillMD("ignored"))
+
+	ctx, err := DetectContext(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Type != ContextMultiSkill {
+		t.Fatalf("expected ContextMultiSkill, got %d", ctx.Type)
+	}
+
+	names := map[string]bool{}
+	for _, s := range ctx.Skills {
+		names[s.Name] = true
+	}
+	if !names["skill-creator"] || !names["eval-harness"] {
+		t.Errorf("expected nested skills skill-creator and eval-harness, got %v", names)
+	}
+	if names["ignored"] {
+		t.Errorf("did not expect skills under vendor to be discovered: %v", names)
+	}
+}
+
 func TestDetectContext_MultiSkillSiblingDirs(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "skill-a", "SKILL.md"), skillMD("skill-a"))


### PR DESCRIPTION
Closes #238

## Summary
- discover nested skills recursively under configured skill roots so `waza check <skill-name>` works for category-based workspaces
- use project-config-aware workspace detection when `waza check` resolves separated evals for explicit skill paths
- add regressions for nested skill discovery and separated eval detection

## Validation
- `go test ./internal/workspace ./cmd/waza`
- `go test ./...`