### PR TITLE
docs: align custom agent eval docs with skill field

### DIFF
--- a/site/src/content/docs/guides/custom-agents.mdx
+++ b/site/src/content/docs/guides/custom-agents.mdx
@@ -42,7 +42,7 @@ Create an `eval.yaml`:
 ```yaml
 name: my-agent-eval
 description: Evaluating my custom agent
-agent: my-agent  # Points to my-agent.agent.md in the same directory
+skill: my-agent  # Points to my-agent.agent.md in the same directory
 version: "1.0"
 
 config:
@@ -226,7 +226,7 @@ Target an agent by name or file path:
 ```yaml
 name: security-agent-eval
 description: Evaluate the security-reviewer agent
-agent: security-reviewer  # Resolves to security-reviewer.agent.md
+skill: security-reviewer  # Resolves to security-reviewer.agent.md
 
 version: "1.0"
 
@@ -256,7 +256,7 @@ tasks:
 
 **Key points:**
 
-- Use the `agent:` field instead of `skill:` to target an agent
+- Use the `skill:` field with the agent name to target an agent
 - All other eval.yaml structure is identical
 - Discovery and grading work the same way
 - The agent's `tools:` field auto-injects a constraint (unless you override it)

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -50,7 +50,7 @@ tasks:
 | Field         | Type   | Required | Description                                                                                |
 | ------------- | ------ | -------- | ------------------------------------------------------------------------------------------ |
 | `name`        | string | ✓        | Eval suite name                                                                            |
-| `description` | string | ✓        | What the eval tests                                                                        |
+| `description` | string | ✗        | What the eval tests                                                                        |
 | `skill`       | string | ✓        | Associated skill or custom agent name (`SKILL.md` or `.agent.md`)                       |
 | `version`     | string | ✗        | Version number (e.g., "1.0")                                                               |
 | `inputs`      | object | ✗        | Key-value map of global template variables (see [Template Variables](#template-variables)) |
@@ -58,7 +58,7 @@ tasks:
 | `hooks`       | object | ✗        | Lifecycle hooks that run shell commands at specific points (see [Hooks](#hooks))           |
 | `baseline`    | bool   | ✗        | Mark this spec as a baseline for A/B comparison                                            |
 
-*`skill` is required.
+`skill` is required.
 
 ## Targeting Custom Agents
 

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -51,15 +51,14 @@ tasks:
 | ------------- | ------ | -------- | ------------------------------------------------------------------------------------------ |
 | `name`        | string | ✓        | Eval suite name                                                                            |
 | `description` | string | ✓        | What the eval tests                                                                        |
-| `skill`       | string | ✓*       | Associated skill name (`SKILL.md` file)                                                    |
-| `agent`       | string | ✓*       | Associated custom agent name (`.agent.md` file). Use `agent` instead of `skill` for custom agents. |
+| `skill`       | string | ✓        | Associated skill or custom agent name (`SKILL.md` or `.agent.md`)                       |
 | `version`     | string | ✗        | Version number (e.g., "1.0")                                                               |
 | `inputs`      | object | ✗        | Key-value map of global template variables (see [Template Variables](#template-variables)) |
 | `tasks_from`  | string | ✗        | Path to an external YAML file containing the task list                                     |
 | `hooks`       | object | ✗        | Lifecycle hooks that run shell commands at specific points (see [Hooks](#hooks))           |
 | `baseline`    | bool   | ✗        | Mark this spec as a baseline for A/B comparison                                            |
 
-*Either `skill` or `agent` is required (one, not both).
+*`skill` is required.
 
 ## Targeting Custom Agents
 
@@ -70,7 +69,7 @@ Waza supports evaluating VS Code custom agents (`.agent.md` files) alongside tra
 ```yaml
 name: security-agent-eval
 description: Evaluate the security-reviewer custom agent
-agent: security-reviewer  # Points to security-reviewer.agent.md
+skill: security-reviewer  # Points to security-reviewer.agent.md
 version: "1.0"
 
 config:
@@ -79,7 +78,7 @@ config:
 
 **Key differences:**
 
-- Use `agent: <name>` instead of `skill: <name>`
+- Use `skill: <name>` to target either a skill or a custom agent
 - Waza discovers `.agent.md` files the same way as `SKILL.md` — in the current directory or `agents/` subdirectories
 - If both `SKILL.md` and `.agent.md` exist in the same directory, `SKILL.md` takes priority
 - Custom agents can declare a `tools:` field in frontmatter, which auto-injects a `tool_constraint` grader


### PR DESCRIPTION
Closes #275

## Summary
- Update the custom-agent and eval-yaml guides to use `skill:` for custom agents, matching the existing eval parser and schema.
- Remove the misleading separate `agent:` eval field from the docs.

## Validation
- `go test ./...`
- `cd site && npm ci`
- `cd site && npm run build`

## Documentation impact
- `site/src/content/docs/guides/custom-agents.mdx`
- `site/src/content/docs/guides/eval-yaml.mdx`
