### PR TITLE
docs: map OpenAI Evals modelgraded YAML to waza graders

### DIFF
--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -165,6 +165,98 @@ All graders return:
 
 See the **[Validators & Graders](../graders/)** guide for all 12 types and examples.
 
+## Mapping OpenAI Evals `modelgraded` YAML
+
+OpenAI Evals `modelgraded` specs usually collapse into Waza's `prompt` grader. The judge prompt carries the label semantics, while Waza handles execution and scoring.
+
+| OpenAI Evals field | Waza equivalent | Notes |
+| ------------------ | --------------- | ----- |
+| `prompt` | `graders[].config.prompt` | Put the judging instructions directly in the prompt |
+| `choice_strings` | prompt text | List the labels in the judge prompt; Waza's prompt grader is binary, so the label choice becomes pass/fail guidance |
+| `choice_scores` | prompt text | Encode the scoring rule in the judge prompt; use `pairwise` mode when the comparison is relative |
+| `input_outputs` | `tasks:` entries | Turn each example into one Waza task with its own `inputs.prompt` and expected checks |
+| `eval_type: cot_classify` | `type: prompt` | Use `mode: independent` for one-shot classification |
+| `battle.yaml` | `type: prompt` + `mode: pairwise` | Closest grader match for head-to-head comparison; `waza compare` is still the better run-level report |
+
+### Translation examples
+
+#### `fact.yaml`
+
+OpenAI's registry uses this pattern for fixed-choice factual classification. In Waza, keep the evaluation as a single prompt grader and turn each input/output row into a task:
+
+```yaml
+graders:
+  - type: prompt
+    name: fact_check
+    config:
+      prompt: |
+        You are checking a multiple-choice answer.
+        Valid choices: A, B, C, D, E.
+        Call set_waza_grade_pass only if the model's answer matches the correct choice.
+        Otherwise call set_waza_grade_fail with a short reason.
+      continue_session: false
+
+tasks:
+  - id: fact-001
+    name: fact-001
+    inputs:
+      prompt: "Which answer is correct for the fact pattern?"
+    expected:
+      output_contains:
+        - "B"
+```
+
+#### `closedqa.yaml`
+
+For closed-book QA, the judge prompt can encode the score mapping directly:
+
+```yaml
+graders:
+  - type: prompt
+    name: closedqa_judge
+    config:
+      prompt: |
+        Judge the answer against the reference.
+        If the answer is fully correct, call set_waza_grade_pass.
+        If it is partially correct or incorrect, call set_waza_grade_fail.
+        Treat "Y" as 1.0 and "N" as 0.0 in your reasoning, but only emit pass/fail.
+      model: claude-sonnet-4.5
+
+tasks:
+  - id: closedqa-001
+    name: closedqa-001
+    inputs:
+      prompt: "Answer the question using the provided context."
+    expected:
+      output_contains:
+        - "Y"
+```
+
+#### `battle.yaml`
+
+Battle-style comparisons are the one place where the mapping is not 1:1. The nearest Waza translation is a pairwise prompt grader, but the run-level comparison report is usually better expressed with `waza compare`:
+
+```yaml
+config:
+  baseline: true
+
+graders:
+  - type: prompt
+    name: battle_judge
+    config:
+      mode: pairwise
+      prompt: |
+        Compare the two answers and decide which one is better.
+        Call set_waza_grade_pass if the skill run wins.
+        Call set_waza_grade_fail if the baseline run wins.
+
+tasks:
+  - id: battle-001
+    name: battle-001
+    inputs:
+      prompt: "Compare these two solutions and pick the better one."
+```
+
 ## Tasks Section
 
 Tasks define individual test cases loaded from YAML files:

--- a/site/src/content/docs/guides/graders.mdx
+++ b/site/src/content/docs/guides/graders.mdx
@@ -306,6 +306,8 @@ One of `schema` or `schema_file` is required.
 
 Uses a second LLM to evaluate the agent's work. The judge LLM calls `set_waza_grade_pass` or `set_waza_grade_fail` tool functions to render its verdict. This is the most flexible grader — it can assess quality, correctness, style, or anything you can describe in natural language.
 
+This is the closest Waza match for OpenAI Evals `modelgraded` specs. See the eval YAML guide for concrete `fact.yaml`, `closedqa.yaml`, and `battle.yaml` translations.
+
 ```yaml
 - type: prompt
   name: quality_check


### PR DESCRIPTION
This clarifies how OpenAI Evals `modelgraded` specs translate into Waza's grader model, so users can migrate existing eval YAML without guessing at the mapping.

## What changed
- Added a field-by-field mapping table for `modelgraded` -> Waza grader equivalents.
- Added concrete translation examples for `fact.yaml`, `closedqa.yaml`, and `battle.yaml`.
- Added a short cross-reference from the prompt-grader guide.

## Validation
- `go test ./...`
- `cd site && npm run build`

## Docs impact
- Updated `site/src/content/docs/guides/eval-yaml.mdx`
- Updated `site/src/content/docs/guides/graders.mdx`

Closes #14