### PR TITLE
fix: pass --model via CLIArgs to override user settings and experiment flights

### DIFF
--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -202,6 +202,12 @@ func modelCLIArgs(defaultModelID string) []string {
 	if defaultModelID == "" {
 		return []string{}
 	}
+	// --model forces the configured model at CLI startup, overriding any
+	// user preference in the local Copilot settings.json (located under
+	// the user's home directory on Unix and %USERPROFILE% on Windows) or
+	// experiment flights that would otherwise cause the embedded CLI to
+	// use unintended models. SessionConfig.Model still takes precedence
+	// for per-session overrides via Execute.
 	return []string{"--model", defaultModelID}
 }
 

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -167,14 +167,17 @@ type CopilotEngineBuilderOptions struct {
 func NewCopilotEngineBuilder(defaultModelID string, options *CopilotEngineBuilderOptions) *CopilotEngineBuilder {
 	var client CopilotClient
 	ownsClient := false
+	cliArgs := modelCLIArgs(defaultModelID)
 
 	if options == nil || options.NewCopilotClient == nil {
 		// Production: share one SDK process across all engines + graders.
-		client = SharedClient(SharedClientOptions{})
+		client = SharedClient(SharedClientOptions{CLIArgs: cliArgs})
 	} else {
 		copilotOptions := &copilot.ClientOptions{
 			// workspace is set at the session level, instead of at the client.
 			LogLevel: "error",
+
+			CLIArgs: cliArgs,
 
 			AutoStart:   utils.Ptr(false), // we handle start in Initialize()
 			AutoRestart: utils.Ptr(true),  // this is a default, but just in case the defaults change...
@@ -193,6 +196,13 @@ func NewCopilotEngineBuilder(defaultModelID string, options *CopilotEngineBuilde
 
 	builder.engine.client = client
 	return builder
+}
+
+func modelCLIArgs(defaultModelID string) []string {
+	if defaultModelID == "" {
+		return []string{}
+	}
+	return []string{"--model", defaultModelID}
 }
 
 func (b *CopilotEngineBuilder) Build() *CopilotEngine {
@@ -323,7 +333,6 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	var session CopilotSession
 
 	permRequestCallback := allowAllTools
-
 	if req.PermissionHandler != nil {
 		permRequestCallback = req.PermissionHandler
 	}

--- a/internal/execution/copilot_engine_test.go
+++ b/internal/execution/copilot_engine_test.go
@@ -327,3 +327,50 @@ func TestCopilotEngine_Shutdown_StopsClientAndCleansWorkspaces(t *testing.T) {
 	_, err = os.Stat(workspaceDir)
 	assert.True(t, os.IsNotExist(err))
 }
+
+// TestCopilotEngineBuilder_CLIArgsCarriesModel is a regression test for #262 /
+// PR #263: when defaultModelID is set, the engine must pass
+// "--model <defaultModelID>" through copilot.ClientOptions.CLIArgs so the
+// embedded CLI honors the eval-configured model instead of the user's local
+// settings.json or experiment-flight default. Without this startup override,
+// SessionConfig.Model is silently ignored by the embedded CLI and evals run
+// against the wrong model.
+func TestCopilotEngineBuilder_CLIArgsCarriesModel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clientMock := NewMockCopilotClient(ctrl)
+
+	const defaultModelID = "claude-sonnet-4.5"
+
+	var captured *copilot.ClientOptions
+	_ = NewCopilotEngineBuilder(defaultModelID, &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(clientOptions *copilot.ClientOptions) CopilotClient {
+			captured = clientOptions
+			return clientMock
+		},
+	}).Build()
+
+	require.NotNil(t, captured, "NewCopilotClient must receive non-nil ClientOptions")
+	require.Equal(t, []string{"--model", defaultModelID}, captured.CLIArgs,
+		"CLIArgs must carry --model <defaultModelID> so it overrides the user's local Copilot settings.json and experiment-flight defaults")
+}
+
+// TestCopilotEngineBuilder_CLIArgsEmptyWhenNoDefaultModel is a regression test
+// asserting that no --model CLI startup arg is injected when no default model
+// is configured. This preserves the embedded CLI's own fallback model selection
+// (settings.json / experiment flights) for callers that explicitly opt out.
+func TestCopilotEngineBuilder_CLIArgsEmptyWhenNoDefaultModel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clientMock := NewMockCopilotClient(ctrl)
+
+	var captured *copilot.ClientOptions
+	_ = NewCopilotEngineBuilder("", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(clientOptions *copilot.ClientOptions) CopilotClient {
+			captured = clientOptions
+			return clientMock
+		},
+	}).Build()
+
+	require.NotNil(t, captured, "NewCopilotClient must receive non-nil ClientOptions")
+	require.Empty(t, captured.CLIArgs,
+		"CLIArgs must be empty when no defaultModelID is provided so the embedded CLI can pick its own fallback")
+}

--- a/internal/execution/sdkclient.go
+++ b/internal/execution/sdkclient.go
@@ -31,11 +31,14 @@ type SharedClientOptions struct {
 var (
 	sharedMu        sync.Mutex
 	sharedClients   map[string]CopilotClient
+	sharedClosed    bool
 	sharedShutdown  sync.Once
 	sharedErr       error
 	sharedConstruct = newCopilotClient // overridable for tests
 	embeddedCLIPath = embedded.Path    // overridable for tests
 )
+
+var errSharedClientClosed = errors.New("shared Copilot client has been shut down")
 
 // SharedClient returns a lazily-constructed, process-wide [CopilotClient].
 //
@@ -62,6 +65,9 @@ func SharedClient(opts SharedClientOptions) CopilotClient {
 
 	if sharedClients == nil {
 		sharedClients = make(map[string]CopilotClient)
+	}
+	if sharedClosed {
+		return &startupErrorClient{err: errSharedClientClosed}
 	}
 	if client := sharedClients[key]; client != nil {
 		return client
@@ -157,6 +163,9 @@ func ShutdownSharedClient(_ context.Context) error {
 	for _, client := range sharedClients {
 		clients = append(clients, client)
 	}
+	if len(clients) > 0 {
+		sharedClosed = true
+	}
 	sharedMu.Unlock()
 
 	if len(clients) == 0 {
@@ -181,5 +190,6 @@ func resetSharedClientForTest() {
 	defer sharedMu.Unlock()
 	sharedShutdown = sync.Once{}
 	sharedClients = nil
+	sharedClosed = false
 	sharedErr = nil
 }

--- a/internal/execution/sdkclient.go
+++ b/internal/execution/sdkclient.go
@@ -19,6 +19,9 @@ type SharedClientOptions struct {
 	// LogLevel passed through to the underlying copilot.Client. Defaults to
 	// "error" when blank.
 	LogLevel string
+	// CLIArgs passed through to the underlying copilot.Client. Only the first
+	// SharedClient call wins because the client is process-wide.
+	CLIArgs []string
 }
 
 var (
@@ -52,7 +55,7 @@ func SharedClient(opts SharedClientOptions) CopilotClient {
 		if logLevel == "" {
 			logLevel = "error"
 		}
-		clientOptions, err := sharedClientOptions(logLevel)
+		clientOptions, err := sharedClientOptions(logLevel, opts.CLIArgs)
 		if err != nil {
 			slog.Warn("Copilot CLI path resolution failed; refusing PATH fallback", "error", err)
 			sharedClient = &startupErrorClient{err: err}
@@ -63,9 +66,10 @@ func SharedClient(opts SharedClientOptions) CopilotClient {
 	return sharedClient
 }
 
-func sharedClientOptions(logLevel string) (*copilot.ClientOptions, error) {
+func sharedClientOptions(logLevel string, cliArgs []string) (*copilot.ClientOptions, error) {
 	opts := &copilot.ClientOptions{
 		LogLevel:    logLevel,
+		CLIArgs:     append([]string{}, cliArgs...),
 		AutoStart:   utils.Ptr(false),
 		AutoRestart: utils.Ptr(true),
 	}

--- a/internal/execution/sdkclient.go
+++ b/internal/execution/sdkclient.go
@@ -2,9 +2,11 @@ package execution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -12,21 +14,23 @@ import (
 	"github.com/microsoft/waza/internal/utils"
 )
 
-// SharedClientOptions configures the lazily-constructed process-wide Copilot
-// SDK client returned by [SharedClient]. Only the first call wins; subsequent
-// calls receive the already-built client regardless of options.
+// SharedClientOptions configures a lazily-constructed process-wide Copilot SDK
+// client returned by [SharedClient]. Clients are shared by CLIArgs key; within
+// each key, only the first call wins and subsequent calls receive the
+// already-built client regardless of options.
 type SharedClientOptions struct {
 	// LogLevel passed through to the underlying copilot.Client. Defaults to
 	// "error" when blank.
 	LogLevel string
-	// CLIArgs passed through to the underlying copilot.Client. Only the first
-	// SharedClient call wins because the client is process-wide.
+	// CLIArgs passed through to the underlying copilot.Client. Calls with the
+	// same CLIArgs share one process; calls with different CLIArgs get separate
+	// processes because CLIArgs are startup-only.
 	CLIArgs []string
 }
 
 var (
-	sharedOnce      sync.Once
-	sharedClient    CopilotClient
+	sharedMu        sync.Mutex
+	sharedClients   map[string]CopilotClient
 	sharedShutdown  sync.Once
 	sharedErr       error
 	sharedConstruct = newCopilotClient // overridable for tests
@@ -38,8 +42,9 @@ var (
 // Rationale (#135 R2): the embedded Copilot CLI process is expensive to
 // spawn / tear down. Now that all per-call state (workdir, model, MCP
 // servers, skill dirs, system message) is provided to CreateSession and
-// ResumeSessionWithOptions, a single SDK client can serve every
-// [CopilotEngine] (one per --model) and every grader within a `waza run`.
+// ResumeSessionWithOptions, a single SDK client can serve compatible
+// [CopilotEngine] instances and graders within a `waza run`. Startup-only
+// CLIArgs (for example --model) are part of the compatibility key.
 //
 // The client is started lazily on first use by [CopilotEngine.Initialize] (or
 // by an explicit [Start] caller) and is stopped exactly once via
@@ -50,20 +55,34 @@ var (
 // [newCopilotClient] (package-private) or pass a custom NewCopilotClient
 // factory via [CopilotEngineBuilderOptions].
 func SharedClient(opts SharedClientOptions) CopilotClient {
-	sharedOnce.Do(func() {
-		logLevel := opts.LogLevel
-		if logLevel == "" {
-			logLevel = "error"
-		}
-		clientOptions, err := sharedClientOptions(logLevel, opts.CLIArgs)
-		if err != nil {
-			slog.Warn("Copilot CLI path resolution failed; refusing PATH fallback", "error", err)
-			sharedClient = &startupErrorClient{err: err}
-			return
-		}
-		sharedClient = sharedConstruct(clientOptions)
-	})
-	return sharedClient
+	key := sharedClientKey(opts.CLIArgs)
+
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+
+	if sharedClients == nil {
+		sharedClients = make(map[string]CopilotClient)
+	}
+	if client := sharedClients[key]; client != nil {
+		return client
+	}
+
+	logLevel := opts.LogLevel
+	if logLevel == "" {
+		logLevel = "error"
+	}
+	clientOptions, err := sharedClientOptions(logLevel, opts.CLIArgs)
+	if err != nil {
+		slog.Warn("Copilot CLI path resolution failed; refusing PATH fallback", "error", err)
+		sharedClients[key] = &startupErrorClient{err: err}
+		return sharedClients[key]
+	}
+	sharedClients[key] = sharedConstruct(clientOptions)
+	return sharedClients[key]
+}
+
+func sharedClientKey(cliArgs []string) string {
+	return strings.Join(cliArgs, "\x00")
 }
 
 func sharedClientOptions(logLevel string, cliArgs []string) (*copilot.ClientOptions, error) {
@@ -133,11 +152,24 @@ func (c *startupErrorClient) ListModels(context.Context) ([]copilot.ModelInfo, e
 // once from the top-level command after all engines have been Shutdown and
 // all graders have completed.
 func ShutdownSharedClient(_ context.Context) error {
-	if sharedClient == nil {
+	sharedMu.Lock()
+	clients := make([]CopilotClient, 0, len(sharedClients))
+	for _, client := range sharedClients {
+		clients = append(clients, client)
+	}
+	sharedMu.Unlock()
+
+	if len(clients) == 0 {
 		return nil
 	}
 	sharedShutdown.Do(func() {
-		sharedErr = sharedClient.Stop()
+		var errs []error
+		for _, client := range clients {
+			if err := client.Stop(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		sharedErr = errors.Join(errs...)
 	})
 	return sharedErr
 }
@@ -145,8 +177,9 @@ func ShutdownSharedClient(_ context.Context) error {
 // resetSharedClientForTest restores SharedClient to a pristine state. For
 // tests only.
 func resetSharedClientForTest() {
-	sharedOnce = sync.Once{}
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
 	sharedShutdown = sync.Once{}
-	sharedClient = nil
+	sharedClients = nil
 	sharedErr = nil
 }

--- a/internal/execution/sdkclient_test.go
+++ b/internal/execution/sdkclient_test.go
@@ -133,6 +133,32 @@ func TestSharedClient_UsesEmbeddedCLIPath(t *testing.T) {
 	}
 }
 
+func TestSharedClient_PassesCLIArgs(t *testing.T) {
+	resetSharedClientForTest()
+	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
+
+	embeddedCLIPath = func() (string, error) { return "/cache/copilot-sdk/copilot_1.0.49", nil }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
+
+	stub := &stubClient{}
+	var gotOptions *copilot.ClientOptions
+	sharedConstruct = func(opts *copilot.ClientOptions) CopilotClient {
+		gotOptions = opts
+		return stub
+	}
+	t.Cleanup(func() { sharedConstruct = newCopilotClient })
+
+	cliArgs := []string{"--model", "claude-sonnet-4.5"}
+	_ = SharedClient(SharedClientOptions{CLIArgs: cliArgs})
+	if gotOptions == nil {
+		t.Fatalf("expected shared client to be constructed")
+	}
+	if strings.Join(gotOptions.CLIArgs, " ") != strings.Join(cliArgs, " ") {
+		t.Fatalf("expected CLIArgs %v, got %v", cliArgs, gotOptions.CLIArgs)
+	}
+}
+
 func TestSharedClient_UsesCOPILOTCLIPathOverride(t *testing.T) {
 	resetSharedClientForTest()
 	t.Cleanup(resetSharedClientForTest)

--- a/internal/execution/sdkclient_test.go
+++ b/internal/execution/sdkclient_test.go
@@ -76,6 +76,38 @@ func TestShutdownSharedClient_Idempotent(t *testing.T) {
 	}
 }
 
+func TestShutdownSharedClient_StopsAllCLIArgClients(t *testing.T) {
+	resetSharedClientForTest()
+	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
+
+	embeddedCLIPath = func() (string, error) { return "/tmp/embedded-copilot", nil }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
+
+	var clients []*stubClient
+	sharedConstruct = func(*copilot.ClientOptions) CopilotClient {
+		stub := &stubClient{}
+		clients = append(clients, stub)
+		return stub
+	}
+	t.Cleanup(func() { sharedConstruct = newCopilotClient })
+
+	_ = SharedClient(SharedClientOptions{CLIArgs: []string{"--model", "claude-sonnet-4.5"}})
+	_ = SharedClient(SharedClientOptions{CLIArgs: []string{"--model", "gpt-5.4"}})
+
+	if err := ShutdownSharedClient(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	if len(clients) != 2 {
+		t.Fatalf("expected two shared clients, got %d", len(clients))
+	}
+	for i, client := range clients {
+		if client.stops != 1 {
+			t.Fatalf("expected client %d Stop to be called once, got %d", i, client.stops)
+		}
+	}
+}
+
 func TestShutdownSharedClient_NoClientNeverConstructed(t *testing.T) {
 	resetSharedClientForTest()
 	t.Cleanup(resetSharedClientForTest)
@@ -156,6 +188,44 @@ func TestSharedClient_PassesCLIArgs(t *testing.T) {
 	}
 	if strings.Join(gotOptions.CLIArgs, " ") != strings.Join(cliArgs, " ") {
 		t.Fatalf("expected CLIArgs %v, got %v", cliArgs, gotOptions.CLIArgs)
+	}
+}
+
+func TestSharedClient_SeparatesDifferentCLIArgs(t *testing.T) {
+	resetSharedClientForTest()
+	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
+
+	embeddedCLIPath = func() (string, error) { return "/cache/copilot-sdk/copilot_1.0.49", nil }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
+
+	var gotArgs [][]string
+	sharedConstruct = func(opts *copilot.ClientOptions) CopilotClient {
+		gotArgs = append(gotArgs, append([]string{}, opts.CLIArgs...))
+		return &stubClient{}
+	}
+	t.Cleanup(func() { sharedConstruct = newCopilotClient })
+
+	sonnetArgs := []string{"--model", "claude-sonnet-4.5"}
+	gptArgs := []string{"--model", "gpt-5.4"}
+	sonnetA := SharedClient(SharedClientOptions{CLIArgs: sonnetArgs})
+	gpt := SharedClient(SharedClientOptions{CLIArgs: gptArgs})
+	sonnetB := SharedClient(SharedClientOptions{CLIArgs: sonnetArgs, LogLevel: "debug"})
+
+	if sonnetA == gpt {
+		t.Fatalf("different CLIArgs must get distinct shared clients")
+	}
+	if sonnetA != sonnetB {
+		t.Fatalf("same CLIArgs must reuse the shared client")
+	}
+	if len(gotArgs) != 2 {
+		t.Fatalf("expected two client constructions, got %d", len(gotArgs))
+	}
+	if strings.Join(gotArgs[0], " ") != strings.Join(sonnetArgs, " ") {
+		t.Fatalf("expected first CLIArgs %v, got %v", sonnetArgs, gotArgs[0])
+	}
+	if strings.Join(gotArgs[1], " ") != strings.Join(gptArgs, " ") {
+		t.Fatalf("expected second CLIArgs %v, got %v", gptArgs, gotArgs[1])
 	}
 }
 

--- a/internal/execution/sdkclient_test.go
+++ b/internal/execution/sdkclient_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -216,7 +217,7 @@ func TestSharedClient_PassesCLIArgs(t *testing.T) {
 	if gotOptions == nil {
 		t.Fatalf("expected shared client to be constructed")
 	}
-	if strings.Join(gotOptions.CLIArgs, " ") != strings.Join(cliArgs, " ") {
+	if !reflect.DeepEqual(gotOptions.CLIArgs, cliArgs) {
 		t.Fatalf("expected CLIArgs %v, got %v", cliArgs, gotOptions.CLIArgs)
 	}
 }
@@ -251,10 +252,10 @@ func TestSharedClient_SeparatesDifferentCLIArgs(t *testing.T) {
 	if len(gotArgs) != 2 {
 		t.Fatalf("expected two client constructions, got %d", len(gotArgs))
 	}
-	if strings.Join(gotArgs[0], " ") != strings.Join(sonnetArgs, " ") {
+	if !reflect.DeepEqual(gotArgs[0], sonnetArgs) {
 		t.Fatalf("expected first CLIArgs %v, got %v", sonnetArgs, gotArgs[0])
 	}
-	if strings.Join(gotArgs[1], " ") != strings.Join(gptArgs, " ") {
+	if !reflect.DeepEqual(gotArgs[1], gptArgs) {
 		t.Fatalf("expected second CLIArgs %v, got %v", gptArgs, gotArgs[1])
 	}
 }

--- a/internal/execution/sdkclient_test.go
+++ b/internal/execution/sdkclient_test.go
@@ -108,6 +108,36 @@ func TestShutdownSharedClient_StopsAllCLIArgClients(t *testing.T) {
 	}
 }
 
+func TestShutdownSharedClient_PreventsNewClientsAfterShutdown(t *testing.T) {
+	resetSharedClientForTest()
+	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
+
+	embeddedCLIPath = func() (string, error) { return "/tmp/embedded-copilot", nil }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
+
+	stub := &stubClient{}
+	constructs := 0
+	sharedConstruct = func(*copilot.ClientOptions) CopilotClient {
+		constructs++
+		return stub
+	}
+	t.Cleanup(func() { sharedConstruct = newCopilotClient })
+
+	_ = SharedClient(SharedClientOptions{CLIArgs: []string{"--model", "claude-sonnet-4.5"}})
+	if err := ShutdownSharedClient(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	client := SharedClient(SharedClientOptions{CLIArgs: []string{"--model", "gpt-5.4"}})
+	if err := client.Start(context.Background()); !errors.Is(err, errSharedClientClosed) {
+		t.Fatalf("expected shared client closed error, got %v", err)
+	}
+	if constructs != 1 {
+		t.Fatalf("expected no new client construction after shutdown, got %d", constructs)
+	}
+}
+
 func TestShutdownSharedClient_NoClientNeverConstructed(t *testing.T) {
 	resetSharedClientForTest()
 	t.Cleanup(resetSharedClientForTest)


### PR DESCRIPTION
## Summary

Pass `--model <defaultModelID>` via `ClientOptions.CLIArgs` so the embedded CLI uses the eval's configured model instead of the user's personal preferences.

Fixes #262

## Problem

The embedded CLI (v1.0.46) reads `~/.copilot/settings.json` at startup and the Copilot experiment flight system can assign a default model per-account (e.g. `copilot_cli_opus_1m_default_model`). Both override `SessionConfig.Model`, causing evals to run on unintended models.

**Impact:** A task configured for `claude-sonnet-4.5` (30s) silently runs on `claude-opus-4.6-1m` with high reasoning (15+ min) with no indication to the user.

## Fix

Pass `--model` as a CLI startup arg in `ClientOptions.CLIArgs`, which takes precedence over settings.json and experiment flights:

```go
cliArgs := []string{}
if defaultModelID != "" {
    cliArgs = append(cliArgs, "--model", defaultModelID)
}
copilotOptions := &copilot.ClientOptions{
    CLIArgs: cliArgs,
    // ...
}
```

## Testing

Verified on Windows 11:
- Without fix: tasks take 15+ min (CLI uses Opus from settings.json)
- With fix: tasks complete in ~30s (CLI uses configured Sonnet)
- `go build ./cmd/waza` passes