### PR TITLE
feat: add per-trial usage to results JSON

### DIFF
--- a/internal/execution/usage.go
+++ b/internal/execution/usage.go
@@ -13,12 +13,17 @@ func UpdateOutcomeUsage(outcome *models.EvaluationOutcome, engine AgentEngine) {
 	for i := range outcome.TestOutcomes {
 		for j := range outcome.TestOutcomes[i].Runs {
 			run := &outcome.TestOutcomes[i].Runs[j]
+			usage := run.SessionDigest.Usage
 			if run.SessionDigest.SessionID == "" {
+				run.Usage = usage
 				continue
 			}
 			if usage := engine.SessionUsage(run.SessionDigest.SessionID); usage != nil {
 				run.SessionDigest.Usage = usage
+				run.Usage = usage
+				continue
 			}
+			run.Usage = usage
 		}
 	}
 
@@ -26,8 +31,8 @@ func UpdateOutcomeUsage(outcome *models.EvaluationOutcome, engine AgentEngine) {
 	var allUsage []*models.UsageStats
 	for _, to := range outcome.TestOutcomes {
 		for _, run := range to.Runs {
-			if run.SessionDigest.Usage != nil {
-				allUsage = append(allUsage, run.SessionDigest.Usage)
+			if run.Usage != nil {
+				allUsage = append(allUsage, run.Usage)
 			}
 		}
 	}

--- a/internal/execution/usage.go
+++ b/internal/execution/usage.go
@@ -27,6 +27,10 @@ func UpdateOutcomeUsage(outcome *models.EvaluationOutcome, engine AgentEngine) {
 		}
 	}
 
+	if outcome.BaselineOutcome != nil && outcome.BaselineOutcome != outcome {
+		UpdateOutcomeUsage(outcome.BaselineOutcome, engine)
+	}
+
 	// Re-aggregate usage across all runs
 	var allUsage []*models.UsageStats
 	for _, to := range outcome.TestOutcomes {

--- a/internal/execution/usage_test.go
+++ b/internal/execution/usage_test.go
@@ -1,49 +1,86 @@
 package execution
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/require"
 )
 
+type stubUsageEngine struct {
+	usage map[string]*models.UsageStats
+}
+
+func (e *stubUsageEngine) Initialize(context.Context) error { return nil }
+
+func (e *stubUsageEngine) Execute(context.Context, *ExecutionRequest) (*ExecutionResponse, error) {
+	return nil, nil
+}
+
+func (e *stubUsageEngine) Shutdown(context.Context) error { return nil }
+
+func (e *stubUsageEngine) SessionUsage(sessionID string) *models.UsageStats {
+	return e.usage[sessionID]
+}
+
 func TestUpdateOutcomeUsage_NilOutcome(t *testing.T) {
-	// Should not panic
 	UpdateOutcomeUsage(nil, NewMockEngine("test"))
 }
 
 func TestUpdateOutcomeUsage_ReplacesAndReaggregates(t *testing.T) {
-	// Create an outcome with fallback usage
 	outcome := &models.EvaluationOutcome{
 		TestOutcomes: []models.TestOutcome{
 			{
 				Runs: []models.RunResult{
 					{
-						SessionDigest: models.SessionDigest{
-							SessionID: "session-1",
-							Usage: &models.UsageStats{
-								InputTokens:  100,
-								OutputTokens: 50,
-							},
-						},
+						SessionDigest: models.SessionDigest{SessionID: "session-1"},
+					},
+					{
+						SessionDigest: models.SessionDigest{SessionID: "session-2"},
 					},
 				},
 			},
 		},
-		Digest: models.OutcomeDigest{
-			Usage: &models.UsageStats{
-				InputTokens:  100,
-				OutputTokens: 50,
+	}
+
+	engine := &stubUsageEngine{
+		usage: map[string]*models.UsageStats{
+			"session-1": {
+				InputTokens:     100,
+				OutputTokens:    25,
+				CacheReadTokens: 4,
+				PremiumRequests: 1,
+			},
+			"session-2": {
+				InputTokens:      50,
+				OutputTokens:     75,
+				CacheWriteTokens: 3,
+				Turns:            2,
 			},
 		},
 	}
 
-	// Mock engine returns nil for SessionUsage (no post-shutdown data)
-	engine := NewMockEngine("test")
 	UpdateOutcomeUsage(outcome, engine)
 
-	// Usage should be unchanged (mock returns nil)
-	require.Equal(t, 100, outcome.TestOutcomes[0].Runs[0].SessionDigest.Usage.InputTokens)
+	run1 := outcome.TestOutcomes[0].Runs[0]
+	run2 := outcome.TestOutcomes[0].Runs[1]
+
+	require.NotNil(t, run1.Usage)
+	require.NotNil(t, run2.Usage)
+	require.Same(t, run1.SessionDigest.Usage, run1.Usage)
+	require.Same(t, run2.SessionDigest.Usage, run2.Usage)
+	require.Equal(t, 100, run1.Usage.InputTokens)
+	require.Equal(t, 50, run2.Usage.InputTokens)
+
+	require.NotNil(t, outcome.Digest.Usage)
+	require.Equal(t, 150, outcome.Digest.Usage.InputTokens)
+	require.Equal(t, 100, outcome.Digest.Usage.OutputTokens)
+	require.Equal(t, 4, outcome.Digest.Usage.CacheReadTokens)
+	require.Equal(t, 3, outcome.Digest.Usage.CacheWriteTokens)
+	require.Equal(t, 1.0, outcome.Digest.Usage.PremiumRequests)
+	require.Equal(t, 2, outcome.Digest.Usage.Turns)
 }
 
 func TestUpdateOutcomeUsage_SkipsEmptySessionID(t *testing.T) {
@@ -54,19 +91,57 @@ func TestUpdateOutcomeUsage_SkipsEmptySessionID(t *testing.T) {
 				Runs: []models.RunResult{
 					{
 						SessionDigest: models.SessionDigest{
-							SessionID: "", // empty — should be skipped
+							SessionID: "",
 							Usage:     originalUsage,
 						},
 					},
 				},
 			},
 		},
-		Digest: models.OutcomeDigest{},
 	}
 
-	engine := NewMockEngine("test")
-	UpdateOutcomeUsage(outcome, engine)
+	UpdateOutcomeUsage(outcome, NewMockEngine("test"))
 
-	// Usage unchanged
 	require.Equal(t, originalUsage, outcome.TestOutcomes[0].Runs[0].SessionDigest.Usage)
+	require.Equal(t, originalUsage, outcome.TestOutcomes[0].Runs[0].Usage)
+}
+
+func TestUpdateOutcomeUsage_JSONIncludesPerRunAndSummaryUsage(t *testing.T) {
+	outcome := &models.EvaluationOutcome{
+		TestOutcomes: []models.TestOutcome{
+			{
+				TestID: "task-1",
+				Runs: []models.RunResult{
+					{RunNumber: 1, SessionDigest: models.SessionDigest{SessionID: "session-1"}},
+					{RunNumber: 2, SessionDigest: models.SessionDigest{SessionID: "session-2"}},
+				},
+			},
+		},
+	}
+
+	UpdateOutcomeUsage(outcome, &stubUsageEngine{
+		usage: map[string]*models.UsageStats{
+			"session-1": {InputTokens: 12, OutputTokens: 34},
+			"session-2": {InputTokens: 8, OutputTokens: 9},
+		},
+	})
+
+	data, err := json.Marshal(outcome)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+
+	tasks := payload["tasks"].([]any)
+	runs := tasks[0].(map[string]any)["runs"].([]any)
+	run1Usage := runs[0].(map[string]any)["usage"].(map[string]any)
+	run2Usage := runs[1].(map[string]any)["usage"].(map[string]any)
+	summaryUsage := payload["summary"].(map[string]any)["usage"].(map[string]any)
+
+	require.Equal(t, float64(12), run1Usage["input_tokens"])
+	require.Equal(t, float64(34), run1Usage["output_tokens"])
+	require.Equal(t, float64(8), run2Usage["input_tokens"])
+	require.Equal(t, float64(9), run2Usage["output_tokens"])
+	require.Equal(t, float64(20), summaryUsage["input_tokens"])
+	require.Equal(t, float64(43), summaryUsage["output_tokens"])
 }

--- a/internal/execution/usage_test.go
+++ b/internal/execution/usage_test.go
@@ -129,21 +129,29 @@ func TestUpdateOutcomeUsage_JSONIncludesPerRunAndSummaryUsage(t *testing.T) {
 	data, err := json.Marshal(outcome)
 	require.NoError(t, err)
 
-	var payload map[string]any
+	var payload struct {
+		Tasks []struct {
+			Runs []struct {
+				Usage *models.UsageStats `json:"usage"`
+			} `json:"runs"`
+		} `json:"tasks"`
+		Summary struct {
+			Usage *models.UsageStats `json:"usage"`
+		} `json:"summary"`
+	}
 	require.NoError(t, json.Unmarshal(data, &payload))
 
-	tasks := payload["tasks"].([]any)
-	runs := tasks[0].(map[string]any)["runs"].([]any)
-	run1Usage := runs[0].(map[string]any)["usage"].(map[string]any)
-	run2Usage := runs[1].(map[string]any)["usage"].(map[string]any)
-	summaryUsage := payload["summary"].(map[string]any)["usage"].(map[string]any)
-
-	require.Equal(t, float64(12), run1Usage["input_tokens"])
-	require.Equal(t, float64(34), run1Usage["output_tokens"])
-	require.Equal(t, float64(8), run2Usage["input_tokens"])
-	require.Equal(t, float64(9), run2Usage["output_tokens"])
-	require.Equal(t, float64(20), summaryUsage["input_tokens"])
-	require.Equal(t, float64(43), summaryUsage["output_tokens"])
+	require.Len(t, payload.Tasks, 1)
+	require.Len(t, payload.Tasks[0].Runs, 2)
+	require.NotNil(t, payload.Tasks[0].Runs[0].Usage)
+	require.NotNil(t, payload.Tasks[0].Runs[1].Usage)
+	require.Equal(t, 12, payload.Tasks[0].Runs[0].Usage.InputTokens)
+	require.Equal(t, 34, payload.Tasks[0].Runs[0].Usage.OutputTokens)
+	require.Equal(t, 8, payload.Tasks[0].Runs[1].Usage.InputTokens)
+	require.Equal(t, 9, payload.Tasks[0].Runs[1].Usage.OutputTokens)
+	require.NotNil(t, payload.Summary.Usage)
+	require.Equal(t, 20, payload.Summary.Usage.InputTokens)
+	require.Equal(t, 43, payload.Summary.Usage.OutputTokens)
 }
 
 func TestUpdateOutcomeUsage_UpdatesBaselineOutcome(t *testing.T) {

--- a/internal/execution/usage_test.go
+++ b/internal/execution/usage_test.go
@@ -145,3 +145,36 @@ func TestUpdateOutcomeUsage_JSONIncludesPerRunAndSummaryUsage(t *testing.T) {
 	require.Equal(t, float64(20), summaryUsage["input_tokens"])
 	require.Equal(t, float64(43), summaryUsage["output_tokens"])
 }
+
+func TestUpdateOutcomeUsage_UpdatesBaselineOutcome(t *testing.T) {
+	outcome := &models.EvaluationOutcome{
+		TestOutcomes: []models.TestOutcome{
+			{
+				Runs: []models.RunResult{
+					{SessionDigest: models.SessionDigest{SessionID: "primary"}},
+				},
+			},
+		},
+		BaselineOutcome: &models.EvaluationOutcome{
+			TestOutcomes: []models.TestOutcome{
+				{
+					Runs: []models.RunResult{
+						{SessionDigest: models.SessionDigest{SessionID: "baseline"}},
+					},
+				},
+			},
+		},
+	}
+
+	UpdateOutcomeUsage(outcome, &stubUsageEngine{
+		usage: map[string]*models.UsageStats{
+			"primary":  {InputTokens: 7},
+			"baseline": {InputTokens: 11},
+		},
+	})
+
+	require.Equal(t, 7, outcome.TestOutcomes[0].Runs[0].Usage.InputTokens)
+	require.Equal(t, 11, outcome.BaselineOutcome.TestOutcomes[0].Runs[0].Usage.InputTokens)
+	require.Equal(t, 7, outcome.Digest.Usage.InputTokens)
+	require.Equal(t, 11, outcome.BaselineOutcome.Digest.Usage.InputTokens)
+}

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -156,6 +156,7 @@ type RunResult struct {
 	FinalOutput      string                   `json:"final_output"`
 	ErrorMsg         string                   `json:"error_msg,omitempty"`
 	SkillInvocations []SkillInvocation        `json:"skill_invocations,omitempty"`
+	Usage            *UsageStats              `json:"usage,omitempty"`
 	WorkspaceDir     string                   `json:"workspace_dir,omitempty"`
 }
 

--- a/site/src/content/docs/reference/statistical-fields.mdx
+++ b/site/src/content/docs/reference/statistical-fields.mdx
@@ -298,7 +298,7 @@ Confidence intervals and significance testing enable data-driven quality gates i
 }
 ```
 
-Each `tasks[].runs[]` entry now includes a flat `usage` block, and `summary.usage` still aggregates all run usage across the benchmark.
+Each `tasks[].runs[]` entry now includes a flat `usage` block, and the aggregate usage summary still reflects all run usage across the benchmark.
 
 ### Multi-task comparison
 

--- a/site/src/content/docs/reference/statistical-fields.mdx
+++ b/site/src/content/docs/reference/statistical-fields.mdx
@@ -298,7 +298,7 @@ Confidence intervals and significance testing enable data-driven quality gates i
 }
 ```
 
-Each `tasks[].runs[]` entry now includes a flat `usage` block, and the aggregate usage summary still reflects all run usage across the benchmark.
+In the full results JSON, each `tasks[].runs[]` entry includes a flat `usage` block, and the aggregate usage summary still reflects all run usage across the benchmark.
 
 ### Multi-task comparison
 

--- a/site/src/content/docs/reference/statistical-fields.mdx
+++ b/site/src/content/docs/reference/statistical-fields.mdx
@@ -298,6 +298,8 @@ Confidence intervals and significance testing enable data-driven quality gates i
 }
 ```
 
+Each `tasks[].runs[]` entry now includes a flat `usage` block, and `summary.usage` still aggregates all run usage across the benchmark.
+
 ### Multi-task comparison
 
 ```json


### PR DESCRIPTION
Closes #272

## Summary
- Add a flat `usage` field to each `tasks[].runs[]` entry in results JSON.
- Preserve the existing aggregated `summary.usage` block.
- Reuse the existing post-shutdown session usage data already collected by the engine.

## Validation
- `go test ./internal/execution ./internal/orchestration ./cmd/waza`
- `go test ./...`
- `cd site && npm ci && npm run build`

## Documentation impact
- Updated `site/src/content/docs/reference/statistical-fields.mdx` to document the new run-level usage block.