### PR TITLE
Add waza update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ azd waza run examples/code-explainer/eval.yaml -v
 Waza automatically checks for new versions in the background. If an update is available, a notice appears after command output:
 
 ```
-A newer version of waza is available: v0.24.0 → v0.28.0. Run: curl -fsSL ... | bash
+A newer version of waza is available: v0.24.0 → v0.28.0. Run: waza update
 ```
 
-The check is non-blocking (never slows commands), cached for 24 hours, and can be disabled with `--no-update-check` or `WAZA_NO_UPDATE_CHECK=1`.
+Run `waza update` to download and execute the official installer after an explicit confirmation prompt. Use `waza update --yes` to skip the prompt in scripted environments. The check is non-blocking (never slows commands), cached for 24 hours, and can be disabled with `--no-update-check` or `WAZA_NO_UPDATE_CHECK=1`.
 
 ## Quick Start
 
@@ -100,6 +100,9 @@ make build
 
 # Initialize a project workspace
 waza init [directory]
+
+# Update waza to the latest release
+waza update
 
 # Create a new skill
 waza new skill skill-name
@@ -143,6 +146,20 @@ waza tokens suggest skills/
 ```
 
 ## Commands
+
+### `waza update`
+
+Update waza to the latest release by running the official installer after confirmation.
+
+| Flag | Description |
+|------|-------------|
+| `--yes`, `-y` | Skip the confirmation prompt |
+
+**Example:**
+```bash
+waza update
+waza update --yes
+```
 
 ### `waza init [directory]`
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ Download and install the latest pre-built binary with the Bash install script on
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
-The script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable). On Windows, piping this command to `bash` from PowerShell may invoke WSL and install the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the standalone waza release assets on GitHub Releases, rename it to `waza.exe`, and place it in a directory on your `PATH`.
+The Bash script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable).
+
+For native Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/microsoft/waza/main/install.ps1 | iex
+```
+
+The PowerShell script downloads the native Windows binary, verifies the checksum, and installs to an existing `waza.exe` location or `%LOCALAPPDATA%\Microsoft\Waza`. On Windows, piping the Bash command from PowerShell may invoke WSL and install the Linux binary inside WSL.
 
 Or browse the [GitHub Releases](https://github.com/microsoft/waza/releases) page and choose the standalone waza binary assets for the version you want.
 
@@ -66,7 +74,7 @@ Waza automatically checks for new versions in the background. If an update is av
 A newer version of waza is available: v0.24.0 → v0.28.0. Run: waza update
 ```
 
-Run `waza update` to download and execute the official installer after an explicit confirmation prompt. Use `waza update --yes` to skip the prompt in scripted environments. The check is non-blocking (never slows commands), cached for 24 hours, and can be disabled with `--no-update-check` or `WAZA_NO_UPDATE_CHECK=1`.
+Run `waza update` to download and execute the official OS-specific installer after an explicit confirmation prompt. It uses the Bash installer on macOS/Linux and the PowerShell installer on native Windows. Use `waza update --yes` to skip the prompt in scripted environments. The check is non-blocking (never slows commands), cached for 24 hours, and can be disabled with `--no-update-check` or `WAZA_NO_UPDATE_CHECK=1`.
 
 ## Quick Start
 
@@ -149,7 +157,7 @@ waza tokens suggest skills/
 
 ### `waza update`
 
-Update waza to the latest release by running the official installer after confirmation.
+Update waza to the latest release by running the official OS-specific installer after confirmation.
 
 | Flag | Description |
 |------|-------------|

--- a/cmd/waza/cmd_update.go
+++ b/cmd/waza/cmd_update.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -17,9 +19,21 @@ import (
 const latestReleaseURL = "https://github.com/microsoft/waza/releases/latest"
 
 type updateCommandOptions struct {
-	InstallerURL string
-	LookPath     func(string) (string, error)
-	RunCommand   func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error
+	BashInstallerURL       string
+	PowerShellInstallerURL string
+	GOOS                   string
+	ExecutablePath         string
+	LookPath               func(string) (string, error)
+	RunCommand             func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error
+}
+
+type updateInstaller struct {
+	Name       string
+	ScriptURL  string
+	Candidates []string
+	Args       []string
+	Env        []string
+	Async      bool
 }
 
 func newUpdateCommand() *cobra.Command {
@@ -33,14 +47,15 @@ func newUpdateCommandWithOptions(options *updateCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update waza to the latest release",
-		Long: fmt.Sprintf(`Update waza to the latest release.
+		Long: `Update waza to the latest release.
 
-This command downloads and runs the official installer:
-  %s
+This command downloads and runs the official installer for your OS:
+  macOS/Linux: Bash installer
+  Windows: PowerShell installer
 
-The installer detects the OS and architecture for the current shell environment,
-downloads the matching release asset, verifies its checksum, and replaces the
-waza binary.`, opts.InstallerURL),
+The selected installer detects the architecture for the current environment,
+downloads the matching release asset, verifies its checksum, and updates the
+waza binary.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdateCommand(cmd, opts, yes)
@@ -54,10 +69,15 @@ waza binary.`, opts.InstallerURL),
 
 func normalizeUpdateCommandOptions(options *updateCommandOptions) updateCommandOptions {
 	opts := updateCommandOptions{
-		InstallerURL: versionpkg.InstallScriptURL,
-		LookPath:     exec.LookPath,
-		RunCommand: func(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+		BashInstallerURL:       versionpkg.BashInstallScriptURL,
+		PowerShellInstallerURL: versionpkg.PowerShellInstallScriptURL,
+		GOOS:                   runtime.GOOS,
+		LookPath:               exec.LookPath,
+		RunCommand: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 			cmd := exec.CommandContext(ctx, name, args...)
+			if len(env) > 0 {
+				cmd.Env = append(os.Environ(), env...)
+			}
 			cmd.Stdin = stdin
 			cmd.Stdout = stdout
 			cmd.Stderr = stderr
@@ -65,10 +85,24 @@ func normalizeUpdateCommandOptions(options *updateCommandOptions) updateCommandO
 		},
 	}
 	if options == nil {
+		if executablePath, err := os.Executable(); err == nil {
+			opts.ExecutablePath = executablePath
+		}
 		return opts
 	}
-	if options.InstallerURL != "" {
-		opts.InstallerURL = options.InstallerURL
+	if options.BashInstallerURL != "" {
+		opts.BashInstallerURL = options.BashInstallerURL
+	}
+	if options.PowerShellInstallerURL != "" {
+		opts.PowerShellInstallerURL = options.PowerShellInstallerURL
+	}
+	if options.GOOS != "" {
+		opts.GOOS = options.GOOS
+	}
+	if options.ExecutablePath != "" {
+		opts.ExecutablePath = options.ExecutablePath
+	} else if executablePath, err := os.Executable(); err == nil {
+		opts.ExecutablePath = executablePath
 	}
 	if options.LookPath != nil {
 		opts.LookPath = options.LookPath
@@ -82,9 +116,13 @@ func normalizeUpdateCommandOptions(options *updateCommandOptions) updateCommandO
 func runUpdateCommand(cmd *cobra.Command, opts updateCommandOptions, yes bool) error {
 	out := cmd.OutOrStdout()
 	errOut := cmd.ErrOrStderr()
+	installer, err := installerForOS(opts.GOOS, opts)
+	if err != nil {
+		return err
+	}
 
 	if !yes {
-		ok, err := confirmUpdate(cmd.InOrStdin(), out, opts.InstallerURL)
+		ok, err := confirmUpdate(cmd.InOrStdin(), out, installer)
 		if err != nil {
 			return err
 		}
@@ -94,23 +132,66 @@ func runUpdateCommand(cmd *cobra.Command, opts updateCommandOptions, yes bool) e
 		}
 	}
 
-	bashPath, err := opts.LookPath("bash")
+	commandPath, err := lookPathAny(opts.LookPath, installer.Candidates)
 	if err != nil {
-		return missingBashError()
+		return missingInstallerError(installer)
 	}
 
-	fmt.Fprintln(out, "Updating waza...")
-	args := []string{"-c", `set -euo pipefail; curl -fsSL "$1" | bash`, "waza-installer", opts.InstallerURL}
-	if err := opts.RunCommand(cmd.Context(), bashPath, args, cmd.InOrStdin(), out, errOut); err != nil {
+	fmt.Fprintf(out, "Updating waza with the %s installer...\n", installer.Name)
+	if err := opts.RunCommand(cmd.Context(), commandPath, installer.Args, installer.Env, cmd.InOrStdin(), out, errOut); err != nil {
 		return fmt.Errorf("running waza installer: %w", err)
 	}
 
-	fmt.Fprintln(out, "Update complete.")
+	if installer.Async {
+		fmt.Fprintln(out, "Update started. The installer will finish after this waza process exits.")
+	} else {
+		fmt.Fprintln(out, "Update complete.")
+	}
 	return nil
 }
 
-func confirmUpdate(in io.Reader, out io.Writer, installerURL string) (bool, error) {
-	fmt.Fprintf(out, "waza update will download and run the official installer:\n  %s\n\nContinue? [y/N]: ", installerURL)
+func installerForOS(goos string, opts updateCommandOptions) (updateInstaller, error) {
+	switch goos {
+	case "darwin", "linux":
+		return updateInstaller{
+			Name:       "Bash",
+			ScriptURL:  opts.BashInstallerURL,
+			Candidates: []string{"bash"},
+			Args:       []string{"-c", `set -euo pipefail; curl -fsSL "$1" | bash`, "waza-installer", opts.BashInstallerURL},
+		}, nil
+	case "windows":
+		script := `$ErrorActionPreference = 'Stop'; Invoke-Expression (Invoke-RestMethod -Uri $args[0])`
+		env := []string{fmt.Sprintf("WAZA_UPDATE_PARENT_PID=%d", os.Getpid())}
+		if opts.ExecutablePath != "" {
+			env = append(env, fmt.Sprintf("WAZA_INSTALL_DIR=%s", filepath.Dir(opts.ExecutablePath)))
+		}
+		return updateInstaller{
+			Name:       "PowerShell",
+			ScriptURL:  opts.PowerShellInstallerURL,
+			Candidates: []string{"pwsh", "powershell"},
+			Args:       []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script, opts.PowerShellInstallerURL},
+			Env:        env,
+			Async:      true,
+		}, nil
+	default:
+		return updateInstaller{}, fmt.Errorf("unsupported OS for waza update: %s", goos)
+	}
+}
+
+func lookPathAny(lookPath func(string) (string, error), names []string) (string, error) {
+	var errs []error
+	for _, name := range names {
+		path, err := lookPath(name)
+		if err == nil {
+			return path, nil
+		}
+		errs = append(errs, fmt.Errorf("%s: %w", name, err))
+	}
+	return "", errors.Join(errs...)
+}
+
+func confirmUpdate(in io.Reader, out io.Writer, installer updateInstaller) (bool, error) {
+	fmt.Fprintf(out, "waza update will download and run the official %s installer:\n  %s\n\nContinue? [y/N]: ", installer.Name, installer.ScriptURL)
 	answer, err := bufio.NewReader(in).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return false, fmt.Errorf("reading confirmation: %w", err)
@@ -124,9 +205,9 @@ func confirmUpdate(in io.Reader, out io.Writer, installerURL string) (bool, erro
 	}
 }
 
-func missingBashError() error {
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("bash is required to run the waza installer; install Git Bash, MSYS2, or Cygwin, or download the native Windows binary from %s", latestReleaseURL)
+func missingInstallerError(installer updateInstaller) error {
+	if installer.Name == "PowerShell" {
+		return fmt.Errorf("PowerShell is required to run the native Windows waza installer; install PowerShell or download the native Windows binary from %s", latestReleaseURL)
 	}
 	return fmt.Errorf("bash is required to run the waza installer; install bash or download a release binary from %s", latestReleaseURL)
 }

--- a/cmd/waza/cmd_update.go
+++ b/cmd/waza/cmd_update.go
@@ -127,7 +127,9 @@ func runUpdateCommand(cmd *cobra.Command, opts updateCommandOptions, yes bool) e
 			return err
 		}
 		if !ok {
-			fmt.Fprintln(out, "Update cancelled.")
+			if _, err := fmt.Fprintln(out, "Update canceled."); err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -137,15 +139,21 @@ func runUpdateCommand(cmd *cobra.Command, opts updateCommandOptions, yes bool) e
 		return missingInstallerError(installer)
 	}
 
-	fmt.Fprintf(out, "Updating waza with the %s installer...\n", installer.Name)
+	if _, err := fmt.Fprintf(out, "Updating waza with the %s installer...\n", installer.Name); err != nil {
+		return err
+	}
 	if err := opts.RunCommand(cmd.Context(), commandPath, installer.Args, installer.Env, cmd.InOrStdin(), out, errOut); err != nil {
 		return fmt.Errorf("running waza installer: %w", err)
 	}
 
 	if installer.Async {
-		fmt.Fprintln(out, "Update started. The installer will finish after this waza process exits.")
+		if _, err := fmt.Fprintln(out, "Update started. The installer will finish after this waza process exits."); err != nil {
+			return err
+		}
 	} else {
-		fmt.Fprintln(out, "Update complete.")
+		if _, err := fmt.Fprintln(out, "Update complete."); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -191,7 +199,9 @@ func lookPathAny(lookPath func(string) (string, error), names []string) (string,
 }
 
 func confirmUpdate(in io.Reader, out io.Writer, installer updateInstaller) (bool, error) {
-	fmt.Fprintf(out, "waza update will download and run the official %s installer:\n  %s\n\nContinue? [y/N]: ", installer.Name, installer.ScriptURL)
+	if _, err := fmt.Fprintf(out, "waza update will download and run the official %s installer:\n  %s\n\nContinue? [y/N]: ", installer.Name, installer.ScriptURL); err != nil {
+		return false, err
+	}
 	answer, err := bufio.NewReader(in).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return false, fmt.Errorf("reading confirmation: %w", err)

--- a/cmd/waza/cmd_update.go
+++ b/cmd/waza/cmd_update.go
@@ -31,6 +31,7 @@ type updateInstaller struct {
 	Name       string
 	ScriptURL  string
 	Candidates []string
+	Requires   []string
 	Args       []string
 	Env        []string
 	Async      bool
@@ -138,6 +139,11 @@ func runUpdateCommand(cmd *cobra.Command, opts updateCommandOptions, yes bool) e
 	if err != nil {
 		return missingInstallerError(installer)
 	}
+	for _, dependency := range installer.Requires {
+		if _, err := opts.LookPath(dependency); err != nil {
+			return missingDependencyError(dependency)
+		}
+	}
 
 	if _, err := fmt.Fprintf(out, "Updating waza with the %s installer...\n", installer.Name); err != nil {
 		return err
@@ -165,6 +171,7 @@ func installerForOS(goos string, opts updateCommandOptions) (updateInstaller, er
 			Name:       "Bash",
 			ScriptURL:  opts.BashInstallerURL,
 			Candidates: []string{"bash"},
+			Requires:   []string{"curl"},
 			Args:       []string{"-c", `set -euo pipefail; curl -fsSL "$1" | bash`, "waza-installer", opts.BashInstallerURL},
 		}, nil
 	case "windows":
@@ -220,4 +227,11 @@ func missingInstallerError(installer updateInstaller) error {
 		return fmt.Errorf("PowerShell is required to run the native Windows waza installer; install PowerShell or download the native Windows binary from %s", latestReleaseURL)
 	}
 	return fmt.Errorf("bash is required to run the waza installer; install bash or download a release binary from %s", latestReleaseURL)
+}
+
+func missingDependencyError(name string) error {
+	if name == "curl" {
+		return fmt.Errorf("curl is required to download the waza installer; install curl or download a release binary from %s", latestReleaseURL)
+	}
+	return fmt.Errorf("%s is required to run the waza installer", name)
 }

--- a/cmd/waza/cmd_update.go
+++ b/cmd/waza/cmd_update.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	versionpkg "github.com/microsoft/waza/internal/version"
+	"github.com/spf13/cobra"
+)
+
+const latestReleaseURL = "https://github.com/microsoft/waza/releases/latest"
+
+type updateCommandOptions struct {
+	InstallerURL string
+	LookPath     func(string) (string, error)
+	RunCommand   func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error
+}
+
+func newUpdateCommand() *cobra.Command {
+	return newUpdateCommandWithOptions(nil)
+}
+
+func newUpdateCommandWithOptions(options *updateCommandOptions) *cobra.Command {
+	opts := normalizeUpdateCommandOptions(options)
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update waza to the latest release",
+		Long: fmt.Sprintf(`Update waza to the latest release.
+
+This command downloads and runs the official installer:
+  %s
+
+The installer detects the OS and architecture for the current shell environment,
+downloads the matching release asset, verifies its checksum, and replaces the
+waza binary.`, opts.InstallerURL),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUpdateCommand(cmd, opts, yes)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Run the update without prompting for confirmation")
+
+	return cmd
+}
+
+func normalizeUpdateCommandOptions(options *updateCommandOptions) updateCommandOptions {
+	opts := updateCommandOptions{
+		InstallerURL: versionpkg.InstallScriptURL,
+		LookPath:     exec.LookPath,
+		RunCommand: func(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+			cmd := exec.CommandContext(ctx, name, args...)
+			cmd.Stdin = stdin
+			cmd.Stdout = stdout
+			cmd.Stderr = stderr
+			return cmd.Run()
+		},
+	}
+	if options == nil {
+		return opts
+	}
+	if options.InstallerURL != "" {
+		opts.InstallerURL = options.InstallerURL
+	}
+	if options.LookPath != nil {
+		opts.LookPath = options.LookPath
+	}
+	if options.RunCommand != nil {
+		opts.RunCommand = options.RunCommand
+	}
+	return opts
+}
+
+func runUpdateCommand(cmd *cobra.Command, opts updateCommandOptions, yes bool) error {
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+
+	if !yes {
+		ok, err := confirmUpdate(cmd.InOrStdin(), out, opts.InstallerURL)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(out, "Update cancelled.")
+			return nil
+		}
+	}
+
+	bashPath, err := opts.LookPath("bash")
+	if err != nil {
+		return missingBashError()
+	}
+
+	fmt.Fprintln(out, "Updating waza...")
+	args := []string{"-c", `set -euo pipefail; curl -fsSL "$1" | bash`, "waza-installer", opts.InstallerURL}
+	if err := opts.RunCommand(cmd.Context(), bashPath, args, cmd.InOrStdin(), out, errOut); err != nil {
+		return fmt.Errorf("running waza installer: %w", err)
+	}
+
+	fmt.Fprintln(out, "Update complete.")
+	return nil
+}
+
+func confirmUpdate(in io.Reader, out io.Writer, installerURL string) (bool, error) {
+	fmt.Fprintf(out, "waza update will download and run the official installer:\n  %s\n\nContinue? [y/N]: ", installerURL)
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("reading confirmation: %w", err)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func missingBashError() error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("bash is required to run the waza installer; install Git Bash, MSYS2, or Cygwin, or download the native Windows binary from %s", latestReleaseURL)
+	}
+	return fmt.Errorf("bash is required to run the waza installer; install bash or download a release binary from %s", latestReleaseURL)
+}

--- a/cmd/waza/cmd_update_test.go
+++ b/cmd/waza/cmd_update_test.go
@@ -18,18 +18,20 @@ func TestUpdateCommand_ConfirmedRunsInstaller(t *testing.T) {
 	var ran bool
 
 	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
-		InstallerURL: "https://example.com/install.sh",
+		BashInstallerURL: "https://example.com/install.sh",
+		GOOS:             "linux",
 		LookPath: func(name string) (string, error) {
 			require.Equal(t, "bash", name)
 			return "/usr/bin/bash", nil
 		},
-		RunCommand: func(ctx context.Context, name string, args []string, stdin io.Reader, out, errOut io.Writer) error {
+		RunCommand: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader, out, errOut io.Writer) error {
 			ran = true
 			assert.Equal(t, "/usr/bin/bash", name)
 			require.Len(t, args, 4)
 			assert.Equal(t, "-c", args[0])
 			assert.Contains(t, args[1], "curl -fsSL")
 			assert.Equal(t, "https://example.com/install.sh", args[3])
+			assert.Empty(t, env)
 			return nil
 		},
 	})
@@ -41,7 +43,7 @@ func TestUpdateCommand_ConfirmedRunsInstaller(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	assert.True(t, ran)
 	assert.Contains(t, stdout.String(), "Continue? [y/N]:")
-	assert.Contains(t, stdout.String(), "Updating waza")
+	assert.Contains(t, stdout.String(), "Bash installer")
 	assert.Contains(t, stdout.String(), "Update complete")
 }
 
@@ -49,7 +51,8 @@ func TestUpdateCommand_DeclinedDoesNotRunInstaller(t *testing.T) {
 	var stdout bytes.Buffer
 
 	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
-		RunCommand: func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error {
+		GOOS: "linux",
+		RunCommand: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 			t.Fatal("installer should not run when update is declined")
 			return nil
 		},
@@ -68,10 +71,11 @@ func TestUpdateCommand_YesFlagSkipsConfirmation(t *testing.T) {
 	var ran bool
 
 	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		GOOS: "linux",
 		LookPath: func(name string) (string, error) {
 			return "/usr/bin/bash", nil
 		},
-		RunCommand: func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error {
+		RunCommand: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 			ran = true
 			return nil
 		},
@@ -88,10 +92,11 @@ func TestUpdateCommand_YesFlagSkipsConfirmation(t *testing.T) {
 
 func TestUpdateCommand_MissingBashReturnsGuidance(t *testing.T) {
 	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		GOOS: "linux",
 		LookPath: func(name string) (string, error) {
 			return "", errors.New("not found")
 		},
-		RunCommand: func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error {
+		RunCommand: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 			t.Fatal("installer should not run when bash is missing")
 			return nil
 		},
@@ -106,10 +111,11 @@ func TestUpdateCommand_MissingBashReturnsGuidance(t *testing.T) {
 
 func TestUpdateCommand_RunFailureIncludesContext(t *testing.T) {
 	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		GOOS: "linux",
 		LookPath: func(name string) (string, error) {
 			return "/usr/bin/bash", nil
 		},
-		RunCommand: func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error {
+		RunCommand: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 			return errors.New("boom")
 		},
 	})
@@ -119,6 +125,99 @@ func TestUpdateCommand_RunFailureIncludesContext(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "running waza installer")
 	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestUpdateCommand_DarwinUsesBashInstaller(t *testing.T) {
+	var ran bool
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		BashInstallerURL: "https://example.com/install.sh",
+		GOOS:             "darwin",
+		LookPath: func(name string) (string, error) {
+			assert.Equal(t, "bash", name)
+			return "/bin/bash", nil
+		},
+		RunCommand: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader, out, errOut io.Writer) error {
+			ran = true
+			assert.Equal(t, "/bin/bash", name)
+			assert.Equal(t, "https://example.com/install.sh", args[3])
+			assert.Empty(t, env)
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"--yes"})
+
+	require.NoError(t, cmd.Execute())
+	assert.True(t, ran)
+}
+
+func TestUpdateCommand_WindowsUsesPowerShellInstaller(t *testing.T) {
+	var stdout bytes.Buffer
+	var lookups []string
+	var ran bool
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		PowerShellInstallerURL: "https://example.com/install.ps1",
+		GOOS:                   "windows",
+		ExecutablePath:         "C:/tools/waza.exe",
+		LookPath: func(name string) (string, error) {
+			lookups = append(lookups, name)
+			if name == "pwsh" {
+				return "", errors.New("not found")
+			}
+			return `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, nil
+		},
+		RunCommand: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader, out, errOut io.Writer) error {
+			ran = true
+			assert.Contains(t, name, "powershell.exe")
+			require.Len(t, args, 6)
+			assert.Equal(t, "-NoProfile", args[0])
+			assert.Equal(t, "-ExecutionPolicy", args[1])
+			assert.Equal(t, "Bypass", args[2])
+			assert.Equal(t, "-Command", args[3])
+			assert.Contains(t, args[4], "Invoke-RestMethod")
+			assert.Equal(t, "https://example.com/install.ps1", args[5])
+			require.Len(t, env, 2)
+			assert.Contains(t, env[0], "WAZA_UPDATE_PARENT_PID=")
+			assert.Equal(t, "WAZA_INSTALL_DIR=C:/tools", env[1])
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"--yes"})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	require.NoError(t, cmd.Execute())
+	assert.True(t, ran)
+	assert.Equal(t, []string{"pwsh", "powershell"}, lookups)
+	assert.Contains(t, stdout.String(), "PowerShell installer")
+	assert.Contains(t, stdout.String(), "Update started")
+}
+
+func TestUpdateCommand_MissingPowerShellReturnsGuidance(t *testing.T) {
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		GOOS: "windows",
+		LookPath: func(name string) (string, error) {
+			return "", errors.New("not found")
+		},
+		RunCommand: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+			t.Fatal("installer should not run when PowerShell is missing")
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"--yes"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PowerShell is required")
+	assert.Contains(t, err.Error(), latestReleaseURL)
+}
+
+func TestUpdateCommand_UnsupportedOS(t *testing.T) {
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{GOOS: "freebsd"})
+	cmd.SetArgs([]string{"--yes"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported OS")
 }
 
 func TestRootCommand_RegistersUpdateCommand(t *testing.T) {

--- a/cmd/waza/cmd_update_test.go
+++ b/cmd/waza/cmd_update_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateCommand_ConfirmedRunsInstaller(t *testing.T) {
+	var stdout bytes.Buffer
+	var ran bool
+
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		InstallerURL: "https://example.com/install.sh",
+		LookPath: func(name string) (string, error) {
+			require.Equal(t, "bash", name)
+			return "/usr/bin/bash", nil
+		},
+		RunCommand: func(ctx context.Context, name string, args []string, stdin io.Reader, out, errOut io.Writer) error {
+			ran = true
+			assert.Equal(t, "/usr/bin/bash", name)
+			require.Len(t, args, 4)
+			assert.Equal(t, "-c", args[0])
+			assert.Contains(t, args[1], "curl -fsSL")
+			assert.Equal(t, "https://example.com/install.sh", args[3])
+			return nil
+		},
+	})
+	cmd.SetIn(strings.NewReader("yes\n"))
+	cmd.SetArgs([]string{})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	require.NoError(t, cmd.Execute())
+	assert.True(t, ran)
+	assert.Contains(t, stdout.String(), "Continue? [y/N]:")
+	assert.Contains(t, stdout.String(), "Updating waza")
+	assert.Contains(t, stdout.String(), "Update complete")
+}
+
+func TestUpdateCommand_DeclinedDoesNotRunInstaller(t *testing.T) {
+	var stdout bytes.Buffer
+
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		RunCommand: func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error {
+			t.Fatal("installer should not run when update is declined")
+			return nil
+		},
+	})
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetArgs([]string{})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stdout.String(), "Update cancelled.")
+}
+
+func TestUpdateCommand_YesFlagSkipsConfirmation(t *testing.T) {
+	var stdout bytes.Buffer
+	var ran bool
+
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		LookPath: func(name string) (string, error) {
+			return "/usr/bin/bash", nil
+		},
+		RunCommand: func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error {
+			ran = true
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"--yes"})
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	require.NoError(t, cmd.Execute())
+	assert.True(t, ran)
+	assert.NotContains(t, stdout.String(), "Continue? [y/N]:")
+}
+
+func TestUpdateCommand_MissingBashReturnsGuidance(t *testing.T) {
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		LookPath: func(name string) (string, error) {
+			return "", errors.New("not found")
+		},
+		RunCommand: func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error {
+			t.Fatal("installer should not run when bash is missing")
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"--yes"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bash is required")
+	assert.Contains(t, err.Error(), latestReleaseURL)
+}
+
+func TestUpdateCommand_RunFailureIncludesContext(t *testing.T) {
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		LookPath: func(name string) (string, error) {
+			return "/usr/bin/bash", nil
+		},
+		RunCommand: func(context.Context, string, []string, io.Reader, io.Writer, io.Writer) error {
+			return errors.New("boom")
+		},
+	})
+	cmd.SetArgs([]string{"--yes"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "running waza installer")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestRootCommand_RegistersUpdateCommand(t *testing.T) {
+	cmd := newRootCommand()
+	found, _, err := cmd.Find([]string{"update"})
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, "update", found.Name())
+}
+
+func TestShouldRunUpdateCheck_SkipsUpdateCommand(t *testing.T) {
+	root := newRootCommand()
+	updateCmd, _, err := root.Find([]string{"update"})
+	require.NoError(t, err)
+
+	assert.False(t, shouldRunUpdateCheck(updateCmd, false))
+}
+
+func TestShouldRunUpdateCheck_RespectsOptOuts(t *testing.T) {
+	root := newRootCommand()
+
+	assert.False(t, shouldRunUpdateCheck(root, true))
+
+	t.Setenv("WAZA_NO_UPDATE_CHECK", "1")
+	assert.False(t, shouldRunUpdateCheck(root, false))
+
+	require.NoError(t, os.Unsetenv("WAZA_NO_UPDATE_CHECK"))
+	assert.True(t, shouldRunUpdateCheck(root, false))
+}

--- a/cmd/waza/cmd_update_test.go
+++ b/cmd/waza/cmd_update_test.go
@@ -63,7 +63,7 @@ func TestUpdateCommand_DeclinedDoesNotRunInstaller(t *testing.T) {
 	cmd.SetErr(&stdout)
 
 	require.NoError(t, cmd.Execute())
-	assert.Contains(t, stdout.String(), "Update cancelled.")
+	assert.Contains(t, stdout.String(), "Update canceled.")
 }
 
 func TestUpdateCommand_YesFlagSkipsConfirmation(t *testing.T) {

--- a/cmd/waza/cmd_update_test.go
+++ b/cmd/waza/cmd_update_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -21,8 +22,15 @@ func TestUpdateCommand_ConfirmedRunsInstaller(t *testing.T) {
 		BashInstallerURL: "https://example.com/install.sh",
 		GOOS:             "linux",
 		LookPath: func(name string) (string, error) {
-			require.Equal(t, "bash", name)
-			return "/usr/bin/bash", nil
+			switch name {
+			case "bash":
+				return "/usr/bin/bash", nil
+			case "curl":
+				return "/usr/bin/curl", nil
+			default:
+				t.Fatalf("unexpected lookup for %s", name)
+				return "", errors.New("unexpected lookup")
+			}
 		},
 		RunCommand: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader, out, errOut io.Writer) error {
 			ran = true
@@ -73,7 +81,7 @@ func TestUpdateCommand_YesFlagSkipsConfirmation(t *testing.T) {
 	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
 		GOOS: "linux",
 		LookPath: func(name string) (string, error) {
-			return "/usr/bin/bash", nil
+			return "/usr/bin/" + name, nil
 		},
 		RunCommand: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 			ran = true
@@ -133,8 +141,15 @@ func TestUpdateCommand_DarwinUsesBashInstaller(t *testing.T) {
 		BashInstallerURL: "https://example.com/install.sh",
 		GOOS:             "darwin",
 		LookPath: func(name string) (string, error) {
-			assert.Equal(t, "bash", name)
-			return "/bin/bash", nil
+			switch name {
+			case "bash":
+				return "/bin/bash", nil
+			case "curl":
+				return "/usr/bin/curl", nil
+			default:
+				t.Fatalf("unexpected lookup for %s", name)
+				return "", errors.New("unexpected lookup")
+			}
 		},
 		RunCommand: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader, out, errOut io.Writer) error {
 			ran = true
@@ -148,6 +163,28 @@ func TestUpdateCommand_DarwinUsesBashInstaller(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.True(t, ran)
+}
+
+func TestUpdateCommand_MissingCurlReturnsGuidance(t *testing.T) {
+	cmd := newUpdateCommandWithOptions(&updateCommandOptions{
+		GOOS: "linux",
+		LookPath: func(name string) (string, error) {
+			if name == "bash" {
+				return "/usr/bin/bash", nil
+			}
+			return "", errors.New("not found")
+		},
+		RunCommand: func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+			t.Fatal("installer should not run when curl is missing")
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"--yes"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "curl is required")
+	assert.Contains(t, err.Error(), latestReleaseURL)
 }
 
 func TestUpdateCommand_WindowsUsesPowerShellInstaller(t *testing.T) {
@@ -177,7 +214,7 @@ func TestUpdateCommand_WindowsUsesPowerShellInstaller(t *testing.T) {
 			assert.Equal(t, "https://example.com/install.ps1", args[5])
 			require.Len(t, env, 2)
 			assert.Contains(t, env[0], "WAZA_UPDATE_PARENT_PID=")
-			assert.Equal(t, "WAZA_INSTALL_DIR=C:/tools", env[1])
+			assert.Equal(t, "WAZA_INSTALL_DIR="+filepath.Dir("C:/tools/waza.exe"), env[1])
 			return nil
 		},
 	})

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -38,7 +38,7 @@ performance against predefined test cases.`,
 		if *debugLogging {
 			logLevel.Set(slog.LevelDebug)
 		}
-		if !*noUpdateCheck && os.Getenv("WAZA_NO_UPDATE_CHECK") == "" {
+		if shouldRunUpdateCheck(cmd, *noUpdateCheck) {
 			checker = versionpkg.NewChecker(version)
 			checker.Run(context.Background())
 		}
@@ -67,6 +67,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newResultsCommand())
 	cmd.AddCommand(newModelsCommand())
 	cmd.AddCommand(newQualityCommand())
+	cmd.AddCommand(newUpdateCommand())
 
 	return cmd
 }
@@ -74,4 +75,16 @@ performance against predefined test cases.`,
 func execute() error {
 	rootCmd := newRootCommand()
 	return rootCmd.Execute()
+}
+
+func shouldRunUpdateCheck(cmd *cobra.Command, noUpdateCheck bool) bool {
+	if noUpdateCheck || os.Getenv("WAZA_NO_UPDATE_CHECK") != "" {
+		return false
+	}
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "update" {
+			return false
+		}
+	}
+	return true
 }

--- a/install.ps1
+++ b/install.ps1
@@ -34,9 +34,8 @@ function Get-InstallDirectory {
 }
 
 function Get-LatestReleaseTag {
-    $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases" -Headers @{ 'User-Agent' = 'waza-installer' }
-    $release = $releases | Where-Object { $_.tag_name -like 'v*' } | Select-Object -First 1
-    if (-not $release) {
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ 'User-Agent' = 'waza-installer' }
+    if (-not $release -or -not ($release.tag_name -like 'v*')) {
         throw 'Could not determine latest release.'
     }
     return $release.tag_name

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,135 @@
+$ErrorActionPreference = 'Stop'
+
+# install.ps1 - Download and install the latest native Windows waza binary.
+# Usage: irm https://raw.githubusercontent.com/microsoft/waza/main/install.ps1 | iex
+
+$Repo = 'microsoft/waza'
+$BinaryName = 'waza'
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("waza-install-{0}" -f ([System.Guid]::NewGuid()))
+$Scheduled = $false
+
+function Get-WazaArchitecture {
+    $arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+    switch -Regex ($arch) {
+        'ARM64' { return 'arm64' }
+        'AMD64|IA64|x64' { return 'amd64' }
+        default { throw "Unsupported architecture: $arch" }
+    }
+}
+
+function Get-InstallDirectory {
+    if ($env:WAZA_INSTALL_DIR) {
+        New-Item -ItemType Directory -Path $env:WAZA_INSTALL_DIR -Force | Out-Null
+        return $env:WAZA_INSTALL_DIR
+    }
+
+    $existing = Get-Command "$BinaryName.exe" -ErrorAction SilentlyContinue
+    if ($existing -and $existing.Source) {
+        return Split-Path -Parent $existing.Source
+    }
+
+    $dir = Join-Path $env:LOCALAPPDATA 'Microsoft\Waza'
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    return $dir
+}
+
+function Get-LatestReleaseTag {
+    $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases" -Headers @{ 'User-Agent' = 'waza-installer' }
+    $release = $releases | Where-Object { $_.tag_name -like 'v*' } | Select-Object -First 1
+    if (-not $release) {
+        throw 'Could not determine latest release.'
+    }
+    return $release.tag_name
+}
+
+function ConvertTo-SingleQuotedPowerShellLiteral([string] $Value) {
+    return "'" + $Value.Replace("'", "''") + "'"
+}
+
+function Install-Binary {
+    param(
+        [string] $Source,
+        [string] $Destination,
+        [string] $Version,
+        [string] $ParentPid
+    )
+
+    if ($ParentPid) {
+        $script:Scheduled = $true
+        $sourceLiteral = ConvertTo-SingleQuotedPowerShellLiteral $Source
+        $destinationLiteral = ConvertTo-SingleQuotedPowerShellLiteral $Destination
+        $tempDirLiteral = ConvertTo-SingleQuotedPowerShellLiteral $TempDir
+        $versionLiteral = ConvertTo-SingleQuotedPowerShellLiteral $Version
+        $moveScript = @"
+`$ErrorActionPreference = 'Stop'
+while (Get-Process -Id $ParentPid -ErrorAction SilentlyContinue) {
+    Start-Sleep -Milliseconds 250
+}
+Move-Item -LiteralPath $sourceLiteral -Destination $destinationLiteral -Force
+Remove-Item -LiteralPath $tempDirLiteral -Recurse -Force -ErrorAction SilentlyContinue
+Write-Host ''
+Write-Host "Installed waza $versionLiteral to $destinationLiteral"
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($moveScript))
+        $powerShellPath = (Get-Process -Id $PID).Path
+        Start-Process -FilePath $powerShellPath -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', $encoded) | Out-Null
+        Write-Host 'Update scheduled. It will finish after the current waza process exits.'
+        return
+    }
+
+    Move-Item -LiteralPath $Source -Destination $Destination -Force
+    Write-Host ''
+    Write-Host "Installed waza $Version to $Destination"
+}
+
+try {
+    if (-not $IsWindows -and $PSVersionTable.PSEdition -eq 'Core') {
+        throw 'install.ps1 is only for native Windows. Use install.sh on macOS, Linux, or WSL.'
+    }
+
+    $arch = Get-WazaArchitecture
+    $os = 'windows'
+    Write-Host "Detected platform: $os/$arch"
+
+    $tag = Get-LatestReleaseTag
+    $version = $tag.TrimStart('v')
+    Write-Host "Latest version: $version ($tag)"
+
+    $assetName = "$BinaryName-$os-$arch.exe"
+    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+    $assetPath = Join-Path $TempDir $assetName
+    $checksumsPath = Join-Path $TempDir 'checksums.txt'
+
+    Write-Host "Downloading $assetName..."
+    Invoke-WebRequest -Uri "https://github.com/$Repo/releases/download/$tag/$assetName" -OutFile $assetPath -UseBasicParsing
+
+    Write-Host 'Downloading checksums...'
+    Invoke-WebRequest -Uri "https://github.com/$Repo/releases/download/$tag/checksums.txt" -OutFile $checksumsPath -UseBasicParsing
+
+    Write-Host 'Verifying checksum...'
+    $checksumLine = Get-Content $checksumsPath | Where-Object { $_ -match [Regex]::Escape($assetName) } | Select-Object -First 1
+    if (-not $checksumLine) {
+        throw "No checksum entry found for $assetName."
+    }
+    $expectedHash = ($checksumLine -split '\s+')[0].ToUpperInvariant()
+    $actualHash = (Get-FileHash -Algorithm SHA256 -Path $assetPath).Hash.ToUpperInvariant()
+    if ($actualHash -ne $expectedHash) {
+        throw "Checksum mismatch for $assetName."
+    }
+    Write-Host 'Checksum verified.'
+
+    $installDir = Get-InstallDirectory
+    $destination = Join-Path $installDir "$BinaryName.exe"
+    Install-Binary -Source $assetPath -Destination $destination -Version $version -ParentPid $env:WAZA_UPDATE_PARENT_PID
+
+    $existingCommand = Get-Command "$BinaryName.exe" -ErrorAction SilentlyContinue
+    $existingDir = if ($existingCommand -and $existingCommand.Source) { Split-Path -Parent $existingCommand.Source } else { $null }
+    if ($installDir -ne $existingDir) {
+        Write-Host "Note: Add $installDir to your PATH if waza is not found after installation."
+    }
+}
+finally {
+    if (-not $Scheduled -and (Test-Path $TempDir)) {
+        Remove-Item -LiteralPath $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -62,8 +62,8 @@ main() {
     echo "For native Windows, download waza-windows-${arch}.exe from https://github.com/${REPO}/releases/latest."
   fi
 
-  # Get latest binary release tag (filter for v* tags; skip azd extension releases)
-  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \
+  # Get latest stable binary release tag.
+  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
     | grep '"tag_name": "v' | head -1 | cut -d'"' -f4)"
 
   if [ -z "$tag" ]; then

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -27,6 +27,13 @@ const (
 	httpTimeout  = 5 * time.Second
 )
 
+const (
+	// InstallScriptURL is the official installer used by update notices and the update command.
+	InstallScriptURL = "https://raw.githubusercontent.com/microsoft/waza/main/install.sh"
+	// DefaultUpdateCommand is the recommended command for upgrading waza.
+	DefaultUpdateCommand = "waza update"
+)
+
 type releaseInfo struct {
 	TagName string `json:"tag_name"`
 }
@@ -254,7 +261,7 @@ func PrintNotice(result *CheckResult, installCmd string) bool {
 		return false
 	}
 	if installCmd == "" {
-		installCmd = "curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash"
+		installCmd = DefaultUpdateCommand
 	}
 	fmt.Fprintf(os.Stderr, "\nA newer version of waza is available: v%s \u2192 v%s. Run: %s\n",
 		result.CurrentVersion, result.LatestVersion, installCmd)

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -28,8 +28,12 @@ const (
 )
 
 const (
-	// InstallScriptURL is the official installer used by update notices and the update command.
-	InstallScriptURL = "https://raw.githubusercontent.com/microsoft/waza/main/install.sh"
+	// BashInstallScriptURL is the official Bash installer for macOS, Linux, and Windows Bash environments.
+	BashInstallScriptURL = "https://raw.githubusercontent.com/microsoft/waza/main/install.sh"
+	// PowerShellInstallScriptURL is the official PowerShell installer for native Windows environments.
+	PowerShellInstallScriptURL = "https://raw.githubusercontent.com/microsoft/waza/main/install.ps1"
+	// InstallScriptURL is the default Unix-like installer URL retained for existing callers.
+	InstallScriptURL = BashInstallScriptURL
 	// DefaultUpdateCommand is the recommended command for upgrading waza.
 	DefaultUpdateCommand = "waza update"
 )

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -26,6 +26,16 @@ func newTestServer(t *testing.T, releases []releaseInfo) *httptest.Server {
 	}))
 }
 
+func waitCheckResult(t *testing.T, ch *Checker) *CheckResult {
+	t.Helper()
+	select {
+	case <-ch.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for version check")
+	}
+	return ch.Result()
+}
+
 func TestCheck_NewerVersionAvailable(t *testing.T) {
 	srv := newTestServer(t, []releaseInfo{{TagName: "v1.2.0"}, {TagName: "v1.1.0"}})
 	defer srv.Close()
@@ -78,7 +88,7 @@ func TestCheck_CacheHit(t *testing.T) {
 	defer srv.Close()
 	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
 	ch.Run(context.Background())
-	result := ch.Result()
+	result := waitCheckResult(t, ch)
 	require.NotNil(t, result)
 	assert.True(t, result.UpdateAvail)
 	assert.Equal(t, "2.0.0", result.LatestVersion)
@@ -94,7 +104,7 @@ func TestCheck_CacheExpired(t *testing.T) {
 	defer srv.Close()
 	ch := NewChecker("v1.0.0", WithAPIBaseURL(srv.URL), WithCacheDir(cacheDir))
 	ch.Run(context.Background())
-	result := ch.Result()
+	result := waitCheckResult(t, ch)
 	require.NotNil(t, result)
 	assert.True(t, result.UpdateAvail)
 	assert.Equal(t, "2.0.0", result.LatestVersion)

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -182,7 +182,7 @@ func TestPrintNotice_UpdateAvailable(t *testing.T) {
 	output := string(out[:n])
 	assert.Contains(t, output, "v1.0.0")
 	assert.Contains(t, output, "v2.0.0")
-	assert.Contains(t, output, "install.sh")
+	assert.Contains(t, output, "waza update")
 }
 
 func TestPrintNotice_CustomInstallCmd(t *testing.T) {

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -15,6 +15,22 @@ waza --version
 
 For native Windows PowerShell, download the Windows binary from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
+## waza update
+
+Update waza to the latest release.
+
+```bash
+waza update
+```
+
+The command prompts for confirmation, then downloads and runs the official installer for the current shell environment. Use `--yes` to skip the prompt in scripted environments:
+
+```bash
+waza update --yes
+```
+
+The installer requires Bash and auto-detects macOS, Linux, or Windows Bash environments such as Git Bash, MSYS2, and Cygwin. For native Windows PowerShell, download the Windows binary from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+
 ## waza run
 
 Run an evaluation benchmark.

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -13,7 +13,12 @@ curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | ba
 waza --version
 ```
 
-For native Windows PowerShell, download the Windows binary from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+For native Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/microsoft/waza/main/install.ps1 | iex
+waza --version
+```
 
 ## waza update
 
@@ -23,13 +28,13 @@ Update waza to the latest release.
 waza update
 ```
 
-The command prompts for confirmation, then downloads and runs the official installer for the current shell environment. Use `--yes` to skip the prompt in scripted environments:
+The command prompts for confirmation, then downloads and runs the official installer for the current OS. It uses the Bash installer on macOS/Linux and the PowerShell installer on native Windows. Use `--yes` to skip the prompt in scripted environments:
 
 ```bash
 waza update --yes
 ```
 
-The installer requires Bash and auto-detects macOS, Linux, or Windows Bash environments such as Git Bash, MSYS2, and Cygwin. For native Windows PowerShell, download the Windows binary from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+The native Windows update path schedules the final binary replacement after the running `waza.exe` exits, avoiding Windows executable file locks. In WSL, `waza update` uses the Linux Bash installer and updates the WSL installation.
 
 ## waza run
 

--- a/site/src/content/docs/reference/releases.mdx
+++ b/site/src/content/docs/reference/releases.mdx
@@ -59,7 +59,11 @@ On Windows, use this command only from Git Bash, MSYS2, or Cygwin. If PowerShell
 </TabItem>
 <TabItem label="Windows (PowerShell)">
 
-Download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.33.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+```powershell
+irm https://raw.githubusercontent.com/microsoft/waza/main/install.ps1 | iex
+```
+
+The PowerShell installer downloads `waza-windows-amd64.exe` or `waza-windows-arm64.exe`, verifies the checksum, and installs `waza.exe`. You can also download the Windows binary from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.33.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Waza already checks for newer releases, but users had to copy and run the raw installer command themselves. This adds a first-class `waza update` path so the update notice can point to a safer, discoverable command.

## Summary

- Add `waza update` with an explicit confirmation prompt before running the official installer.
- Target installers by OS: Bash for macOS/Linux and PowerShell for native Windows.
- Add `install.ps1` for native Windows, including checksum verification and delayed replacement to avoid Windows locking the running `waza.exe`.
- Add `--yes`/`-y` for scripted updates and clear guidance when the required installer shell is unavailable.
- Skip the automatic update notice while the update command itself is running.
- Change update notices to recommend `waza update` and document OS-specific install/update behavior in README and the docs site.

## Testing

- `go test ./cmd/waza ./internal/version`
- `go test ./...`
- `cd site && npm ci --no-audit --no-fund && npm run build`
- PowerShell parser check for `install.ps1` when `pwsh` is available