### PR TITLE
feat: include instruction files in eval runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,8 @@ config:
   executor: mock          # or copilot-sdk
   model: claude-sonnet-4-20250514
   group_by: model          # Group results by model (or other dimension)
+  instruction_files:
+    - .github/instructions/project.instructions.md
 
 # Custom input variables available as {{.Vars.key}} in tasks and hooks
 inputs:
@@ -941,6 +943,18 @@ Variables are accessible in:
 - Hook commands
 - Task prompts and fixtures (via template rendering)
 - Grader configurations
+
+### Instruction Files
+
+Use `instruction_files` to apply `*.instructions.md` guidance during task execution:
+
+```yaml
+config:
+  instruction_files:
+    - .github/instructions/project.instructions.md
+```
+
+Instruction files are resolved from the active fixtures/context directory, copied into each task's temp workspace, and appended to the agent system message as path-labeled instructions. Task YAML files can also set top-level `instruction_files`; task-level entries are added to the eval-level list.
 
 ### CSV Dataset Support
 
@@ -1161,6 +1175,9 @@ your-skill/
     ├── tasks/            # Task definitions
     │   └── *.yaml
     └── fixtures/         # Context files
+        ├── .github/
+        │   └── instructions/
+        │       └── project.instructions.md
         └── *.txt
 ```
 

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -165,13 +165,20 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	// Build skill directories list and system message, unless skills are disabled
 	var skillDirs []string
 	var systemMessage *copilot.SystemMessageConfig
+	var systemMessageParts []string
 	if !req.NoSkills {
 		skillDirs = e.getSkillDirs(sourceDir, req)
 		if msg := buildSkillSystemMessage(skillDirs, req.SkillName); msg != "" {
-			systemMessage = &copilot.SystemMessageConfig{
-				Mode:    "append",
-				Content: msg,
-			}
+			systemMessageParts = append(systemMessageParts, msg)
+		}
+	}
+	if msg := buildInstructionSystemMessage(req.Instructions); msg != "" {
+		systemMessageParts = append(systemMessageParts, msg)
+	}
+	if len(systemMessageParts) > 0 {
+		systemMessage = &copilot.SystemMessageConfig{
+			Mode:    "append",
+			Content: strings.Join(systemMessageParts, "\n"),
 		}
 	}
 
@@ -571,6 +578,33 @@ func buildSkillSystemMessage(skillDirs []string, skillName string) string {
 		sb.WriteString("</skill>\n")
 	}
 	sb.WriteString("</available_skills>\n")
+
+	return sb.String()
+}
+
+func buildInstructionSystemMessage(instructions []InstructionFile) string {
+	if len(instructions) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n<instruction_files>\n")
+	sb.WriteString("The following instruction files apply to this evaluation task. Follow them as additional repository instructions.\n")
+	for _, instruction := range instructions {
+		if instruction.Path == "" {
+			continue
+		}
+		sb.WriteString("\n<instruction_file>\n")
+		fmt.Fprintf(&sb, "<path>%s</path>\n", instruction.Path)
+		sb.WriteString("<content>\n")
+		sb.Write(instruction.Content)
+		if len(instruction.Content) == 0 || instruction.Content[len(instruction.Content)-1] != '\n' {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("</content>\n")
+		sb.WriteString("</instruction_file>\n")
+	}
+	sb.WriteString("</instruction_files>\n")
 
 	return sb.String()
 }

--- a/internal/execution/copilot_test.go
+++ b/internal/execution/copilot_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -472,6 +473,68 @@ func TestCopilotCreateSession_InjectsSkillSystemMessage(t *testing.T) {
 		SkillName: "test-skill",
 		SourceDir: sourceDir,
 		Timeout:   time.Minute,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+}
+
+func TestCopilotCreateSession_InjectsInstructionSystemMessage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clientMock := newClientMock(ctrl)
+	sessionMock := NewMockCopilotSession(ctrl)
+
+	sourceDir := t.TempDir()
+	skillContent := "---\nname: test-skill\ndescription: A test\n---\n# Rules\nAlways greet"
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte(skillContent), 0644))
+
+	instructions := []InstructionFile{{
+		Path:    ".github/instructions/project.instructions.md",
+		Content: []byte("Prefer small functions."),
+	}}
+	expectedSystemMsg := strings.Join([]string{
+		buildSkillSystemMessage([]string{sourceDir}, "test-skill"),
+		buildInstructionSystemMessage(instructions),
+	}, "\n")
+	require.NotEmpty(t, expectedSystemMsg)
+
+	expectedConfig := sessionConfigMatcher{
+		t:         t,
+		sourceDir: sourceDir,
+		expected: copilot.SessionConfig{
+			Model:               "gpt-4o-mini",
+			SkillDirectories:    []string{sourceDir},
+			OnPermissionRequest: allowAllTools,
+			SystemMessage: &copilot.SystemMessageConfig{
+				Mode:    "append",
+				Content: expectedSystemMsg,
+			},
+		},
+	}
+
+	clientMock.EXPECT().CreateSession(gomock.Any(), expectedConfig).Return(sessionMock, nil)
+	sessionMock.EXPECT().Disconnect()
+	clientMock.EXPECT().DeleteSession(gomock.Any(), "session-1")
+
+	sessionMock.EXPECT().On(gomock.Any()).Times(3).Return(func() {})
+	sessionMock.EXPECT().SendAndWait(gomock.Any(), gomock.Any()).Return(&copilot.SessionEvent{}, nil)
+	sessionMock.EXPECT().SessionID().Return("session-1")
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(clientOptions *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+
+	defer func() {
+		require.NoError(t, engine.Shutdown(context.Background()))
+	}()
+
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message:      "hello",
+		SkillName:    "test-skill",
+		SourceDir:    sourceDir,
+		Instructions: instructions,
+		Timeout:      time.Minute,
 	})
 	require.NoError(t, err)
 	require.True(t, resp.Success)

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -36,10 +36,11 @@ type WorkspaceKeeper interface {
 
 // ExecutionRequest represents a test execution request
 type ExecutionRequest struct {
-	ModelID   string
-	Message   string
-	Context   map[string]any
-	Resources []ResourceFile
+	ModelID      string
+	Message      string
+	Context      map[string]any
+	Resources    []ResourceFile
+	Instructions []InstructionFile
 
 	SessionID    string
 	WorkspaceDir string // Reuse an existing workspace directory (for follow-up prompts)
@@ -74,6 +75,12 @@ type ExecutionRequest struct {
 
 // ResourceFile represents a file resource
 type ResourceFile struct {
+	Path    string
+	Content []byte
+}
+
+// InstructionFile represents a file whose content should be applied as agent instructions.
+type InstructionFile struct {
 	Path    string
 	Content []byte
 }

--- a/internal/execution/skill_injection_test.go
+++ b/internal/execution/skill_injection_test.go
@@ -90,6 +90,30 @@ func TestBuildSkillSystemMessage_SkipsHiddenAndVendor(t *testing.T) {
 	assert.Empty(t, msg)
 }
 
+func TestBuildInstructionSystemMessage(t *testing.T) {
+	msg := buildInstructionSystemMessage([]InstructionFile{
+		{
+			Path:    ".github/instructions/project.instructions.md",
+			Content: []byte("Always use table-driven tests."),
+		},
+		{
+			Path:    "docs/task.instructions.md",
+			Content: []byte("Mention edge cases.\n"),
+		},
+	})
+
+	assert.Contains(t, msg, "<instruction_files>")
+	assert.Contains(t, msg, "<path>.github/instructions/project.instructions.md</path>")
+	assert.Contains(t, msg, "Always use table-driven tests.")
+	assert.Contains(t, msg, "<path>docs/task.instructions.md</path>")
+	assert.Contains(t, msg, "Mention edge cases.")
+	assert.Contains(t, msg, "</instruction_files>")
+}
+
+func TestBuildInstructionSystemMessage_NoInstructions(t *testing.T) {
+	assert.Empty(t, buildInstructionSystemMessage(nil))
+}
+
 func TestParseSkillFrontmatter(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -35,20 +35,21 @@ type SpecIdentity struct {
 
 // Config controls execution behavior
 type Config struct {
-	TrialsPerTask  int            `yaml:"trials_per_task" json:"runs_per_test"`
-	TimeoutSec     int            `yaml:"timeout_seconds" json:"timeout_sec"`
-	Concurrent     bool           `yaml:"parallel" json:"concurrent"`
-	Workers        int            `yaml:"workers,omitempty" json:"workers,omitempty"`
-	StopOnError    bool           `yaml:"fail_fast,omitempty" json:"stop_on_error,omitempty"`
-	EngineType     string         `yaml:"executor" json:"engine_type"`
-	ModelID        string         `yaml:"model" json:"model_id"`
-	SkillPaths     []string       `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
-	DisabledSkills []string       `yaml:"disabled_skills,omitempty" json:"disabled_skills,omitempty"`
-	RequiredSkills []string       `yaml:"required_skills,omitempty" json:"required_skills,omitempty"`
-	ServerConfigs  map[string]any `yaml:"mcp_servers,omitempty" json:"server_configs,omitempty"`
-	MaxAttempts    int            `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty"`
-	GroupBy        string         `yaml:"group_by,omitempty" json:"group_by,omitempty"`
-	JudgeModel     string         `yaml:"judge_model,omitempty" json:"judge_model,omitempty"`
+	TrialsPerTask    int            `yaml:"trials_per_task" json:"runs_per_test"`
+	TimeoutSec       int            `yaml:"timeout_seconds" json:"timeout_sec"`
+	Concurrent       bool           `yaml:"parallel" json:"concurrent"`
+	Workers          int            `yaml:"workers,omitempty" json:"workers,omitempty"`
+	StopOnError      bool           `yaml:"fail_fast,omitempty" json:"stop_on_error,omitempty"`
+	EngineType       string         `yaml:"executor" json:"engine_type"`
+	ModelID          string         `yaml:"model" json:"model_id"`
+	SkillPaths       []string       `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
+	InstructionFiles []string       `yaml:"instruction_files,omitempty" json:"instruction_files,omitempty"`
+	DisabledSkills   []string       `yaml:"disabled_skills,omitempty" json:"disabled_skills,omitempty"`
+	RequiredSkills   []string       `yaml:"required_skills,omitempty" json:"required_skills,omitempty"`
+	ServerConfigs    map[string]any `yaml:"mcp_servers,omitempty" json:"server_configs,omitempty"`
+	MaxAttempts      int            `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty"`
+	GroupBy          string         `yaml:"group_by,omitempty" json:"group_by,omitempty"`
+	JudgeModel       string         `yaml:"judge_model,omitempty" json:"judge_model,omitempty"`
 }
 
 // GraderConfig defines a validator/grader

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -204,6 +204,42 @@ config:
 	}
 }
 
+func TestEvalSpec_InstructionFilesDeserialization(t *testing.T) {
+	tempDir := t.TempDir()
+	yamlContent := `name: instructions-test
+skill: test-skill
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: test-model
+  instruction_files:
+    - .github/instructions/project.instructions.md
+    - docs/agent.instructions.md
+tasks:
+  - "tasks/*.yaml"
+`
+	specPath := filepath.Join(tempDir, "instructions.yaml")
+	if err := os.WriteFile(specPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write spec file: %v", err)
+	}
+
+	spec, err := LoadEvalSpec(specPath)
+	if err != nil {
+		t.Fatalf("Failed to load spec: %v", err)
+	}
+
+	if len(spec.Config.InstructionFiles) != 2 {
+		t.Fatalf("Expected 2 instruction files, got %d", len(spec.Config.InstructionFiles))
+	}
+	if spec.Config.InstructionFiles[0] != ".github/instructions/project.instructions.md" {
+		t.Errorf("Unexpected first instruction file: %q", spec.Config.InstructionFiles[0])
+	}
+	if spec.Config.InstructionFiles[1] != "docs/agent.instructions.md" {
+		t.Errorf("Unexpected second instruction file: %q", spec.Config.InstructionFiles[1])
+	}
+}
+
 func TestEvalSpec_DefaultValues(t *testing.T) {
 	tempDir := t.TempDir()
 	// Minimal YAML - defaults need to be set by loader

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -12,17 +12,18 @@ import (
 
 // TestCase represents a single evaluation test
 type TestCase struct {
-	Active      *bool             `yaml:"enabled,omitempty" json:"active,omitempty"`
-	ContextRoot string            `yaml:"context_dir,omitempty" json:"context_root,omitempty"`
-	DisplayName string            `yaml:"name" json:"display_name"`
-	Expectation TaskExpectation   `yaml:"expected,omitempty" json:"expectation,omitempty"`
-	SkillPaths  []string          `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
-	Stimulus    TaskStimulus      `yaml:"inputs" json:"stimulus"`
-	Summary     string            `yaml:"description,omitempty" json:"summary,omitempty"`
-	Tags        []string          `yaml:"tags,omitempty" json:"labels,omitempty"`
-	TestID      string            `yaml:"id" json:"test_id"`
-	TimeoutSec  *int              `yaml:"timeout_seconds,omitempty" json:"timeout_sec,omitempty"`
-	Validators  []ValidatorInline `yaml:"graders,omitempty" json:"validators,omitempty"`
+	Active           *bool             `yaml:"enabled,omitempty" json:"active,omitempty"`
+	ContextRoot      string            `yaml:"context_dir,omitempty" json:"context_root,omitempty"`
+	DisplayName      string            `yaml:"name" json:"display_name"`
+	Expectation      TaskExpectation   `yaml:"expected,omitempty" json:"expectation,omitempty"`
+	InstructionFiles []string          `yaml:"instruction_files,omitempty" json:"instruction_files,omitempty"`
+	SkillPaths       []string          `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
+	Stimulus         TaskStimulus      `yaml:"inputs" json:"stimulus"`
+	Summary          string            `yaml:"description,omitempty" json:"summary,omitempty"`
+	Tags             []string          `yaml:"tags,omitempty" json:"labels,omitempty"`
+	TestID           string            `yaml:"id" json:"test_id"`
+	TimeoutSec       *int              `yaml:"timeout_seconds,omitempty" json:"timeout_sec,omitempty"`
+	Validators       []ValidatorInline `yaml:"graders,omitempty" json:"validators,omitempty"`
 }
 
 // TaskStimulus defines the input for a task.

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -163,3 +163,33 @@ skill_directories:
 		t.Errorf("Expected second skill path '/absolute/skills', got %q", tc.SkillPaths[1])
 	}
 }
+
+func TestLoadTestCase_InstructionFiles(t *testing.T) {
+	yamlContent := `id: instructions-test
+name: Instruction files test
+inputs:
+  prompt: "test prompt"
+instruction_files:
+  - .github/instructions/task.instructions.md
+  - docs/task.instructions.md
+`
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tc.yaml")
+	if err := os.WriteFile(p, []byte(yamlContent), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tc, err := LoadTestCase(p)
+	if err != nil {
+		t.Fatalf("LoadTestCase: %v", err)
+	}
+	if len(tc.InstructionFiles) != 2 {
+		t.Fatalf("Expected 2 instruction files, got %d", len(tc.InstructionFiles))
+	}
+	if tc.InstructionFiles[0] != ".github/instructions/task.instructions.md" {
+		t.Errorf("Expected first instruction file '.github/instructions/task.instructions.md', got %q", tc.InstructionFiles[0])
+	}
+	if tc.InstructionFiles[1] != "docs/task.instructions.md" {
+		t.Errorf("Expected second instruction file 'docs/task.instructions.md', got %q", tc.InstructionFiles[1])
+	}
+}

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1019,7 +1019,15 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 	startTime := time.Now()
 
 	// Prepare execution request
-	req := r.buildExecutionRequest(tc)
+	req, err := r.buildExecutionRequest(tc)
+	if err != nil {
+		return models.RunResult{
+			RunNumber:  runNum,
+			Status:     models.StatusError,
+			DurationMs: time.Since(startTime).Milliseconds(),
+			ErrorMsg:   err.Error(),
+		}
+	}
 
 	// Emit agent prompt event before execution
 	if r.verbose {
@@ -1139,9 +1147,14 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 	}
 }
 
-func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) *execution.ExecutionRequest {
+func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) (*execution.ExecutionRequest, error) {
 	// Load resource files
 	resources := r.loadResources(tc)
+	instructions, instructionResources, err := r.loadInstructionFiles(tc)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, instructionResources...)
 
 	spec := r.cfg.Spec()
 	timeout := spec.Config.TimeoutSec
@@ -1161,6 +1174,7 @@ func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) *execution.Execu
 		Message:         tc.Stimulus.Message,
 		Context:         tc.Stimulus.Metadata,
 		Resources:       resources,
+		Instructions:    instructions,
 		SkillName:       spec.SkillName,
 		TaskName:        tc.DisplayName,
 		TaskDescription: tc.Summary,
@@ -1168,14 +1182,18 @@ func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) *execution.Execu
 		NoSkills:        noSkills,
 		Timeout:         time.Duration(timeout) * time.Second,
 		MCPServers:      convertMCPServers(spec.Config.ServerConfigs),
-	}
+	}, nil
 }
 
 // executeFollowUps sends follow-up prompts using the same workspace and session,
 // aggregating results into the original response.
 func (r *EvalRunner) executeFollowUps(ctx context.Context, tc *models.TestCase, resp *execution.ExecutionResponse) {
 	for i, prompt := range tc.Stimulus.FollowUps {
-		followReq := r.buildExecutionRequest(tc)
+		followReq, err := r.buildExecutionRequest(tc)
+		if err != nil {
+			resp.ErrorMsg = fmt.Sprintf("follow-up %d/%d setup failed: %v", i+1, len(tc.Stimulus.FollowUps), err)
+			break
+		}
 		followReq.Message = prompt
 		followReq.SessionID = resp.SessionID
 		followReq.WorkspaceDir = resp.WorkspaceDir
@@ -1279,6 +1297,92 @@ func (r *EvalRunner) loadResources(tc *models.TestCase) []execution.ResourceFile
 	}
 
 	return resources
+}
+
+func (r *EvalRunner) loadInstructionFiles(tc *models.TestCase) ([]execution.InstructionFile, []execution.ResourceFile, error) {
+	spec := r.cfg.Spec()
+	paths := append([]string{}, spec.Config.InstructionFiles...)
+	paths = append(paths, tc.InstructionFiles...)
+	if len(paths) == 0 {
+		return nil, nil, nil
+	}
+
+	fixtureDir := r.cfg.FixtureDir()
+	if tc.ContextRoot != "" {
+		fixtureDir = tc.ContextRoot
+	}
+	if fixtureDir == "" {
+		return nil, nil, fmt.Errorf("instruction_files require a context/fixtures directory")
+	}
+
+	instructions := make([]execution.InstructionFile, 0, len(paths))
+	resources := make([]execution.ResourceFile, 0, len(paths))
+	for _, path := range paths {
+		cleanPath, fullPath, err := resolveContextFile(fixtureDir, path, "instruction_files")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading instruction file %q: %w", path, err)
+		}
+
+		instructions = append(instructions, execution.InstructionFile{
+			Path:    filepath.ToSlash(cleanPath),
+			Content: content,
+		})
+		resources = append(resources, execution.ResourceFile{
+			Path:    filepath.ToSlash(cleanPath),
+			Content: content,
+		})
+	}
+
+	return instructions, resources, nil
+}
+
+func resolveContextFile(baseDir, relPath, field string) (string, string, error) {
+	if relPath == "" {
+		return "", "", fmt.Errorf("%s path must not be empty", field)
+	}
+	if filepath.IsAbs(relPath) {
+		return "", "", fmt.Errorf("%s path %q must be relative", field, relPath)
+	}
+	if containsPathTraversal(relPath) {
+		return "", "", fmt.Errorf("%s path %q must not contain path traversal", field, relPath)
+	}
+
+	cleanPath := filepath.Clean(relPath)
+	if cleanPath == "." {
+		return "", "", fmt.Errorf("%s path must not be empty", field)
+	}
+
+	fullPath := filepath.Join(baseDir, cleanPath)
+	absBaseDir, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving context directory: %w", err)
+	}
+	absFullPath, err := filepath.Abs(fullPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving %s path %q: %w", field, relPath, err)
+	}
+
+	if absFullPath != absBaseDir && !strings.HasPrefix(absFullPath, absBaseDir+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("%s path %q escapes context directory", field, relPath)
+	}
+
+	return cleanPath, fullPath, nil
+}
+
+func containsPathTraversal(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // convertMCPServers converts the eval YAML mcp_servers config (map[string]any)

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -90,7 +90,8 @@ func TestBuildExecutionRequest_SkillPaths(t *testing.T) {
 			runner := NewEvalRunner(cfg, nil)
 
 			// Build execution request
-			req := runner.buildExecutionRequest(tc)
+			req, err := runner.buildExecutionRequest(tc)
+			require.NoError(t, err)
 
 			// Verify skill paths
 			require.NotNil(t, req, "execution request should not be nil")
@@ -137,7 +138,8 @@ func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 	}
 
 	runner := NewEvalRunner(cfg, nil)
-	req := runner.buildExecutionRequest(tc)
+	req, err := runner.buildExecutionRequest(tc)
+	require.NoError(t, err)
 
 	// Verify basic fields
 	assert.Equal(t, "Hello world", req.Message)
@@ -174,7 +176,8 @@ func TestBuildExecutionRequest_TimeoutOverride(t *testing.T) {
 	}
 
 	runner := NewEvalRunner(cfg, nil)
-	req := runner.buildExecutionRequest(tc)
+	req, err := runner.buildExecutionRequest(tc)
+	require.NoError(t, err)
 
 	// Verify timeout is overridden
 	assert.Equal(t, float64(300), req.Timeout.Seconds(), "test case timeout should override spec timeout")
@@ -206,7 +209,8 @@ func TestBuildExecutionRequest_TaskLevelSkillPaths(t *testing.T) {
 		Stimulus:    models.TaskStimulus{Message: "test"},
 		SkillPaths:  []string{"./task-skills", "./more-skills"},
 	}
-	req := runner.buildExecutionRequest(tc)
+	req, err := runner.buildExecutionRequest(tc)
+	require.NoError(t, err)
 	require.NotNil(t, req)
 	assert.Equal(t, 2, len(req.SkillPaths), "task-level skill paths should override eval-level")
 	assert.Equal(t, filepath.Join(specDir, "task-skills"), req.SkillPaths[0])
@@ -218,10 +222,119 @@ func TestBuildExecutionRequest_TaskLevelSkillPaths(t *testing.T) {
 		DisplayName: "Test Case 2",
 		Stimulus:    models.TaskStimulus{Message: "test"},
 	}
-	req2 := runner.buildExecutionRequest(tc2)
+	req2, err := runner.buildExecutionRequest(tc2)
+	require.NoError(t, err)
 	require.NotNil(t, req2)
 	assert.Equal(t, 1, len(req2.SkillPaths), "should fall back to eval-level skill paths")
 	assert.Equal(t, filepath.Join(specDir, "eval-skills"), req2.SkillPaths[0])
+}
+
+func TestBuildExecutionRequest_InstructionFilesAreAdditive(t *testing.T) {
+	fixtureDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(fixtureDir, ".github", "instructions"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(fixtureDir, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(fixtureDir, ".github", "instructions", "project.instructions.md"), []byte("Use project rules."), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(fixtureDir, "docs", "task.instructions.md"), []byte("Use task rules."), 0o644))
+
+	spec := &models.EvalSpec{
+		SkillName: "test-skill",
+		Config: models.Config{
+			EngineType:       "mock",
+			ModelID:          "gpt-4",
+			TimeoutSec:       60,
+			InstructionFiles: []string{".github/instructions/project.instructions.md"},
+		},
+	}
+	cfg := config.NewEvalConfig(spec, config.WithFixtureDir(fixtureDir))
+	runner := NewEvalRunner(cfg, nil)
+
+	tc := &models.TestCase{
+		TestID:           "test-001",
+		DisplayName:      "Test Case",
+		Stimulus:         models.TaskStimulus{Message: "test"},
+		InstructionFiles: []string{"docs/task.instructions.md"},
+	}
+
+	req, err := runner.buildExecutionRequest(tc)
+	require.NoError(t, err)
+	require.Len(t, req.Instructions, 2)
+	assert.Equal(t, ".github/instructions/project.instructions.md", req.Instructions[0].Path)
+	assert.Equal(t, "Use project rules.", string(req.Instructions[0].Content))
+	assert.Equal(t, "docs/task.instructions.md", req.Instructions[1].Path)
+	assert.Equal(t, "Use task rules.", string(req.Instructions[1].Content))
+
+	require.Len(t, req.Resources, 2)
+	assert.Equal(t, ".github/instructions/project.instructions.md", req.Resources[0].Path)
+	assert.Equal(t, "docs/task.instructions.md", req.Resources[1].Path)
+}
+
+func TestBuildExecutionRequest_InstructionFilesUseTaskContextRoot(t *testing.T) {
+	evalFixtureDir := t.TempDir()
+	taskFixtureDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(taskFixtureDir, ".github", "instructions"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(taskFixtureDir, ".github", "instructions", "task.instructions.md"), []byte("Task context rules."), 0o644))
+
+	spec := &models.EvalSpec{
+		SkillName: "test-skill",
+		Config: models.Config{
+			EngineType:       "mock",
+			ModelID:          "gpt-4",
+			TimeoutSec:       60,
+			InstructionFiles: []string{".github/instructions/task.instructions.md"},
+		},
+	}
+	cfg := config.NewEvalConfig(spec, config.WithFixtureDir(evalFixtureDir))
+	runner := NewEvalRunner(cfg, nil)
+
+	tc := &models.TestCase{
+		TestID:      "test-001",
+		DisplayName: "Test Case",
+		ContextRoot: taskFixtureDir,
+		Stimulus:    models.TaskStimulus{Message: "test"},
+	}
+
+	req, err := runner.buildExecutionRequest(tc)
+	require.NoError(t, err)
+	require.Len(t, req.Instructions, 1)
+	assert.Equal(t, "Task context rules.", string(req.Instructions[0].Content))
+}
+
+func TestBuildExecutionRequest_InstructionFileErrors(t *testing.T) {
+	fixtureDir := t.TempDir()
+	spec := &models.EvalSpec{
+		SkillName: "test-skill",
+		Config: models.Config{
+			EngineType: "mock",
+			ModelID:    "gpt-4",
+			TimeoutSec: 60,
+		},
+	}
+	cfg := config.NewEvalConfig(spec, config.WithFixtureDir(fixtureDir))
+	runner := NewEvalRunner(cfg, nil)
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "missing", path: "missing.instructions.md", want: "reading instruction file"},
+		{name: "absolute", path: filepath.Join(fixtureDir, "absolute.instructions.md"), want: "must be relative"},
+		{name: "traversal", path: "../escape.instructions.md", want: "must not contain path traversal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &models.TestCase{
+				TestID:           "test-001",
+				DisplayName:      "Test Case",
+				Stimulus:         models.TaskStimulus{Message: "test"},
+				InstructionFiles: []string{tt.path},
+			}
+			_, err := runner.buildExecutionRequest(tc)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
 }
 
 func TestComputeTestStats_ErrorRunsAreSeparateFromFailed(t *testing.T) {

--- a/internal/validation/schema_test.go
+++ b/internal/validation/schema_test.go
@@ -56,6 +56,28 @@ func TestValidateEvalBytes_Valid(t *testing.T) {
 	require.Empty(t, errs, "valid eval should have no errors")
 }
 
+func TestValidateEvalBytes_InstructionFiles(t *testing.T) {
+	yaml := `name: test-eval
+skill: test-skill
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: gpt-4o
+  instruction_files:
+    - .github/instructions/project.instructions.md
+metrics:
+  - name: accuracy
+    weight: 1.0
+    threshold: 0.8
+tasks:
+  - "tasks/*.yaml"
+`
+	errs := ValidateEvalBytes([]byte(yaml))
+	require.Empty(t, errs, "eval with instruction_files should have no errors")
+}
+
 func TestValidateEvalBytes_Invalid(t *testing.T) {
 	errs := ValidateEvalBytes([]byte(invalidEvalYAML))
 	require.NotEmpty(t, errs, "invalid eval should have errors")
@@ -68,6 +90,18 @@ func TestValidateEvalBytes_Invalid(t *testing.T) {
 func TestValidateTaskBytes_Valid(t *testing.T) {
 	errs := ValidateTaskBytes([]byte(validTaskYAML))
 	require.Empty(t, errs, "valid task should have no errors")
+}
+
+func TestValidateTaskBytes_InstructionFiles(t *testing.T) {
+	yaml := `id: task-1
+name: Basic task
+instruction_files:
+  - .github/instructions/task.instructions.md
+inputs:
+  prompt: "Explain this code"
+`
+	errs := ValidateTaskBytes([]byte(yaml))
+	require.Empty(t, errs, "task with instruction_files should have no errors")
 }
 
 func TestValidateTaskBytes_Invalid(t *testing.T) {

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -164,6 +164,13 @@
           },
           "description": "Additional directories to search for skill definitions."
         },
+        "instruction_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Instruction files to apply to every task, resolved relative to the active context/fixtures directory."
+        },
         "disabled_skills": {
           "type": "array",
           "items": {

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -71,6 +71,13 @@
       "items": {
         "type": "string"
       }
+    },
+    "instruction_files": {
+      "type": "array",
+      "description": "Instruction files to apply to this task in addition to eval-level instruction_files. Paths are resolved relative to the active context/fixtures directory.",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "$defs": {

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -99,6 +99,8 @@ config:
   model: claude-sonnet-4.6 # Default model (override with --model)
   judge_model: gpt-4o # Model for LLM-as-judge graders (optional)
   executor: mock # mock (local) or copilot-sdk (real API)
+  instruction_files:
+    - .github/instructions/project.instructions.md
 ```
 
 | Field               | Type      | Default           | Description                                                 |
@@ -114,6 +116,7 @@ config:
 | `group_by`          | string    | —                 | Group results by a field (e.g., `tags`, `task_id`)          |
 | `fail_fast`         | bool      | false             | Stop the entire run on first task failure                   |
 | `skill_directories` | list[str] | `[]`              | Additional directories to search for skills                 |
+| `instruction_files` | list[str] | `[]`              | Instruction files to apply to every task                    |
 | `disabled_skills`   | list[str] | `[]`              | Skills to disable. Use `["*"]` to disable all skills        |
 | `required_skills`   | list[str] | `[]`              | Skills that must be available before running                |
 | `mcp_servers`       | object    | —                 | MCP server configurations for the evaluation                |
@@ -217,6 +220,7 @@ expected:
 | `inputs`      | object | Test inputs (prompt, files)                         |
 | `expected`    | object | Validation rules and expected behavior              |
 | `skill_directories` | string[] | Skill directories for this task (overrides eval-level) |
+| `instruction_files` | string[] | Instruction files for this task (adds to eval-level files) |
 
 ### Inputs Section
 
@@ -341,6 +345,29 @@ inputs:
   files:
     - path: sample.py
 ```
+
+### Instruction Files
+
+Use `instruction_files` for repository or task-specific `*.instructions.md` guidance:
+
+```yaml
+# eval.yaml
+config:
+  instruction_files:
+    - .github/instructions/project.instructions.md
+```
+
+```yaml
+# tasks/review.yaml
+instruction_files:
+  - .github/instructions/review.instructions.md
+inputs:
+  prompt: "Review this change"
+  files:
+    - path: sample.py
+```
+
+Instruction files are resolved from the active fixtures/context directory, copied into each fresh temp workspace, and appended to the agent system message with path labels. Eval-level files apply to every task; task-level files are added for that task. Paths must be relative and cannot use directory traversal.
 
 ### Directory Structure
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -218,6 +218,19 @@ config:
     - /opt/shared-skills
 ```
 
+### instruction_files
+
+**Type:** list[string]
+**Default:** `[]`
+
+Instruction files to apply to every task. Paths are resolved relative to the active fixtures/context directory, copied into each task workspace, and appended to the agent system message as path-labeled instructions.
+
+```yaml
+config:
+  instruction_files:
+    - .github/instructions/project.instructions.md
+```
+
 ### required_skills
 
 **Type:** list[string]  
@@ -408,6 +421,15 @@ skill_directories:
 ```
 
 When specified on a task, this **replaces** (not merges with) the eval-level `skill_directories`.
+
+### instruction_files (optional)
+
+Apply additional instruction files for a specific task. Paths are resolved relative to the active fixtures/context directory. Task-level entries are **added to** the eval-level `config.instruction_files` list.
+
+```yaml
+instruction_files:
+  - .github/instructions/review.instructions.md
+```
 
 ## inputs Section
 


### PR DESCRIPTION
## Summary
- Add eval-level `config.instruction_files` and task-level `instruction_files` YAML support
- Copy listed instruction files from the active fixtures/context directory into each task workspace
- Append path-labeled instruction file contents to the Copilot system message during execution
- Update schemas, docs, and regression tests

Closes #239

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Validation
- `go test ./...`
- `cd site && npm run build`