### PR TITLE
fix: prompt grader gracefully recovers when follow-up turn fails after grades collected

### DIFF
--- a/internal/graders/prompt_grader.go
+++ b/internal/graders/prompt_grader.go
@@ -111,8 +111,19 @@ func (p *promptGrader) gradeIndependent(ctx context.Context, gradingContext *Con
 			Mode:   "enqueue",
 		})
 
+		// The SDK unconditionally sends tool results back to the model after
+		// the grade tool calls fire, which starts a follow-up assistant turn.
+		// That follow-up turn can fail ("Failed to get response from the AI
+		// model") even though the grades were already collected. If we have
+		// grade data, use it — the error is from an unnecessary follow-up
+		// turn, not from the grading itself.
 		if err != nil {
-			return nil, fmt.Errorf("failed to send prompt: %w", err)
+			total := len(wazaTools.Failures) + len(wazaTools.Passes)
+			if total == 0 {
+				return nil, fmt.Errorf("failed to send prompt: %w", err)
+			}
+			slog.WarnContext(ctx, "prompt grader: ignoring post-grade session error (grades already collected)",
+				"err", err, "passes", len(wazaTools.Passes), "failures", len(wazaTools.Failures))
 		}
 
 		var score = 0.0
@@ -124,8 +135,11 @@ func (p *promptGrader) gradeIndependent(ctx context.Context, gradingContext *Con
 			score = float64(len(wazaTools.Passes)) / float64(total)
 		}
 
-		respContent := resp.Data.Content
-
+		// resp may be nil when we recovered from a post-grade error above.
+		var respContent *string
+		if resp != nil && resp.Data.Content != nil {
+			respContent = resp.Data.Content
+		}
 		if respContent == nil {
 			respContent = utils.Ptr("<no response content>")
 		}


### PR DESCRIPTION
## Summary

Fixes #250 — the prompt grader now gracefully recovers when the Copilot SDK's follow-up turn fails after grade tool results are sent back to the model.

## Problem

`SendAndWait` returns an error when the model fails to respond to the follow-up turn after `set_waza_grade_pass`/`set_waza_grade_fail` tool results are sent back. The error was propagated unconditionally, discarding the already-collected grades. This caused evaluations to report `score=0.00` and `status=error` even though the judge successfully graded every criterion.

## Fix

After `SendAndWait` returns an error, check if grade tool calls were already collected in `wazaTools.Passes`/`wazaTools.Failures`. If they were, log a warning and continue with the actual scores instead of failing. Also handles the `nil` resp case since `SendAndWait` returns `(nil, error)`.

## Changes

- `internal/graders/prompt_grader.go`: 
  - Check `len(wazaTools.Passes) + len(wazaTools.Failures) > 0` before propagating error
  - Guard `resp.Data.Content` access for nil resp
  - Log warning with pass/fail counts for observability

## Testing

Verified on Windows 11 with waza v0.31.0 (built from source with this patch):

**Before patch:** `score=0.00, status=error` — grades discarded
```
[ERROR] running graders: failed to run grader rubric_judge: failed to send prompt: 
session error: Failed to get response from the AI model; retried 5 times
```

**After patch:** `score=0.60` — grades recovered (3 pass, 2 fail)
```
WARN "prompt grader: ignoring post-grade session error (grades already collected)" passes=3 failures=2
[GRADER] rubric_judge score=0.60 (39.835s)
```

## Note

The `pairwise` grader (`runPairwiseOnce`) has the same `SendAndWait` + error pattern and would benefit from the same fix. I kept this PR focused on the `gradeIndependent` path where I could reproduce and verify the fix.