### PR TITLE
ci: Deploy Pages after release workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'site/**'
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -18,6 +21,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     name: Build
     steps:
@@ -27,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: site/package-lock.json
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: '22.12.0'
           cache: npm
           cache-dependency-path: site/package-lock.json
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,7 +11,7 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-This triggers the full pipeline: CLI build → extension build → GitHub Release → extension publish → version sync.
+This triggers the full pipeline: CLI build → extension build → GitHub Release → extension publish → version sync → GitHub Pages deploy.
 
 ## What the Workflow Does
 
@@ -19,6 +19,7 @@ This triggers the full pipeline: CLI build → extension build → GitHub Releas
 2. **build-cli** — Matrix build for 6 platforms (linux, darwin, windows × amd64, arm64). Builds the web UI then produces `waza-{os}-{arch}` binaries.
 3. **release-cli** — Downloads CLI artifacts, generates SHA256 checksums, and creates the **CLI GitHub Release** (`Waza vX.Y.Z`) with standalone binaries attached.
 4. **release-extension** — Syncs `version.txt` and `extension.yaml`, builds the web UI, builds and packs the azd extension, creates the **Extension GitHub Release** (`Waza azd Extension vX.Y.Z`), publishes to the azd registry, then opens a PR with updated `registry.json` and synced version files.
+5. **pages.yml** — Deploys the documentation site after the `Release` workflow completes successfully, ensuring release notes and download links published to `site/` are pushed to GitHub Pages.
 
 ## Version File Locations
 


### PR DESCRIPTION
## Summary
- Deploy GitHub Pages after the `Release` workflow completes successfully, so release-site updates are published even when the main push path filter does not trigger.
- Update the Pages workflow to Node 22 to satisfy the current Astro requirement (`>=22.12.0`).
- Document the Pages deploy as part of the release pipeline.

## Validation
- Parsed `.github/workflows/pages.yml` with Ruby YAML parser.
- Confirmed the current manual Pages run fails on Node 20 with Astro requiring Node >=22.12.0.