### PR TITLE
Add forbidden skills to skill invocation grader

### DIFF
--- a/docs/graders/skill_invocation.md
+++ b/docs/graders/skill_invocation.md
@@ -1,6 +1,6 @@
 ### `skill_invocation` - Skill Invocation Sequence Validation
 
-Validates that dependent skills were invoked in the correct sequence during orchestration skill execution. Useful for verifying that orchestration workflows call the right skills in the right order.
+Validates that dependent skills were invoked in the correct sequence during orchestration skill execution. Useful for verifying that orchestration workflows call the right skills in the right order, or that a specific skill was not invoked.
 
 ```yaml
 - type: skill_invocation
@@ -16,9 +16,12 @@ Validates that dependent skills were invoked in the correct sequence during orch
 **Options:**
 | Option | Type | Description |
 |--------|------|-------------|
-| `mode` | string | How to match sequences (see modes below) |
-| `required_skills` | list[str] | List of required skill names in sequence |
-| `allow_extra` | bool | Whether to allow extra skill invocations (default: true) |
+| `mode` | string | How to match required skill sequences (required when `required_skills` is set; ignored for forbidden-only configs) |
+| `required_skills` | list[str] | Skill names that must be invoked in sequence |
+| `forbidden_skills` | list[str] | Skill names that must not be invoked |
+| `allow_extra` | bool | Whether to allow extra skill invocations beyond `required_skills` (default: true; ignored for forbidden-only configs) |
+
+At least one of `required_skills` or `forbidden_skills` must be non-empty.
 
 **Matching Modes:**
 
@@ -48,6 +51,8 @@ The grader calculates three metrics:
 
 When `allow_extra: false`, the score is penalized for extra skill invocations beyond the required set.
 
+For forbidden-only configs, the score is `1.0` when no forbidden skill appears and `0.0` when any forbidden skill appears. Unrelated skill invocations are allowed. For mixed required and forbidden configs, the grader uses the required-skill score unless a forbidden skill appears, which fails the grader with a score of `0.0`.
+
 The `passed` field is based on the matching mode constraint, while the `score` field uses F1 (with optional penalty).
 
 **Example Use Cases:**
@@ -75,6 +80,22 @@ The `passed` field is based on the matching mode constraint, while the `score` f
   config:
     mode: any_order
     required_skills: ["azure-prepare", "azure-deploy", "azure-validate"]
+    allow_extra: true
+
+# Ensure a skill was not invoked; unrelated skills are fine
+- type: skill_invocation
+  name: no_prod_deploy
+  config:
+    forbidden_skills: ["azure-prod-deploy"]
+    allow_extra: true
+
+# Require one skill while forbidding another
+- type: skill_invocation
+  name: safe_validation
+  config:
+    mode: any_order
+    required_skills: ["azure-validate"]
+    forbidden_skills: ["azure-prod-deploy"]
     allow_extra: true
 ```
 

--- a/internal/graders/skill_invocation_grader.go
+++ b/internal/graders/skill_invocation_grader.go
@@ -13,19 +13,23 @@ import (
 // an expected set of skills. It supports three matching modes and calculates
 // precision, recall, and F1 scores.
 type skillInvocationGrader struct {
-	name           string
-	matchingMode   models.SkillInvocationMatchingMode
-	requiredSkills []string
-	allowExtra     bool
+	name            string
+	matchingMode    models.SkillInvocationMatchingMode
+	requiredSkills  []string
+	forbiddenSkills []string
+	allowExtra      bool
 }
 
 // NewSkillInvocationGrader creates a skillInvocationGrader from decoded parameters.
 func NewSkillInvocationGrader(name string, params models.SkillInvocationGraderParameters) (*skillInvocationGrader, error) {
-	if len(params.RequiredSkills) == 0 {
-		return nil, fmt.Errorf("skill_invocation grader '%s' must have at least one required_skills entry", name)
+	if len(params.RequiredSkills) == 0 && len(params.ForbiddenSkills) == 0 {
+		return nil, fmt.Errorf("skill_invocation grader '%s' must have at least one required_skills or forbidden_skills entry", name)
 	}
 
 	mode := params.Mode
+	if len(params.RequiredSkills) == 0 && mode == "" {
+		mode = models.SkillMatchingModeAnyOrder
+	}
 	switch mode {
 	case models.SkillMatchingModeExact, models.SkillMatchingModeInOrder, models.SkillMatchingModeAnyOrder:
 		// valid
@@ -42,11 +46,21 @@ func NewSkillInvocationGrader(name string, params models.SkillInvocationGraderPa
 		allowExtra = *params.AllowExtra
 	}
 
+	requiredSkills := params.RequiredSkills
+	if requiredSkills == nil {
+		requiredSkills = []string{}
+	}
+	forbiddenSkills := params.ForbiddenSkills
+	if forbiddenSkills == nil {
+		forbiddenSkills = []string{}
+	}
+
 	return &skillInvocationGrader{
-		name:           name,
-		matchingMode:   mode,
-		requiredSkills: params.RequiredSkills,
-		allowExtra:     allowExtra,
+		name:            name,
+		matchingMode:    mode,
+		requiredSkills:  requiredSkills,
+		forbiddenSkills: forbiddenSkills,
+		allowExtra:      allowExtra,
 	}, nil
 }
 
@@ -66,23 +80,38 @@ func (g *skillInvocationGrader) Grade(ctx context.Context, gradingContext *Conte
 			actual[i] = si.Name
 		}
 
-		precision, recall := g.computePrecisionRecall(actual)
-		f1 := computeF1(precision, recall)
+		precision, recall, f1 := 1.0, 1.0, 1.0
+		requiredPassed := true
+		if len(g.requiredSkills) > 0 {
+			precision, recall = g.computePrecisionRecall(actual)
+			f1 = computeF1(precision, recall)
+			requiredPassed = g.checkMatch(actual)
+		}
+		forbiddenViolations := g.findForbiddenViolations(actual)
+		if forbiddenViolations == nil {
+			forbiddenViolations = []string{}
+		}
+		forbiddenPassed := len(forbiddenViolations) == 0
 
 		// Adjust score based on allow_extra flag
 		score := f1
-		if !g.allowExtra && len(actual) > len(g.requiredSkills) {
+		if !g.allowExtra && len(g.requiredSkills) > 0 && len(actual) > len(g.requiredSkills) {
 			// Penalize extra invocations when not allowed
 			extraCount := len(actual) - len(g.requiredSkills)
 			penalty := float64(extraCount) / float64(len(actual))
 			score = f1 * (1.0 - penalty*0.6) // Reduce score by up to 60% for extras
 		}
+		if !forbiddenPassed {
+			score = 0.0
+		}
 
-		passed := g.checkMatch(actual)
+		passed := requiredPassed && forbiddenPassed
 
 		feedback := "Skill invocation sequence matched"
 		if !passed {
-			feedback = g.buildFailureFeedback(actual)
+			feedback = g.buildFailureFeedback(actual, requiredPassed, forbiddenViolations)
+		} else if len(g.requiredSkills) == 0 {
+			feedback = "Forbidden skills were not invoked"
 		} else if !g.allowExtra && len(actual) > len(g.requiredSkills) {
 			// Passed the match but has extra invocations when not allowed
 			feedback = fmt.Sprintf("Skill invocation sequence matched but had extra invocations (got %d, expected %d)", len(actual), len(g.requiredSkills))
@@ -95,13 +124,15 @@ func (g *skillInvocationGrader) Grade(ctx context.Context, gradingContext *Conte
 			Passed:   passed,
 			Feedback: feedback,
 			Details: map[string]any{
-				"mode":            string(g.matchingMode),
-				"required_skills": g.requiredSkills,
-				"actual_skills":   actual,
-				"allow_extra":     g.allowExtra,
-				"precision":       precision,
-				"recall":          recall,
-				"f1":              f1,
+				"mode":                 string(g.matchingMode),
+				"required_skills":      g.requiredSkills,
+				"forbidden_skills":     g.forbiddenSkills,
+				"forbidden_violations": forbiddenViolations,
+				"actual_skills":        actual,
+				"allow_extra":          g.allowExtra,
+				"precision":            precision,
+				"recall":               recall,
+				"f1":                   f1,
 			},
 		}, nil
 	})
@@ -109,6 +140,10 @@ func (g *skillInvocationGrader) Grade(ctx context.Context, gradingContext *Conte
 
 // checkMatch returns true if the actual sequence satisfies the matching mode constraint.
 func (g *skillInvocationGrader) checkMatch(actual []string) bool {
+	if len(g.requiredSkills) == 0 {
+		return true
+	}
+
 	switch g.matchingMode {
 	case models.SkillMatchingModeExact:
 		return g.exactMatch(actual)
@@ -207,40 +242,71 @@ func (g *skillInvocationGrader) computePrecisionRecall(actual []string) (precisi
 	return precision, recall
 }
 
-// buildFailureFeedback generates a human-readable explanation of why the match failed.
-func (g *skillInvocationGrader) buildFailureFeedback(actual []string) string {
-	var parts []string
-
-	switch g.matchingMode {
-	case models.SkillMatchingModeExact:
-		parts = append(parts, fmt.Sprintf("Exact match failed: expected %d skills %v, got %d skills %v",
-			len(g.requiredSkills), g.requiredSkills, len(actual), actual))
-	case models.SkillMatchingModeInOrder:
-		parts = append(parts, fmt.Sprintf("In-order match failed: not all required skills %v appeared in order within actual %v",
-			g.requiredSkills, actual))
-	case models.SkillMatchingModeAnyOrder:
-		// Identify which required skills are missing or insufficient
-		requiredCounts := make(map[string]int, len(g.requiredSkills))
-		for _, e := range g.requiredSkills {
-			requiredCounts[e]++
-		}
-		actualCounts := make(map[string]int, len(actual))
-		for _, a := range actual {
-			actualCounts[a]++
-		}
-		var missing []string
-		for skill, needed := range requiredCounts {
-			got := actualCounts[skill]
-			if got < needed {
-				missing = append(missing, fmt.Sprintf("%s (need %d, got %d)", skill, needed, got))
-			}
-		}
-		parts = append(parts, fmt.Sprintf("Any-order match failed: missing or insufficient skills: %s",
-			strings.Join(missing, ", ")))
+func (g *skillInvocationGrader) findForbiddenViolations(actual []string) []string {
+	if len(g.forbiddenSkills) == 0 || len(actual) == 0 {
+		return nil
 	}
 
-	if !g.allowExtra && len(actual) > len(g.requiredSkills) {
+	actualCounts := make(map[string]int, len(actual))
+	for _, a := range actual {
+		actualCounts[a]++
+	}
+
+	violations := make([]string, 0, len(g.forbiddenSkills))
+	seen := make(map[string]bool, len(g.forbiddenSkills))
+	for _, skill := range g.forbiddenSkills {
+		if actualCounts[skill] > 0 && !seen[skill] {
+			violations = append(violations, skill)
+			seen[skill] = true
+		}
+	}
+	return violations
+}
+
+// buildFailureFeedback generates a human-readable explanation of why the match failed.
+func (g *skillInvocationGrader) buildFailureFeedback(actual []string, requiredPassed bool, forbiddenViolations []string) string {
+	var parts []string
+
+	if len(g.requiredSkills) > 0 && !requiredPassed {
+		switch g.matchingMode {
+		case models.SkillMatchingModeExact:
+			parts = append(parts, fmt.Sprintf("Exact match failed: expected %d skills %v, got %d skills %v",
+				len(g.requiredSkills), g.requiredSkills, len(actual), actual))
+		case models.SkillMatchingModeInOrder:
+			parts = append(parts, fmt.Sprintf("In-order match failed: not all required skills %v appeared in order within actual %v",
+				g.requiredSkills, actual))
+		case models.SkillMatchingModeAnyOrder:
+			// Identify which required skills are missing or insufficient
+			requiredCounts := make(map[string]int, len(g.requiredSkills))
+			for _, e := range g.requiredSkills {
+				requiredCounts[e]++
+			}
+			actualCounts := make(map[string]int, len(actual))
+			for _, a := range actual {
+				actualCounts[a]++
+			}
+			var missing []string
+			for skill, needed := range requiredCounts {
+				got := actualCounts[skill]
+				if got < needed {
+					missing = append(missing, fmt.Sprintf("%s (need %d, got %d)", skill, needed, got))
+				}
+			}
+			parts = append(parts, fmt.Sprintf("Any-order match failed: missing or insufficient skills: %s",
+				strings.Join(missing, ", ")))
+		}
+	}
+
+	if len(g.requiredSkills) > 0 && !g.allowExtra && len(actual) > len(g.requiredSkills) {
 		parts = append(parts, fmt.Sprintf("Extra invocations not allowed (got %d, expected %d)", len(actual), len(g.requiredSkills)))
+	}
+
+	if len(forbiddenViolations) > 0 {
+		parts = append(parts, fmt.Sprintf("Forbidden skills invoked: %s", strings.Join(forbiddenViolations, ", ")))
+	}
+
+	if len(parts) == 0 {
+		return "Skill invocation constraints failed"
 	}
 
 	return strings.Join(parts, "; ")

--- a/internal/graders/skill_invocation_grader_test.go
+++ b/internal/graders/skill_invocation_grader_test.go
@@ -66,6 +66,25 @@ func TestSkillInvocationGraderParams_ConfigRoundTrip(t *testing.T) {
 		require.Equal(t, original, decoded)
 	})
 
+	t.Run("roundtrip_forbidden_skills", func(t *testing.T) {
+		original := models.SkillInvocationGraderParameters{
+			ForbiddenSkills: []string{"azure-deploy"},
+		}
+
+		raw, err := yaml.Marshal(original)
+		require.NoError(t, err)
+
+		config := map[string]any{}
+		require.NoError(t, yaml.Unmarshal(raw, &config))
+		require.Contains(t, config, "forbidden_skills")
+		require.NotContains(t, config, "required_skills")
+		require.NotContains(t, config, "mode")
+
+		var decoded models.SkillInvocationGraderParameters
+		require.NoError(t, yaml.Unmarshal(raw, &decoded))
+		require.Equal(t, original, decoded)
+	})
+
 	t.Run("roundtrip_empty_fields_omitted", func(t *testing.T) {
 		original := models.SkillInvocationGraderParameters{}
 
@@ -75,6 +94,7 @@ func TestSkillInvocationGraderParams_ConfigRoundTrip(t *testing.T) {
 		config := map[string]any{}
 		require.NoError(t, yaml.Unmarshal(raw, &config))
 		require.NotContains(t, config, "required_skills")
+		require.NotContains(t, config, "forbidden_skills")
 		require.NotContains(t, config, "mode")
 		require.NotContains(t, config, "allow_extra")
 
@@ -85,7 +105,7 @@ func TestSkillInvocationGraderParams_ConfigRoundTrip(t *testing.T) {
 }
 
 func TestSkillInvocationGrader_Constructor(t *testing.T) {
-	t.Run("no required_skills returns error", func(t *testing.T) {
+	t.Run("no skill constraints returns error", func(t *testing.T) {
 		_, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
 			Mode:           "exact_match",
 			RequiredSkills: nil,
@@ -93,7 +113,7 @@ func TestSkillInvocationGrader_Constructor(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("empty required_skills returns error", func(t *testing.T) {
+	t.Run("empty skill constraints returns error", func(t *testing.T) {
 		_, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
 			Mode:           "exact_match",
 			RequiredSkills: []string{},
@@ -146,6 +166,23 @@ func TestSkillInvocationGrader_Constructor(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.False(t, g.allowExtra)
+	})
+
+	t.Run("forbidden_skills only succeeds without mode", func(t *testing.T) {
+		g, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
+			ForbiddenSkills: []string{"skill1"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, g)
+		require.Equal(t, models.SkillMatchingModeAnyOrder, g.matchingMode)
+	})
+
+	t.Run("forbidden_skills only validates explicit mode", func(t *testing.T) {
+		_, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
+			Mode:            "invalid_mode",
+			ForbiddenSkills: []string{"skill1"},
+		})
+		require.Error(t, err)
 	})
 }
 
@@ -435,6 +472,105 @@ func TestSkillInvocationGrader_AllowExtra(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// forbidden_skills
+// ---------------------------------------------------------------------------
+
+func TestSkillInvocationGrader_ForbiddenSkills(t *testing.T) {
+	t.Run("forbidden-only passes with no invocations", func(t *testing.T) {
+		g, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
+			ForbiddenSkills: []string{"skill1"},
+		})
+		require.NoError(t, err)
+
+		result, err := g.Grade(context.Background(), &Context{
+			SkillInvocations: []execution.SkillInvocation{},
+		})
+		require.NoError(t, err)
+		require.True(t, result.Passed)
+		require.Equal(t, 1.0, result.Score)
+		require.Equal(t, []string{}, result.Details["forbidden_violations"])
+	})
+
+	t.Run("forbidden-only allows unrelated skills", func(t *testing.T) {
+		allowExtra := false
+		g, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
+			ForbiddenSkills: []string{"skill1"},
+			AllowExtra:      &allowExtra,
+		})
+		require.NoError(t, err)
+
+		result, err := g.Grade(context.Background(), &Context{
+			SkillInvocations: []execution.SkillInvocation{
+				{Name: "skill2"},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, result.Passed)
+		require.Equal(t, 1.0, result.Score)
+	})
+
+	t.Run("forbidden-only fails when forbidden skill appears", func(t *testing.T) {
+		g, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
+			ForbiddenSkills: []string{"skill1"},
+		})
+		require.NoError(t, err)
+
+		result, err := g.Grade(context.Background(), &Context{
+			SkillInvocations: []execution.SkillInvocation{
+				{Name: "skill1"},
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, result.Passed)
+		require.Equal(t, 0.0, result.Score)
+		require.Equal(t, []string{"skill1"}, result.Details["forbidden_violations"])
+		require.Contains(t, result.Feedback, "Forbidden skills invoked: skill1")
+	})
+
+	t.Run("mixed required and forbidden passes when required appears and forbidden is absent", func(t *testing.T) {
+		g, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
+			Mode:            "any_order",
+			RequiredSkills:  []string{"skill1"},
+			ForbiddenSkills: []string{"skill3"},
+		})
+		require.NoError(t, err)
+
+		result, err := g.Grade(context.Background(), &Context{
+			SkillInvocations: []execution.SkillInvocation{
+				{Name: "skill1"},
+				{Name: "skill2"},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, result.Passed)
+		require.Greater(t, result.Score, 0.0)
+		require.Equal(t, []string{}, result.Details["forbidden_violations"])
+	})
+
+	t.Run("mixed required and forbidden fails when forbidden appears", func(t *testing.T) {
+		g, err := NewSkillInvocationGrader("test", models.SkillInvocationGraderParameters{
+			Mode:            "any_order",
+			RequiredSkills:  []string{"skill1"},
+			ForbiddenSkills: []string{"skill3"},
+		})
+		require.NoError(t, err)
+
+		result, err := g.Grade(context.Background(), &Context{
+			SkillInvocations: []execution.SkillInvocation{
+				{Name: "skill1"},
+				{Name: "skill3"},
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, result.Passed)
+		require.Equal(t, 0.0, result.Score)
+		require.Equal(t, []string{"skill3"}, result.Details["forbidden_violations"])
+		require.Contains(t, result.Feedback, "Forbidden skills invoked: skill3")
+		require.NotContains(t, result.Feedback, "Any-order match failed")
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 
@@ -493,6 +629,8 @@ func TestSkillInvocationGrader_EdgeCases(t *testing.T) {
 
 		require.Contains(t, result.Details, "mode")
 		require.Contains(t, result.Details, "required_skills")
+		require.Contains(t, result.Details, "forbidden_skills")
+		require.Contains(t, result.Details, "forbidden_violations")
 		require.Contains(t, result.Details, "actual_skills")
 		require.Contains(t, result.Details, "allow_extra")
 		require.Contains(t, result.Details, "precision")

--- a/internal/models/grader_params.go
+++ b/internal/models/grader_params.go
@@ -97,9 +97,10 @@ const (
 )
 
 type SkillInvocationGraderParameters struct {
-	RequiredSkills []string                    `yaml:"required_skills,omitempty" json:"required_skills,omitempty"`
-	Mode           SkillInvocationMatchingMode `yaml:"mode,omitempty" json:"mode,omitempty"`
-	AllowExtra     *bool                       `yaml:"allow_extra,omitempty" json:"allow_extra,omitempty"`
+	RequiredSkills  []string                    `yaml:"required_skills,omitempty" json:"required_skills,omitempty"`
+	ForbiddenSkills []string                    `yaml:"forbidden_skills,omitempty" json:"forbidden_skills,omitempty"`
+	Mode            SkillInvocationMatchingMode `yaml:"mode,omitempty" json:"mode,omitempty"`
+	AllowExtra      *bool                       `yaml:"allow_extra,omitempty" json:"allow_extra,omitempty"`
 }
 
 // SkillInvocationMatchingMode controls how actual skill invocations are compared to expected skills.

--- a/internal/models/grader_validation_test.go
+++ b/internal/models/grader_validation_test.go
@@ -177,7 +177,7 @@ graders:
 			errorMsg:    "must have at least one action",
 		},
 		{
-			name: "skill_invocation grader with no required_skills",
+			name: "skill_invocation grader with no skill constraints",
 			specYAML: `name: test
 skill: test-skill
 config:
@@ -191,7 +191,25 @@ graders:
     config: {}
 `,
 			expectError: true,
-			errorMsg:    "must have at least one skill",
+			errorMsg:    "must have at least one skill in config.required_skills or config.forbidden_skills",
+		},
+		{
+			name: "skill_invocation grader with only forbidden_skills",
+			specYAML: `name: test
+skill: test-skill
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: test-model
+graders:
+  - name: "my grader"
+    type: "skill_invocation"
+    config:
+      forbidden_skills:
+        - forbidden-skill
+`,
+			expectError: false,
 		},
 		{
 			name: "tool_constraint grader with no expect_tools or reject_tools",
@@ -348,6 +366,35 @@ graders:
 `,
 			expectError: true,
 			errorMsg:    "must have at least one file",
+		},
+		{
+			name: "skill_invocation validator with no skill constraints",
+			taskYAML: `id: test-001
+name: Test Case
+inputs:
+  prompt: Test prompt
+graders:
+  - name: "my validator"
+    type: "skill_invocation"
+    config: {}
+`,
+			expectError: true,
+			errorMsg:    "must have at least one skill in config.required_skills or config.forbidden_skills",
+		},
+		{
+			name: "skill_invocation validator with only forbidden_skills",
+			taskYAML: `id: test-001
+name: Test Case
+inputs:
+  prompt: Test prompt
+graders:
+  - name: "my validator"
+    type: "skill_invocation"
+    config:
+      forbidden_skills:
+        - forbidden-skill
+`,
+			expectError: false,
 		},
 	}
 

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -177,8 +177,8 @@ func (g *GraderConfig) Validate() error {
 		if !ok {
 			return fmt.Errorf("skill_invocation grader %q: expected SkillInvocationGraderParameters, got %T", g.Identifier, g.Parameters)
 		}
-		if len(params.RequiredSkills) == 0 {
-			return fmt.Errorf("skill_invocation grader %q: must have at least one skill in config.required_skills", g.Identifier)
+		if len(params.RequiredSkills) == 0 && len(params.ForbiddenSkills) == 0 {
+			return fmt.Errorf("skill_invocation grader %q: must have at least one skill in config.required_skills or config.forbidden_skills", g.Identifier)
 		}
 
 	case GraderKindToolConstraint:

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -195,8 +195,8 @@ func (v *ValidatorInline) Validate() error {
 		if !ok {
 			return fmt.Errorf("skill_invocation grader %q: expected SkillInvocationGraderParameters, got %T", v.Identifier, v.Parameters)
 		}
-		if len(params.RequiredSkills) == 0 {
-			return fmt.Errorf("skill_invocation grader %q: must have at least one skill in config.required_skills", v.Identifier)
+		if len(params.RequiredSkills) == 0 && len(params.ForbiddenSkills) == 0 {
+			return fmt.Errorf("skill_invocation grader %q: must have at least one skill in config.required_skills or config.forbidden_skills", v.Identifier)
 		}
 
 	case GraderKindToolConstraint:

--- a/internal/suggest/prompt.go
+++ b/internal/suggest/prompt.go
@@ -112,7 +112,7 @@ func renderImplementationPrompt(data promptData, graderDocs string) string {
 	b.WriteString("- Ensure eval_yaml is valid waza EvalSpec YAML.\n")
 	b.WriteString("- Each grader entry MUST be an object with at least 'type' and 'name' fields. NEVER use bare strings like '- grader_name'. Always use '- name: grader_name' with a 'type' field.\n")
 	b.WriteString("- Include required config fields for each grader type (see grader documentation below).\n")
-	b.WriteString("- For skill_invocation graders, use config fields required_skills (list) and mode (exact_match, in_order, any_order).\n")
+	b.WriteString("- For skill_invocation graders, use required_skills + mode (exact_match, in_order, any_order) for positive checks, forbidden_skills for negative checks, or both together.\n")
 	b.WriteString("- Include at least 3 diverse tasks and at least 1 negative/anti-trigger task.\n")
 	b.WriteString("- Use grader types from the allowed list only.\n")
 	b.WriteString("- Keep task IDs deterministic and kebab-case.\n")

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -891,12 +891,49 @@
     },
     "skillInvocationGraderConfig": {
       "type": "object",
-      "required": [
-        "mode",
-        "required_skills"
-      ],
       "additionalProperties": false,
       "description": "Config for the skill invocation grader. Validates that specific skills were invoked during execution.",
+      "anyOf": [
+        {
+          "required": [
+            "required_skills"
+          ],
+          "properties": {
+            "required_skills": {
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "required": [
+            "forbidden_skills"
+          ],
+          "properties": {
+            "forbidden_skills": {
+              "minItems": 1
+            }
+          }
+        }
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "required_skills"
+            ],
+            "properties": {
+              "required_skills": {
+                "minItems": 1
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "mode"
+            ]
+          }
+        }
+      ],
       "properties": {
         "mode": {
           "type": "string",
@@ -905,20 +942,26 @@
             "in_order",
             "any_order"
           ],
-          "description": "How to compare actual skill invocations against expected."
+          "description": "How to compare actual skill invocations against expected required skills. Required when required_skills is set; ignored for forbidden-only configs."
         },
         "required_skills": {
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "string"
           },
           "description": "Skill names that must be invoked."
         },
+        "forbidden_skills": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Skill names that must not be invoked."
+        },
         "allow_extra": {
           "type": "boolean",
           "default": true,
-          "description": "When true, extra skill invocations beyond the required list are allowed."
+          "description": "When true, extra skill invocations beyond the required list are allowed. Ignored for forbidden-only configs."
         }
       }
     },

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -810,11 +810,48 @@
     },
     "skillInvocationGraderConfig": {
       "type": "object",
-      "required": [
-        "mode",
-        "required_skills"
-      ],
       "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "required_skills"
+          ],
+          "properties": {
+            "required_skills": {
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "required": [
+            "forbidden_skills"
+          ],
+          "properties": {
+            "forbidden_skills": {
+              "minItems": 1
+            }
+          }
+        }
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "required_skills"
+            ],
+            "properties": {
+              "required_skills": {
+                "minItems": 1
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "mode"
+            ]
+          }
+        }
+      ],
       "properties": {
         "mode": {
           "type": "string",
@@ -826,7 +863,12 @@
         },
         "required_skills": {
           "type": "array",
-          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "forbidden_skills": {
+          "type": "array",
           "items": {
             "type": "string"
           }

--- a/site/src/content/docs/guides/graders.mdx
+++ b/site/src/content/docs/guides/graders.mdx
@@ -432,7 +432,7 @@ Validates the sequence of tool calls the agent made against an expected action p
 
 ## Skill Invocation (`skill_invocation`)
 
-Validates which Copilot skills the agent invoked during a session. Useful for multi-skill orchestration testing — verifying the agent delegates to the right skills.
+Validates which Copilot skills the agent invoked during a session. Useful for multi-skill orchestration testing — verifying the agent delegates to the right skills, or that a specific skill was not invoked.
 
 ```yaml
 - type: skill_invocation
@@ -445,15 +445,29 @@ Validates which Copilot skills the agent invoked during a session. Useful for mu
     allow_extra: true
 ```
 
-| Option            | Type        | Default      | Description                                              |
-| ----------------- | ----------- | ------------ | -------------------------------------------------------- |
-| `required_skills` | `list[str]` | _(required)_ | Skills that must be invoked                              |
-| `mode`            | `string`    | _(required)_ | Matching mode: `exact_match`, `in_order`, or `any_order` |
-| `allow_extra`     | `bool`      | `true`       | Whether extra skill invocations are penalized            |
+| Option             | Type        | Default | Description                                                                     |
+| ------------------ | ----------- | ------- | ------------------------------------------------------------------------------- |
+| `required_skills`  | `list[str]` | `[]`    | Skills that must be invoked                                                     |
+| `forbidden_skills` | `list[str]` | `[]`    | Skills that must not be invoked                                                 |
+| `mode`             | `string`    | —       | Matching mode for `required_skills`: `exact_match`, `in_order`, or `any_order`  |
+| `allow_extra`      | `bool`      | `true`  | Whether extra skill invocations beyond `required_skills` are penalized          |
+
+At least one of `required_skills` or `forbidden_skills` must be non-empty. `mode` is required when `required_skills` is set and ignored for forbidden-only configs.
 
 When `allow_extra: false`, extra invocations beyond the required list reduce the score by up to 60%.
 
-**Scoring:** F1 score (precision × recall), with optional penalty for extra invocations.
+For forbidden-only configs, unrelated skill invocations are allowed and the grader scores `1.0` unless a forbidden skill appears. For mixed required and forbidden configs, forbidden skill use fails the grader with a score of `0.0`.
+
+```yaml
+- type: skill_invocation
+  name: no_prod_deploy
+  config:
+    forbidden_skills:
+      - azure-prod-deploy
+    allow_extra: true
+```
+
+**Scoring:** F1 score (precision × recall) for required skills, with optional penalty for extra invocations. Forbidden-only configs score `1.0` when all forbidden skills are absent and `0.0` when any are present.
 
 ---
 


### PR DESCRIPTION
Negative trigger evals need to assert that one specific skill was not invoked without rejecting unrelated skill use. This adds first-class `forbidden_skills` support to the `skill_invocation` grader so those checks can stay deterministic and scoped to the skill under test.

## Summary

- Add `forbidden_skills` to `SkillInvocationGraderParameters` and relax validation so either `required_skills` or `forbidden_skills` can define the grader.
- Preserve existing required-skill F1 scoring while failing with score `0.0` when a forbidden skill appears.
- Update eval/task JSON schemas, docs, and generator guidance for forbidden-only and mixed required+forbidden configs.
- Add regression coverage for forbidden-only pass/fail, mixed behavior, validation, details, and feedback.

## Review notes

This is a medium feature with schema and docs impact, so please have a squad member review before merging. `mode` remains required when `required_skills` is set, but forbidden-only configs can omit it because ordering is irrelevant.

## Validation

- `go test ./...`
- `make build`
- `make lint` (skipped by Makefile because `golangci-lint` is not installed)
- `cd site && npm ci --no-audit --no-fund && npm run build`
- `jq empty schemas/eval.schema.json schemas/task.schema.json`

Fixes: #286