### PR TITLE
fix: remove nonstandard skill type prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ waza init my-project --no-skill
 
 ### `waza new skill <skill-name>`
 
-Create a new skill with scaffolded structure and evaluation suite. Detects workspace context and adapts output.
+Create a new skill with scaffolded structure and evaluation suite. Detects workspace context and adapts output. In interactive mode, the wizard collects spec-aligned metadata: name, description, trigger phrases, and anti-trigger phrases.
 
 | Flag | Short | Description |
 |------|-------|-------------|

--- a/cmd/waza/cmd_new.go
+++ b/cmd/waza/cmd_new.go
@@ -452,7 +452,6 @@ func dirFileCount(dir string) int {
 func defaultSkillMD(name string) string {
 	return fmt.Sprintf(`---
 name: %s
-type: utility
 description: |
   USE FOR: %s tasks, ...
   DO NOT USE FOR: unrelated tasks, ...

--- a/cmd/waza/cmd_new_test.go
+++ b/cmd/waza/cmd_new_test.go
@@ -254,8 +254,10 @@ func TestNewCommand_EmptySkillMD_NonTTY_OverwritesWithDefaults(t *testing.T) {
 	// SKILL.md should be overwritten with default content (not empty anymore)
 	data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
 	require.NoError(t, err)
-	assert.NotEmpty(t, string(data), "empty SKILL.md should be overwritten with defaults")
-	assert.Contains(t, string(data), "name: my-skill", "overwritten SKILL.md should have valid frontmatter")
+	content := string(data)
+	assert.NotEmpty(t, content, "empty SKILL.md should be overwritten with defaults")
+	assert.Contains(t, content, "name: my-skill", "overwritten SKILL.md should have valid frontmatter")
+	assert.NotContains(t, content, "type:", "new SKILL.md frontmatter should not include nonstandard type metadata")
 
 	// Warning should appear in output
 	output := buf.String()
@@ -289,7 +291,9 @@ func TestNewCommand_MalformedSkillMD_NonTTY_OverwritesWithDefaults(t *testing.T)
 	// SKILL.md should be overwritten
 	data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
 	require.NoError(t, err)
-	assert.Contains(t, string(data), "name: my-skill", "malformed SKILL.md should be overwritten")
+	content := string(data)
+	assert.Contains(t, content, "name: my-skill", "malformed SKILL.md should be overwritten")
+	assert.NotContains(t, content, "type:", "new SKILL.md frontmatter should not include nonstandard type metadata")
 
 	// Warning should appear
 	assert.Contains(t, buf.String(), "empty or malformed")
@@ -348,7 +352,9 @@ func TestNewCommand_NoSkillMD_NonTTY_CreatesEverything(t *testing.T) {
 	// SKILL.md should be created with default content
 	data, err := os.ReadFile(filepath.Join(dir, "skills", "my-skill", "SKILL.md"))
 	require.NoError(t, err)
-	assert.Contains(t, string(data), "name: my-skill")
+	content := string(data)
+	assert.Contains(t, content, "name: my-skill")
+	assert.NotContains(t, content, "type:", "new SKILL.md frontmatter should not include nonstandard type metadata")
 
 	// Output should show "Scaffolding" header
 	output := buf.String()

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -85,7 +85,6 @@ Edit `skills/code-explainer/SKILL.md`:
 ```yaml
 ---
 name: code-explainer
-type: utility
 description: |
   USE FOR: Explaining code, analyzing code patterns, refactoring suggestions
   DO NOT USE FOR: Running code, generating boilerplate

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -252,7 +252,7 @@ waza init my-skills --no-skill
 
 ### `waza new skill [skill-name]`
 
-Create a new skill with its evaluation suite.
+Create a new skill with its evaluation suite. In interactive mode, the wizard collects spec-aligned metadata: name, description, trigger phrases, and anti-trigger phrases.
 
 **Flags:**
 - `--template, -t` — Template pack (coming soon)

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -12,27 +12,16 @@ import (
 	"golang.org/x/term"
 )
 
-// SkillType represents the category of a skill.
-type SkillType string
-
-const (
-	SkillTypeWorkflow SkillType = "workflow"
-	SkillTypeUtility  SkillType = "utility"
-	SkillTypeAnalysis SkillType = "analysis"
-)
-
 // SkillSpec holds all fields collected during the interactive wizard.
 type SkillSpec struct {
 	Name         string
 	Description  string
 	Triggers     []string
 	AntiTriggers []string
-	Type         SkillType
 }
 
 const skillMDTemplate = `---
 name: {{ .Name }}
-type: {{ .Type }}
 description: >
   {{ .Description }}
 ---
@@ -62,7 +51,6 @@ func RunSkillWizard(in io.Reader, out io.Writer, initialName string) (*SkillSpec
 		description     string
 		triggersRaw     string
 		antiTriggersRaw string
-		skillType       string
 	)
 
 	form := huh.NewForm(
@@ -96,14 +84,6 @@ func RunSkillWizard(in io.Reader, out io.Writer, initialName string) (*SkillSpec
 				Description("Comma-separated phrases that should NOT activate this skill").
 				Placeholder("unrelated task, wrong domain").
 				Value(&antiTriggersRaw),
-			huh.NewSelect[string]().
-				Title("Skill type").
-				Options(
-					huh.NewOption("workflow", "workflow"),
-					huh.NewOption("utility", "utility"),
-					huh.NewOption("analysis", "analysis"),
-				).
-				Value(&skillType),
 		),
 	).
 		WithInput(in).
@@ -123,7 +103,6 @@ func RunSkillWizard(in io.Reader, out io.Writer, initialName string) (*SkillSpec
 		Description:  strings.TrimSpace(description),
 		Triggers:     splitAndTrim(triggersRaw),
 		AntiTriggers: splitAndTrim(antiTriggersRaw),
-		Type:         SkillType(skillType),
 	}, nil
 }
 

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -98,16 +98,18 @@ func RunSkillWizard(in io.Reader, out io.Writer, initialName string) (*SkillSpec
 		return nil, fmt.Errorf("wizard failed: %w", err)
 	}
 
-	if strings.TrimSpace(name) == "" {
-		return nil, fmt.Errorf("skill name is required")
+	name = strings.TrimSpace(name)
+	description = strings.TrimSpace(description)
+	if err := scaffold.ValidateName(name); err != nil {
+		return nil, fmt.Errorf("invalid skill name: %w", err)
 	}
-	if strings.TrimSpace(description) == "" {
-		return nil, fmt.Errorf("skill description is required")
+	if description == "" {
+		return nil, fmt.Errorf("description is required")
 	}
 
 	return &SkillSpec{
-		Name:         strings.TrimSpace(name),
-		Description:  strings.TrimSpace(description),
+		Name:         name,
+		Description:  description,
 		Triggers:     splitAndTrim(triggersRaw),
 		AntiTriggers: splitAndTrim(antiTriggersRaw),
 	}, nil

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -98,6 +98,13 @@ func RunSkillWizard(in io.Reader, out io.Writer, initialName string) (*SkillSpec
 		return nil, fmt.Errorf("wizard failed: %w", err)
 	}
 
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("skill name is required")
+	}
+	if strings.TrimSpace(description) == "" {
+		return nil, fmt.Errorf("skill description is required")
+	}
+
 	return &SkillSpec{
 		Name:         strings.TrimSpace(name),
 		Description:  strings.TrimSpace(description),

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -98,24 +98,23 @@ func TestRunSkillWizard_ValidInput(t *testing.T) {
 }
 
 func TestRunSkillWizard_EmptyInput(t *testing.T) {
-	// huh gracefully handles EOF by using default (empty) values
+	// EOF with no input should return an error because name is required.
 	in := strings.NewReader("")
 	out := &bytes.Buffer{}
 
-	spec, err := RunSkillWizard(in, out, "")
-	require.NoError(t, err)
-	assert.Empty(t, spec.Name)
+	_, err := RunSkillWizard(in, out, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
 }
 
 func TestRunSkillWizard_IncompleteInput(t *testing.T) {
-	// Only name provided; remaining fields use defaults
+	// Only name provided; description is missing so an error must be returned.
 	in := pipeInput(t, "my-skill")
 	out := &bytes.Buffer{}
 
-	spec, err := RunSkillWizard(in, out, "")
-	require.NoError(t, err)
-	assert.Equal(t, "my-skill", spec.Name)
-	assert.Empty(t, spec.Description)
+	_, err := RunSkillWizard(in, out, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "description")
 }
 
 func TestRunSkillWizard_InitialName(t *testing.T) {

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -17,14 +17,13 @@ func TestGenerateSkillMD_BasicSpec(t *testing.T) {
 		Description:  "Reviews code for quality and best practices.",
 		Triggers:     []string{"review code", "check quality"},
 		AntiTriggers: []string{"deploy code", "run tests"},
-		Type:         SkillTypeWorkflow,
 	}
 
 	result, err := GenerateSkillMD(spec)
 	require.NoError(t, err)
 
 	assert.Contains(t, result, "name: code-reviewer")
-	assert.Contains(t, result, "type: workflow")
+	assert.NotContains(t, result, "type:")
 	assert.Contains(t, result, "Reviews code for quality and best practices.")
 	assert.Contains(t, result, "# code-reviewer")
 	assert.Contains(t, result, "**USE FOR:**")
@@ -35,35 +34,10 @@ func TestGenerateSkillMD_BasicSpec(t *testing.T) {
 	assert.Contains(t, result, "- run tests")
 }
 
-func TestGenerateSkillMD_AllTypes(t *testing.T) {
-	tests := []struct {
-		skillType SkillType
-		expected  string
-	}{
-		{SkillTypeWorkflow, "type: workflow"},
-		{SkillTypeUtility, "type: utility"},
-		{SkillTypeAnalysis, "type: analysis"},
-	}
-
-	for _, tt := range tests {
-		t.Run(string(tt.skillType), func(t *testing.T) {
-			spec := &SkillSpec{
-				Name:        "test-skill",
-				Description: "A test skill.",
-				Type:        tt.skillType,
-			}
-			result, err := GenerateSkillMD(spec)
-			require.NoError(t, err)
-			assert.Contains(t, result, tt.expected)
-		})
-	}
-}
-
 func TestGenerateSkillMD_EmptyTriggers(t *testing.T) {
 	spec := &SkillSpec{
 		Name:        "minimal-skill",
 		Description: "A minimal skill with no triggers.",
-		Type:        SkillTypeUtility,
 	}
 
 	result, err := GenerateSkillMD(spec)
@@ -111,8 +85,7 @@ func pipeInput(t *testing.T, lines ...string) io.Reader {
 }
 
 func TestRunSkillWizard_ValidInput(t *testing.T) {
-	// huh accessible mode: Input reads a line, Select reads option number (1-indexed)
-	in := pipeInput(t, "my-skill", "A great skill", "trigger1, trigger2", "anti1, anti2", "1")
+	in := pipeInput(t, "my-skill", "A great skill", "trigger1, trigger2", "anti1, anti2")
 	out := &bytes.Buffer{}
 
 	spec, err := RunSkillWizard(in, out, "")
@@ -122,7 +95,6 @@ func TestRunSkillWizard_ValidInput(t *testing.T) {
 	assert.Equal(t, "A great skill", spec.Description)
 	assert.Equal(t, []string{"trigger1", "trigger2"}, spec.Triggers)
 	assert.Equal(t, []string{"anti1", "anti2"}, spec.AntiTriggers)
-	assert.Equal(t, SkillTypeWorkflow, spec.Type)
 }
 
 func TestRunSkillWizard_EmptyInput(t *testing.T) {
@@ -133,7 +105,6 @@ func TestRunSkillWizard_EmptyInput(t *testing.T) {
 	spec, err := RunSkillWizard(in, out, "")
 	require.NoError(t, err)
 	assert.Empty(t, spec.Name)
-	assert.Equal(t, SkillType("workflow"), spec.Type) // default to first option
 }
 
 func TestRunSkillWizard_IncompleteInput(t *testing.T) {
@@ -147,20 +118,10 @@ func TestRunSkillWizard_IncompleteInput(t *testing.T) {
 	assert.Empty(t, spec.Description)
 }
 
-func TestRunSkillWizard_SelectAnalysis(t *testing.T) {
-	// 3 = analysis (third option)
-	in := pipeInput(t, "test-skill", "A test skill", "", "", "3")
-	out := &bytes.Buffer{}
-
-	spec, err := RunSkillWizard(in, out, "")
-	require.NoError(t, err)
-	assert.Equal(t, SkillTypeAnalysis, spec.Type)
-}
-
 func TestRunSkillWizard_InitialName(t *testing.T) {
 	// When initialName is provided, the name field is pre-populated.
 	// User submits the pre-populated name and fills in other fields.
-	in := pipeInput(t, "azure-deploy", "My pre-named skill", "use for testing", "", "1")
+	in := pipeInput(t, "azure-deploy", "My pre-named skill", "use for testing", "")
 	out := &bytes.Buffer{}
 
 	spec, err := RunSkillWizard(in, out, "azure-deploy")

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -98,23 +98,23 @@ func TestRunSkillWizard_ValidInput(t *testing.T) {
 }
 
 func TestRunSkillWizard_EmptyInput(t *testing.T) {
-	// EOF with no input should return an error because name is required.
 	in := strings.NewReader("")
 	out := &bytes.Buffer{}
 
-	_, err := RunSkillWizard(in, out, "")
+	spec, err := RunSkillWizard(in, out, "")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "name")
+	assert.Nil(t, spec)
+	assert.ErrorContains(t, err, "invalid skill name")
 }
 
 func TestRunSkillWizard_IncompleteInput(t *testing.T) {
-	// Only name provided; description is missing so an error must be returned.
 	in := pipeInput(t, "my-skill")
 	out := &bytes.Buffer{}
 
-	_, err := RunSkillWizard(in, out, "")
+	spec, err := RunSkillWizard(in, out, "")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "description")
+	assert.Nil(t, spec)
+	assert.ErrorContains(t, err, "description is required")
 }
 
 func TestRunSkillWizard_InitialName(t *testing.T) {

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -131,7 +131,6 @@ Edit `skills/code-explainer/SKILL.md`:
 ```yaml
 ---
 name: code-explainer
-type: utility
 description: |
   USE FOR: Explaining code, analyzing code patterns, refactoring suggestions
   DO NOT USE FOR: Running code, generating boilerplate

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -169,7 +169,7 @@ waza init my-project --no-skill
 
 ## waza new skill
 
-Create a new skill.
+Create a new skill. In interactive mode, the wizard collects spec-aligned metadata: name, description, trigger phrases, and anti-trigger phrases.
 
 ```bash
 waza new skill [skill-name]


### PR DESCRIPTION
Closes #243

## Summary
- Remove the nonstandard skill type question from the `waza new skill` interactive wizard.
- Stop generating `type:` frontmatter in new skill scaffolds.
- Update tests and docs/examples so new skills use spec-aligned metadata only.

## Validation
- `go test ./internal/wizard ./cmd/waza`
- `go test ./...`
- `cd site && npm run build`

Note: `golangci-lint` was not available in this environment.