### PR TITLE
fix: address prompt grader review feedback

### DIFF
--- a/internal/execution/mock.go
+++ b/internal/execution/mock.go
@@ -117,6 +117,11 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 		sessionID = fmt.Sprintf("mock-session-%d", time.Now().UnixNano())
 	}
 
+	var workspaceFiles map[string][]byte
+	if !req.SkipWorkspaceCapture {
+		workspaceFiles = captureWorkspaceFiles(m.workspace)
+	}
+
 	resp := &ExecutionResponse{
 		FinalOutput:    output,
 		Events:         []copilot.SessionEvent{},
@@ -126,10 +131,7 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 		Success:        true,
 		SessionID:      sessionID,
 		WorkspaceDir:   m.workspace,
-		WorkspaceFiles: captureWorkspaceFiles(m.workspace),
-	}
-	if req.SkipWorkspaceCapture {
-		resp.WorkspaceFiles = nil
+		WorkspaceFiles: workspaceFiles,
 	}
 
 	return resp, nil

--- a/internal/execution/mock_engine_test.go
+++ b/internal/execution/mock_engine_test.go
@@ -138,3 +138,19 @@ func TestMockEngine_Execute_TruncatesLargeContent(t *testing.T) {
 
 	require.NoError(t, engine.Shutdown(context.Background()))
 }
+
+func TestMockEngine_Execute_SkipWorkspaceCapture(t *testing.T) {
+	engine := NewMockEngine("test-model")
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	resp, err := engine.Execute(context.Background(), &ExecutionRequest{
+		Message:              "hello",
+		Resources:            []ResourceFile{{Path: "input.txt", Content: []byte("content")}},
+		SkipWorkspaceCapture: true,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.WorkspaceFiles)
+	require.FileExists(t, filepath.Join(resp.WorkspaceDir, "input.txt"))
+
+	require.NoError(t, engine.Shutdown(context.Background()))
+}

--- a/internal/graders/prompt_grader.go
+++ b/internal/graders/prompt_grader.go
@@ -71,13 +71,17 @@ func (p *promptGrader) gradeIndependent(ctx context.Context, gradingContext *Con
 				return nil, errors.New("no session id set, can't continue session in prompt grading")
 			}
 		}
+		sessionID := ""
+		if p.args.ContinueSession {
+			sessionID = gradingContext.SessionID
+		}
 		resp, err := executePromptGrader(ctx, gradingContext, &execution.ExecutionRequest{
 			ModelID:              p.args.Model,
 			Message:              p.args.Prompt,
 			Tools:                wazaTools.Tools,
 			MessageMode:          execution.MessageModeEnqueue,
 			Streaming:            true,
-			SessionID:            gradingContext.SessionID,
+			SessionID:            sessionID,
 			WorkspaceDir:         gradingContext.WorkspaceDir,
 			NoSkills:             true,
 			Timeout:              promptGraderTimeout,

--- a/internal/graders/prompt_grader_test.go
+++ b/internal/graders/prompt_grader_test.go
@@ -91,6 +91,7 @@ func TestPromptGraderUsesExecutorTools(t *testing.T) {
 			require.True(t, req.Streaming)
 			require.True(t, req.EphemeralSession)
 			require.True(t, req.SkipWorkspaceCapture)
+			require.Empty(t, req.SessionID)
 			require.True(t, req.NoSkills)
 			require.Len(t, req.Tools, 2)
 			_, err := req.Tools[0].Handler(copilot.ToolInvocation{
@@ -109,6 +110,7 @@ func TestPromptGraderUsesExecutorTools(t *testing.T) {
 
 	results, err := promptGrader.Grade(context.Background(), &Context{
 		WorkspaceDir: "/tmp/workspace",
+		SessionID:    "task-session",
 		Executor:     executor,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Addresses Copilot review feedback from #258.

Changes:
- Only pass `ExecutionRequest.SessionID` for prompt grading when `ContinueSession` is true, preserving fresh judge sessions by default.
- Avoid `captureWorkspaceFiles` entirely in `MockEngine` when `SkipWorkspaceCapture` is set.
- Add regression coverage for both behaviors.

Validation:
- `go test ./internal/graders ./internal/execution`
- `golangci-lint run --timeout=5m ./...`
- `go test ./...`

Stacked on #258.
