### PR TITLE
fix: use SDK approval kind for tool permissions

### DIFF
--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -520,7 +520,9 @@ func joinStrings(parts []string) string {
 	return builder.String()
 }
 
-var allowAllTools = copilot.PermissionHandler.ApproveAll
+func allowAllTools(request copilot.PermissionRequest, invocation copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+	return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+}
 
 // skillDefinition holds the content extracted from a SKILL.md file.
 type skillDefinition struct {

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -520,10 +520,7 @@ func joinStrings(parts []string) string {
 	return builder.String()
 }
 
-func allowAllTools(request copilot.PermissionRequest, invocation copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
-	// value for 'Kind' came from the permissions_test.go in the Copilot SDK.
-	return copilot.PermissionRequestResult{Kind: "approved"}, nil
-}
+var allowAllTools = copilot.PermissionHandler.ApproveAll
 
 // skillDefinition holds the content extracted from a SKILL.md file.
 type skillDefinition struct {

--- a/internal/execution/copilot_test.go
+++ b/internal/execution/copilot_test.go
@@ -20,6 +20,12 @@ import (
 
 var enableLiveCopilotTests = os.Getenv("ENABLE_COPILOT_TESTS") == "true"
 
+func TestAllowAllTools_UsesSDKApprovedKind(t *testing.T) {
+	result, err := allowAllTools(copilot.PermissionRequest{}, copilot.PermissionInvocation{})
+	require.NoError(t, err)
+	require.Equal(t, copilot.PermissionRequestResultKindApproved, result.Kind)
+}
+
 func TestCopilotNoSessionID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	clientMock := newClientMock(ctrl)


### PR DESCRIPTION
Closes #266

## Summary
- switch the default permission callback to the SDK's built-in ApproveAll handler
- add a regression test that verifies the approval kind matches the SDK constant

## What Changed
- replaced the legacy literal "approved" response in internal/execution/copilot.go
- added a focused regression test in internal/execution/copilot_test.go

## Testing
- Unable to run go test ./... in this environment because go is not available on PATH.
