### PR TITLE
fix: guard empty sandbox prompts

### DIFF
--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1156,6 +1156,9 @@ func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) (*execution.Exec
 		return nil, err
 	}
 	resources = append(resources, instructionResources...)
+	if err := rejectRelativePathPromptWithEmptySandbox(tc, resources); err != nil {
+		return nil, err
+	}
 
 	spec := r.cfg.Spec()
 	timeout := spec.Config.TimeoutSec
@@ -1184,6 +1187,19 @@ func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) (*execution.Exec
 		Timeout:         time.Duration(timeout) * time.Second,
 		MCPServers:      convertMCPServers(spec.Config.ServerConfigs),
 	}, nil
+}
+
+func rejectRelativePathPromptWithEmptySandbox(tc *models.TestCase, resources []execution.ResourceFile) error {
+	if len(resources) > 0 {
+		return nil
+	}
+
+	message := tc.Stimulus.Message
+	if strings.Contains(message, "./") || strings.Contains(message, "../") {
+		return fmt.Errorf("prompt references relative paths but no workspace files were loaded; use inputs.files to copy fixtures into the sandbox")
+	}
+
+	return nil
 }
 
 // executeFollowUps sends follow-up prompts using the same workspace and session,

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -148,6 +148,34 @@ func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 	assert.Equal(t, "value", req.Context["key"])
 }
 
+func TestBuildExecutionRequest_RejectsRelativePathPromptWithEmptySandbox(t *testing.T) {
+	spec := &models.EvalSpec{
+		SpecIdentity: models.SpecIdentity{Name: "test-benchmark"},
+		SkillName:    "my-skill",
+		Config: models.Config{
+			EngineType: "mock",
+			ModelID:    "gpt-4",
+			TimeoutSec: 60,
+		},
+	}
+
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, nil)
+
+	tc := &models.TestCase{
+		TestID:      "test-001",
+		DisplayName: "Test Case",
+		Stimulus: models.TaskStimulus{
+			Message: "Explore the repository at ./my-repo and describe its architecture.",
+		},
+	}
+
+	req, err := runner.buildExecutionRequest(tc)
+	require.Error(t, err)
+	assert.Nil(t, req)
+	assert.Contains(t, err.Error(), "no workspace files were loaded")
+}
+
 func TestBuildExecutionRequest_TimeoutOverride(t *testing.T) {
 	// Create a spec with default timeout
 	spec := &models.EvalSpec{

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -95,6 +95,8 @@ You'll see:
 
 Open `skills/my-skill/evals/eval.yaml` and modify it to this minimal spec:
 
+If your task needs files in the sandbox, list them under `inputs.files`; `--context-dir` is only the lookup base for those paths.
+
 ```yaml
 name: my-skill-eval
 description: Test my skill
@@ -106,7 +108,8 @@ graders:
   - type: text
     name: has_response
     config:
-      pattern: "\\w+"
+      contains:
+        - "How can I help"
 
 tasks:
   - name: test-task-1


### PR DESCRIPTION
Closes #273

## Summary
- Fail fast when prompts mention relative paths but no workspace files were loaded.
- Update the quick-start example to use a valid, more specific `contains` check and clarify that `--context-dir` only resolves `inputs.files`.
- Add regression coverage for the empty-sandbox path.

## Validation
- `go test ./...`
- `cd site && npm run build`

## Docs impact
- Updated `site/src/content/docs/quick-start.mdx` to correct the grader example and document sandbox/file-loading behavior.