### PR TITLE
fix: respect signal cancellation in waza run

### DIFF
--- a/cmd/waza/cmd_run.go
+++ b/cmd/waza/cmd_run.go
@@ -741,7 +741,13 @@ func runSingleModel(cmd *cobra.Command, spec *models.EvalSpec, specPath string, 
 	}
 
 	// Run benchmark with signal cancellation so Ctrl+C stops the long-running work.
-	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	var ctx context.Context
+	var stop context.CancelFunc
+	if cmd != nil {
+		ctx, stop = signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	} else {
+		ctx, stop = signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	}
 	defer stop()
 
 	fmt.Printf("Running benchmark: %s\n", spec.Name)

--- a/cmd/waza/cmd_run.go
+++ b/cmd/waza/cmd_run.go
@@ -9,9 +9,11 @@ import (
 	"log/slog"
 	"maps"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
 
 	"golang.org/x/text/language"
@@ -70,7 +72,16 @@ var (
 
 	// newCopilotClientFn allows you to override the client used by the copilot engine, for this command.
 	newCopilotClientFn func(clientOptions *copilot.ClientOptions) execution.CopilotClient
+
+	newBenchmarkRunner = func(cfg *config.EvalConfig, engine execution.AgentEngine, opts ...orchestration.RunnerOption) benchmarkRunner {
+		return orchestration.NewEvalRunner(cfg, engine, opts...)
+	}
 )
+
+type benchmarkRunner interface {
+	OnProgress(orchestration.ProgressListener)
+	RunBenchmark(context.Context) (*models.EvaluationOutcome, error)
+}
 
 // modelResult pairs a model identifier with its evaluation outcome.
 type modelResult struct {
@@ -672,7 +683,7 @@ func runSingleModel(cmd *cobra.Command, spec *models.EvalSpec, specPath string, 
 	if skipGradersFlag {
 		runnerOpts = append(runnerOpts, orchestration.WithSkipGraders())
 	}
-	runner := orchestration.NewEvalRunner(cfg, engine, runnerOpts...)
+	runner := newBenchmarkRunner(cfg, engine, runnerOpts...)
 
 	// Setup session logger if enabled
 	var sessLogger session.Logger = session.NopLogger{}
@@ -729,8 +740,9 @@ func runSingleModel(cmd *cobra.Command, spec *models.EvalSpec, specPath string, 
 		runner.OnProgress(simpleProgressListener)
 	}
 
-	// Run benchmark
-	ctx := context.Background()
+	// Run benchmark with signal cancellation so Ctrl+C stops the long-running work.
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	fmt.Printf("Running benchmark: %s\n", spec.Name)
 	fmt.Printf("Skill: %s\n", spec.SkillName)

--- a/cmd/waza/cmd_run_signal_test.go
+++ b/cmd/waza/cmd_run_signal_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/microsoft/waza/internal/config"
+	"github.com/microsoft/waza/internal/execution"
+	"github.com/microsoft/waza/internal/models"
+	"github.com/microsoft/waza/internal/orchestration"
+	"github.com/stretchr/testify/require"
+)
+
+const runSignalHelperEnv = "WAZA_RUN_SIGNAL_HELPER"
+const runSignalSpecEnv = "WAZA_RUN_SIGNAL_SPEC"
+
+type blockingBenchmarkRunner struct{}
+
+func (r *blockingBenchmarkRunner) OnProgress(orchestration.ProgressListener) {}
+
+func (r *blockingBenchmarkRunner) RunBenchmark(ctx context.Context) (*models.EvaluationOutcome, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestRunCommand_CancelsOnInterrupt(t *testing.T) {
+	resetRunGlobals()
+
+	dir := t.TempDir()
+	taskDir := filepath.Join(dir, "tasks")
+	require.NoError(t, os.MkdirAll(taskDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(taskDir, "task.yaml"), []byte(`
+id: signal-task
+name: Signal Task
+inputs:
+  prompt: "test"
+`), 0o644))
+
+	specPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(`
+name: signal-cancel-test
+skill: test-skill
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 30
+  executor: mock
+  model: test-model
+tasks:
+  - "tasks/*.yaml"
+`), 0o644))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestRunCommand_SignalCancelsBenchmarkHelperProcess")
+	cmd.Env = append(os.Environ(),
+		runSignalHelperEnv+"=1",
+		runSignalSpecEnv+"="+specPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Start())
+	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, cmd.Process.Signal(syscall.SIGTERM))
+	require.NoError(t, cmd.Wait(), "run should exit cleanly after SIGTERM; stdout=%s stderr=%s", stdout.String(), stderr.String())
+}
+
+func TestRunCommand_SignalCancelsBenchmarkHelperProcess(t *testing.T) {
+	if os.Getenv(runSignalHelperEnv) != "1" {
+		return
+	}
+
+	resetRunGlobals()
+	newBenchmarkRunner = func(cfg *config.EvalConfig, engine execution.AgentEngine, opts ...orchestration.RunnerOption) benchmarkRunner {
+		return &blockingBenchmarkRunner{}
+	}
+
+	specPath := os.Getenv(runSignalSpecEnv)
+	if specPath == "" {
+		fmt.Fprintln(os.Stderr, "missing signal test spec path")
+		os.Exit(2)
+	}
+
+	cmd := newRunCommand()
+	cmd.SetArgs([]string{specPath})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		fmt.Fprintln(os.Stderr, "expected interrupt to cancel the run")
+		os.Exit(3)
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(4)
+	}
+	os.Exit(0)
+}

--- a/cmd/waza/cmd_run_signal_test.go
+++ b/cmd/waza/cmd_run_signal_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -33,6 +34,9 @@ func (r *blockingBenchmarkRunner) RunBenchmark(ctx context.Context) (*models.Eva
 }
 
 func TestRunCommand_CancelsOnInterrupt(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows: Process.Signal(SIGTERM) is not supported")
+	}
 	resetRunGlobals()
 
 	dir := t.TempDir()

--- a/cmd/waza/cmd_run_signal_test.go
+++ b/cmd/waza/cmd_run_signal_test.go
@@ -33,9 +33,9 @@ func (r *blockingBenchmarkRunner) RunBenchmark(ctx context.Context) (*models.Eva
 	return nil, ctx.Err()
 }
 
-func TestRunCommand_CancelsOnInterrupt(t *testing.T) {
+func TestRunCommand_CancelsOnSIGTERM(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on Windows: Process.Signal(SIGTERM) is not supported")
+		t.Skip("SIGTERM is not supported on Windows")
 	}
 	resetRunGlobals()
 

--- a/cmd/waza/cmd_run_test.go
+++ b/cmd/waza/cmd_run_test.go
@@ -19,9 +19,11 @@ import (
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/config"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/graders"
 	"github.com/microsoft/waza/internal/models"
+	"github.com/microsoft/waza/internal/orchestration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -55,6 +57,9 @@ func resetRunGlobals() {
 	updateSnapshots = false
 	keepWorkspace = false
 	newCopilotClientFn = nil
+	newBenchmarkRunner = func(cfg *config.EvalConfig, engine execution.AgentEngine, opts ...orchestration.RunnerOption) benchmarkRunner {
+		return orchestration.NewEvalRunner(cfg, engine, opts...)
+	}
 }
 
 // helper creates a valid minimal eval spec YAML in a temp dir,


### PR DESCRIPTION
Closes #23

## Summary
- Use a cancellable `signal.NotifyContext` for the long-running benchmark path in `waza run`.
- Add a narrow regression test that proves the run path observes signal cancellation via a fake benchmark runner.

## Validation
- `go test ./cmd/waza -run TestRunCommand_CancelsOnInterrupt -count=1`
- `make build`
- `make test` currently fails in `web/node_modules/flatted/golang/pkg/flatted` after `npm ci` (unrelated repo issue)

## Documentation impact
- No docs update needed; this is an internal cancellation behavior change only.