### PR TITLE
Fix custom-agent eval example schema

### DIFF
--- a/examples/custom-agent/eval.yaml
+++ b/examples/custom-agent/eval.yaml
@@ -1,12 +1,19 @@
 name: security-reviewer-eval
 description: Evaluates the security-reviewer custom agent
+skill: security-reviewer
+version: "1.0"
 
 config:
-  executor: copilot
+  executor: mock
   model: claude-sonnet-4
   trials_per_task: 1
   timeout_seconds: 120
   parallel: false
+
+metrics:
+  - name: review_quality
+    weight: 1.0
+    threshold: 0.8
 
 tasks:
   - tasks/*.yaml
@@ -20,8 +27,9 @@ graders:
 
   - type: prompt
     name: review_quality
-    rubric: |
-      Score 1-5 how well the response identified security issues:
-      5 — found all vulnerabilities with accurate severity and clear remediation
-      3 — found most issues but missed some details
-      1 — missed major vulnerabilities or wrong severity
+    config:
+      prompt: |
+        Score 1-5 how well the response identified security issues:
+        5 - found all vulnerabilities with accurate severity and clear remediation
+        3 - found most issues but missed some details
+        1 - missed major vulnerabilities or wrong severity

--- a/examples/custom-agent/eval.yaml
+++ b/examples/custom-agent/eval.yaml
@@ -4,7 +4,7 @@ skill: security-reviewer
 version: "1.0"
 
 config:
-  executor: mock
+  executor: copilot-sdk
   model: claude-sonnet-4
   trials_per_task: 1
   timeout_seconds: 120
@@ -29,7 +29,10 @@ graders:
     name: review_quality
     config:
       prompt: |
-        Score 1-5 how well the response identified security issues:
+        Score the response from 1 to 5 based on how well it identified security issues:
         5 - found all vulnerabilities with accurate severity and clear remediation
         3 - found most issues but missed some details
         1 - missed major vulnerabilities or wrong severity
+
+        If the response scores 4 or 5, call set_waza_grade_pass with a short reason.
+        Otherwise, call set_waza_grade_fail with a short reason.

--- a/examples/custom-agent/tasks/find-sql-injection.yaml
+++ b/examples/custom-agent/tasks/find-sql-injection.yaml
@@ -1,3 +1,9 @@
-name: find-sql-injection-in-vulnerable-py
-prompt: Review the file fixtures/vulnerable.py for security issues
-expected_behavior: Should identify SQL injection on the line where user input is concatenated into a query string
+# Task: Find SQL injection
+id: find-sql-injection-001
+name: Find SQL Injection
+description: Review vulnerable.py for SQL injection.
+
+inputs:
+  prompt: Review the attached file for security issues.
+  files:
+    - path: vulnerable.py

--- a/examples/custom-agent/tasks/find-xss.yaml
+++ b/examples/custom-agent/tasks/find-xss.yaml
@@ -1,3 +1,9 @@
-name: find-xss-in-template
-prompt: Review the file fixtures/xss.html for security issues
-expected_behavior: Should identify cross-site scripting (XSS) vulnerability where user content is rendered without escaping
+# Task: Find XSS
+id: find-xss-001
+name: Find XSS
+description: Review xss.html for cross-site scripting issues.
+
+inputs:
+  prompt: Review the attached file for security issues.
+  files:
+    - path: xss.html

--- a/examples/custom-agent/tasks/review-clean-code.yaml
+++ b/examples/custom-agent/tasks/review-clean-code.yaml
@@ -1,3 +1,9 @@
-name: review-clean-code
-prompt: Review the file fixtures/clean.go for security issues
-expected_behavior: Should report no vulnerabilities — the code uses parameterized queries and proper input handling
+# Task: Review clean code
+id: review-clean-code-001
+name: Review Clean Code
+description: Review clean.go and confirm it does not contain security issues.
+
+inputs:
+  prompt: Review the attached file for security issues.
+  files:
+    - path: clean.go

--- a/internal/validation/schema_test.go
+++ b/internal/validation/schema_test.go
@@ -141,6 +141,15 @@ func TestValidateEvalFile_InvalidEval(t *testing.T) {
 	require.NotEmpty(t, evalErrs, "invalid eval should return errors")
 }
 
+func TestValidateEvalFile_CustomAgentExample(t *testing.T) {
+	evalPath := filepath.Join("..", "..", "examples", "custom-agent", "eval.yaml")
+
+	evalErrs, taskErrs, err := ValidateEvalFile(evalPath)
+	require.NoError(t, err)
+	require.Empty(t, evalErrs, "custom-agent example eval should be valid")
+	require.Empty(t, taskErrs, "custom-agent example tasks should be valid")
+}
+
 func TestValidateEvalFile_InvalidTask(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
This updates the checked-in custom-agent example so it matches the current eval and task schemas and can be copy/paste run with the current CLI.

- Adds the required eval top-level fields and switches the example to a supported executor
- Updates the prompt grader to the current config shape
- Rewrites the example task files to the current task schema and references the fixture files directly
- Adds a regression test to keep the checked-in example schema-valid

Validation: `go test ./...`

Docs impact: none beyond the example and schema regression coverage.

Closes #274