### PR TITLE
docs: fix binary release links for #276

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Download and install the latest pre-built binary with the Bash install script on
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
-The script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable). On Windows, piping this command to `bash` from PowerShell may invoke WSL and install the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` directly from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+The script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable). On Windows, piping this command to `bash` from PowerShell may invoke WSL and install the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` directly from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.33.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
-Or download binaries directly from the [latest release](https://github.com/microsoft/waza/releases/latest).
+Or download the standalone binaries directly from the [waza v0.33.0 release](https://github.com/microsoft/waza/releases/tag/v0.33.0).
 
 ### Install from Source
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Download and install the latest pre-built binary with the Bash install script on
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
-The script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable). On Windows, piping this command to `bash` from PowerShell may invoke WSL and install the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` directly from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.33.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+The script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable). On Windows, piping this command to `bash` from PowerShell may invoke WSL and install the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the standalone waza release assets on GitHub Releases, rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
-Or download the standalone binaries directly from the [waza v0.33.0 release](https://github.com/microsoft/waza/releases/tag/v0.33.0).
+Or browse the [GitHub Releases](https://github.com/microsoft/waza/releases) page and choose the standalone waza binary assets for the version you want.
 
 ### Install from Source
 

--- a/site/src/content/docs/reference/releases.mdx
+++ b/site/src/content/docs/reference/releases.mdx
@@ -59,7 +59,7 @@ On Windows, use this command only from Git Bash, MSYS2, or Cygwin. If PowerShell
 </TabItem>
 <TabItem label="Windows (PowerShell)">
 
-Download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+Download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.33.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
The README binary install links and the public releases docs were pointing standalone binary users at `/releases/latest`, which resolves to the azd extension release instead of the waza binary release.

This change points those binary download links at the standalone waza release and adds a clear note that the binary release is distinct from the azd extension release.

Closes #276

Validation:
- `cd site && npm install`
- `cd site && npm run build`

Documentation impact:
- `README.md`
- `site/src/content/docs/reference/releases.mdx`