### PR TITLE
Add skill body injection opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,18 @@ config:
 
 Instruction files are resolved from the active fixtures/context directory, copied into each task's temp workspace, and appended to the agent system message as path-labeled instructions. Task YAML files can also set top-level `instruction_files`; task-level entries are added to the eval-level list.
 
+### Skill Body Injection
+
+By default, an eval with `skill: <name>` injects the target `SKILL.md` or `.agent.md` body into the agent system prompt. For trigger-precision evals, disable that body injection while preserving the skill association and compact skill summary:
+
+```yaml
+skill: xyz
+config:
+  inject_skill_body: false
+```
+
+The skill remains discoverable through the `skill` tool and appears in `<available_skills>` as name and description only. `disabled_skills: ["*"]` still disables all skill loading.
+
 ### CSV Dataset Support
 
 Generate tasks dynamically from a CSV file using `tasks_from`:

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -274,7 +274,7 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	var systemMessageParts []string
 	if !req.NoSkills {
 		skillDirs = e.getSkillDirs(sourceDir, req)
-		if msg := buildSkillSystemMessage(skillDirs, req.SkillName); msg != "" {
+		if msg := buildSkillSystemMessage(skillDirs, req.SkillName, !req.SuppressSkillBody); msg != "" {
 			systemMessageParts = append(systemMessageParts, msg)
 		}
 	}
@@ -647,10 +647,11 @@ type skillDefinition struct {
 }
 
 // buildSkillSystemMessage scans skill directories for SKILL.md files and returns
-// a system message that tells the agent about available skills. For the target
-// skill (matching skillName), the full SKILL.md content is injected. For other
-// discovered skills, only a compact summary is included.
-func buildSkillSystemMessage(skillDirs []string, skillName string) string {
+// a system message that tells the agent about available skills. When
+// injectSkillBody is true, the target skill (matching skillName) also gets its
+// full definition injected. Other discovered skills always use compact summary
+// entries only.
+func buildSkillSystemMessage(skillDirs []string, skillName string, injectSkillBody bool) string {
 	var skills []skillDefinition
 
 	for _, dir := range skillDirs {
@@ -687,13 +688,15 @@ func buildSkillSystemMessage(skillDirs []string, skillName string) string {
 
 	var sb strings.Builder
 
-	// Inject full content for the target skill (first match only)
-	for _, s := range skills {
-		if skillName != "" && strings.EqualFold(s.Name, skillName) {
-			sb.WriteString("\n<skill_context>\n")
-			sb.WriteString(s.Content)
-			sb.WriteString("\n</skill_context>\n")
-			break
+	if injectSkillBody {
+		// Inject full content for the target skill (first match only)
+		for _, s := range skills {
+			if skillName != "" && strings.EqualFold(s.Name, skillName) {
+				sb.WriteString("\n<skill_context>\n")
+				sb.WriteString(s.Content)
+				sb.WriteString("\n</skill_context>\n")
+				break
+			}
 		}
 	}
 

--- a/internal/execution/copilot_test.go
+++ b/internal/execution/copilot_test.go
@@ -634,7 +634,7 @@ func TestCopilotCreateSession_InjectsSkillSystemMessage(t *testing.T) {
 	skillContent := "---\nname: test-skill\ndescription: A test\n---\n# Rules\nAlways greet"
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte(skillContent), 0644))
 
-	expectedSystemMsg := buildSkillSystemMessage([]string{sourceDir}, "test-skill")
+	expectedSystemMsg := buildSkillSystemMessage([]string{sourceDir}, "test-skill", true)
 	require.NotEmpty(t, expectedSystemMsg)
 
 	expectedConfig := sessionConfigMatcher{
@@ -693,7 +693,7 @@ func TestCopilotCreateSession_InjectsInstructionSystemMessage(t *testing.T) {
 		Content: []byte("Prefer small functions."),
 	}}
 	expectedSystemMsg := strings.Join([]string{
-		buildSkillSystemMessage([]string{sourceDir}, "test-skill"),
+		buildSkillSystemMessage([]string{sourceDir}, "test-skill", true),
 		buildInstructionSystemMessage(instructions),
 	}, "\n")
 	require.NotEmpty(t, expectedSystemMsg)
@@ -802,7 +802,7 @@ func TestCopilotResumeSession_PassesMCPServersAndSystemMessage(t *testing.T) {
 	skillContent := "---\nname: resume-skill\ndescription: Resume test\n---\nResume body"
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte(skillContent), 0644))
 
-	expectedSystemMsg := buildSkillSystemMessage([]string{sourceDir}, "resume-skill")
+	expectedSystemMsg := buildSkillSystemMessage([]string{sourceDir}, "resume-skill", true)
 
 	mcpServers := map[string]copilot.MCPServerConfig{
 		"mcp-srv": copilot.MCPStdioServerConfig{Command: "test"},

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -78,6 +78,9 @@ type ExecutionRequest struct {
 	SourceDir  string   // used when looking for workspace items via relative path, like skills.
 	SkillPaths []string // Directories to search for skills
 	NoSkills   bool     // When true, skip all skill loading
+	// SuppressSkillBody prevents full target skill content from being appended
+	// while still allowing skill discovery and compact summaries.
+	SuppressSkillBody bool
 
 	Timeout time.Duration
 

--- a/internal/execution/skill_injection_test.go
+++ b/internal/execution/skill_injection_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBuildSkillSystemMessage_NoSkills(t *testing.T) {
-	msg := buildSkillSystemMessage([]string{t.TempDir()}, "")
+	msg := buildSkillSystemMessage([]string{t.TempDir()}, "", true)
 	assert.Empty(t, msg)
 }
 
@@ -19,7 +19,7 @@ func TestBuildSkillSystemMessage_DirectSkillMD(t *testing.T) {
 	skillContent := "---\nname: test-skill\ndescription: A test skill\n---\n# Rules\nAlways say hello"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillContent), 0644))
 
-	msg := buildSkillSystemMessage([]string{dir}, "test-skill")
+	msg := buildSkillSystemMessage([]string{dir}, "test-skill", true)
 
 	// Should include full skill content for target skill
 	assert.Contains(t, msg, "<skill_context>")
@@ -33,6 +33,20 @@ func TestBuildSkillSystemMessage_DirectSkillMD(t *testing.T) {
 	assert.Contains(t, msg, "</available_skills>")
 }
 
+func TestBuildSkillSystemMessage_SuppressTargetSkillBody(t *testing.T) {
+	dir := t.TempDir()
+	skillContent := "---\nname: test-skill\ndescription: A test skill\n---\n# Rules\nAlways say hello"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillContent), 0644))
+
+	msg := buildSkillSystemMessage([]string{dir}, "test-skill", false)
+
+	assert.NotContains(t, msg, "<skill_context>")
+	assert.NotContains(t, msg, "Always say hello")
+	assert.Contains(t, msg, "<available_skills>")
+	assert.Contains(t, msg, "<name>test-skill</name>")
+	assert.Contains(t, msg, "<description>A test skill</description>")
+}
+
 func TestBuildSkillSystemMessage_NestedSkillMD(t *testing.T) {
 	root := t.TempDir()
 	skillDir := filepath.Join(root, "my-skill")
@@ -41,7 +55,7 @@ func TestBuildSkillSystemMessage_NestedSkillMD(t *testing.T) {
 	skillContent := "---\nname: nested-skill\ndescription: Nested\n---\nBody content"
 	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0644))
 
-	msg := buildSkillSystemMessage([]string{root}, "nested-skill")
+	msg := buildSkillSystemMessage([]string{root}, "nested-skill", true)
 
 	assert.Contains(t, msg, "<skill_context>")
 	assert.Contains(t, msg, "Body content")
@@ -54,7 +68,7 @@ func TestBuildSkillSystemMessage_NonTargetSkillSummaryOnly(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillContent), 0644))
 
 	// Target is different skill
-	msg := buildSkillSystemMessage([]string{dir}, "my-target-skill")
+	msg := buildSkillSystemMessage([]string{dir}, "my-target-skill", true)
 
 	// Should have summary but NOT full body
 	assert.Contains(t, msg, "<name>other-skill</name>")
@@ -66,7 +80,7 @@ func TestBuildSkillSystemMessage_NoFrontmatter_UsesDirectoryName(t *testing.T) {
 	skillContent := "# No frontmatter skill\nJust body."
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillContent), 0644))
 
-	msg := buildSkillSystemMessage([]string{dir}, "")
+	msg := buildSkillSystemMessage([]string{dir}, "", true)
 
 	assert.Contains(t, msg, "<available_skills>")
 	// Should use directory name as the skill name
@@ -86,7 +100,7 @@ func TestBuildSkillSystemMessage_SkipsHiddenAndVendor(t *testing.T) {
 	require.NoError(t, os.MkdirAll(vendor, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(vendor, "SKILL.md"), []byte("---\nname: vendored\n---\n"), 0644))
 
-	msg := buildSkillSystemMessage([]string{root}, "")
+	msg := buildSkillSystemMessage([]string{root}, "", true)
 	assert.Empty(t, msg)
 }
 

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -44,12 +44,19 @@ type Config struct {
 	ModelID          string         `yaml:"model" json:"model_id"`
 	SkillPaths       []string       `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
 	InstructionFiles []string       `yaml:"instruction_files,omitempty" json:"instruction_files,omitempty"`
+	InjectSkillBody  *bool          `yaml:"inject_skill_body,omitempty" json:"inject_skill_body,omitempty"`
 	DisabledSkills   []string       `yaml:"disabled_skills,omitempty" json:"disabled_skills,omitempty"`
 	RequiredSkills   []string       `yaml:"required_skills,omitempty" json:"required_skills,omitempty"`
 	ServerConfigs    map[string]any `yaml:"mcp_servers,omitempty" json:"server_configs,omitempty"`
 	MaxAttempts      int            `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty"`
 	GroupBy          string         `yaml:"group_by,omitempty" json:"group_by,omitempty"`
 	JudgeModel       string         `yaml:"judge_model,omitempty" json:"judge_model,omitempty"`
+}
+
+// ShouldInjectSkillBody returns true unless the eval explicitly opts out of
+// injecting the target skill body into the system prompt.
+func (c *Config) ShouldInjectSkillBody() bool {
+	return c.InjectSkillBody == nil || *c.InjectSkillBody
 }
 
 // GraderConfig defines a validator/grader

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -270,6 +270,63 @@ config:
 	if spec.Config.EngineType != "mock" {
 		t.Errorf("Expected engine='mock', got '%s'", spec.Config.EngineType)
 	}
+	if !spec.Config.ShouldInjectSkillBody() {
+		t.Error("Expected omitted inject_skill_body to default to true")
+	}
+}
+
+func TestEvalSpec_InjectSkillBodyDeserialization(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "explicit true",
+			yaml: `name: inject-true
+skill: test
+config:
+  trials_per_task: 1
+  timeout_seconds: 300
+  executor: mock
+  inject_skill_body: true
+`,
+			want: true,
+		},
+		{
+			name: "explicit false",
+			yaml: `name: inject-false
+skill: test
+config:
+  trials_per_task: 1
+  timeout_seconds: 300
+  executor: mock
+  inject_skill_body: false
+`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			specPath := filepath.Join(tempDir, "spec.yaml")
+			if err := os.WriteFile(specPath, []byte(tt.yaml), 0644); err != nil {
+				t.Fatalf("Failed to write spec file: %v", err)
+			}
+
+			spec, err := LoadEvalSpec(specPath)
+			if err != nil {
+				t.Fatalf("Failed to load spec: %v", err)
+			}
+			if spec.Config.InjectSkillBody == nil {
+				t.Fatal("Expected inject_skill_body pointer to be set")
+			}
+			if got := spec.Config.ShouldInjectSkillBody(); got != tt.want {
+				t.Errorf("ShouldInjectSkillBody() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestGraderConfig_EffectiveWeight(t *testing.T) {

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1175,17 +1175,18 @@ func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) (*execution.Exec
 	noSkills := spec.Config.AllSkillsDisabled()
 
 	return &execution.ExecutionRequest{
-		Message:         tc.Stimulus.Message,
-		Context:         tc.Stimulus.Metadata,
-		Resources:       resources,
-		Instructions:    instructions,
-		SkillName:       spec.SkillName,
-		TaskName:        tc.DisplayName,
-		TaskDescription: tc.Summary,
-		SkillPaths:      resolvedSkillPaths,
-		NoSkills:        noSkills,
-		Timeout:         time.Duration(timeout) * time.Second,
-		MCPServers:      convertMCPServers(spec.Config.ServerConfigs),
+		Message:           tc.Stimulus.Message,
+		Context:           tc.Stimulus.Metadata,
+		Resources:         resources,
+		Instructions:      instructions,
+		SkillName:         spec.SkillName,
+		TaskName:          tc.DisplayName,
+		TaskDescription:   tc.Summary,
+		SkillPaths:        resolvedSkillPaths,
+		NoSkills:          noSkills,
+		SuppressSkillBody: !spec.Config.ShouldInjectSkillBody(),
+		Timeout:           time.Duration(timeout) * time.Second,
+		MCPServers:        convertMCPServers(spec.Config.ServerConfigs),
 	}, nil
 }
 

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -146,6 +146,33 @@ func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 	assert.Equal(t, "my-skill", req.SkillName)
 	assert.Equal(t, float64(120), req.Timeout.Seconds())
 	assert.Equal(t, "value", req.Context["key"])
+	assert.False(t, req.SuppressSkillBody)
+}
+
+func TestBuildExecutionRequest_SuppressSkillBody(t *testing.T) {
+	injectSkillBody := false
+	spec := &models.EvalSpec{
+		SpecIdentity: models.SpecIdentity{Name: "test-benchmark"},
+		SkillName:    "my-skill",
+		Config: models.Config{
+			EngineType:      "mock",
+			ModelID:         "gpt-4",
+			TimeoutSec:      120,
+			InjectSkillBody: &injectSkillBody,
+		},
+	}
+
+	cfg := config.NewEvalConfig(spec)
+	runner := NewEvalRunner(cfg, nil)
+	req, err := runner.buildExecutionRequest(&models.TestCase{
+		TestID:      "test-001",
+		DisplayName: "Test Case",
+		Stimulus:    models.TaskStimulus{Message: "Hello world"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-skill", req.SkillName)
+	assert.True(t, req.SuppressSkillBody)
 }
 
 func TestBuildExecutionRequest_RejectsRelativePathPromptWithEmptySandbox(t *testing.T) {

--- a/internal/trigger/runner.go
+++ b/internal/trigger/runner.go
@@ -176,6 +176,7 @@ func (r *Runner) testTrigger(ctx context.Context, prompt string) (*execution.Exe
 		SkillName:               r.spec.Skill,
 		SkillPaths:              utils.ResolvePaths(spec.Config.FilteredSkillPaths(), r.cfg.SpecDir()),
 		NoSkills:                spec.Config.AllSkillsDisabled(),
+		SuppressSkillBody:       !spec.Config.ShouldInjectSkillBody(),
 		SourceDir:               r.cfg.SpecDir(),
 		Resources:               r.fixtures,
 		MCPServers:              r.mcpConfig,

--- a/internal/trigger/runner_test.go
+++ b/internal/trigger/runner_test.go
@@ -136,6 +136,7 @@ func (e *stubEngine) Execute(_ context.Context, req *execution.ExecutionRequest)
 }
 
 func TestEvalRunnerRunConfig(t *testing.T) {
+	injectSkillBody := false
 	spec := &TestSpec{
 		Skill: "my-skill",
 		ShouldTriggerPrompts: []TestPrompt{
@@ -148,8 +149,9 @@ func TestEvalRunnerRunConfig(t *testing.T) {
 		&models.EvalSpec{
 			SkillName: "my-skill",
 			Config: models.Config{
-				TimeoutSec: 120,
-				SkillPaths: []string{"skills/a", "skills/b"},
+				TimeoutSec:      120,
+				SkillPaths:      []string{"skills/a", "skills/b"},
+				InjectSkillBody: &injectSkillBody,
 			},
 		},
 		config.WithSpecDir("/base"),
@@ -163,6 +165,7 @@ func TestEvalRunnerRunConfig(t *testing.T) {
 	if len(engine.LastReq().SkillPaths) != 2 {
 		t.Errorf("SkillPaths = %v, want 2 entries", engine.LastReq().SkillPaths)
 	}
+	require.True(t, engine.LastReq().SuppressSkillBody)
 }
 
 type capturingEngine struct {

--- a/internal/validation/schema_test.go
+++ b/internal/validation/schema_test.go
@@ -78,6 +78,27 @@ tasks:
 	require.Empty(t, errs, "eval with instruction_files should have no errors")
 }
 
+func TestValidateEvalBytes_InjectSkillBody(t *testing.T) {
+	yaml := `name: test-eval
+skill: test-skill
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: gpt-4o
+  inject_skill_body: false
+metrics:
+  - name: accuracy
+    weight: 1.0
+    threshold: 0.8
+tasks:
+  - "tasks/*.yaml"
+`
+	errs := ValidateEvalBytes([]byte(yaml))
+	require.Empty(t, errs, "eval with inject_skill_body should have no errors")
+}
+
 func TestValidateEvalBytes_Invalid(t *testing.T) {
 	errs := ValidateEvalBytes([]byte(invalidEvalYAML))
 	require.NotEmpty(t, errs, "invalid eval should have errors")

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -171,6 +171,11 @@
           },
           "description": "Instruction files to apply to every task, resolved relative to the active context/fixtures directory."
         },
+        "inject_skill_body": {
+          "type": "boolean",
+          "default": true,
+          "description": "When false, do not inject the target SKILL.md or .agent.md body into the system prompt. Skill discovery and compact available_skills summaries remain enabled."
+        },
         "disabled_skills": {
           "type": "array",
           "items": {

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -98,6 +98,7 @@ config:
   model: claude-sonnet-4.6 # Default model (override with --model)
   judge_model: gpt-4o # Model for LLM-as-judge graders (optional)
   executor: mock # mock (local) or copilot-sdk (real API)
+  inject_skill_body: true # Inject target SKILL.md/.agent.md body into the prompt
   instruction_files:
     - .github/instructions/project.instructions.md
 ```
@@ -116,9 +117,39 @@ config:
 | `fail_fast`         | bool      | false             | Stop the entire run on first task failure                   |
 | `skill_directories` | list[str] | `[]`              | Additional directories to search for skills                 |
 | `instruction_files` | list[str] | `[]`              | Instruction files to apply to every task                    |
+| `inject_skill_body` | bool      | true              | Inject the target `SKILL.md` or `.agent.md` body into the system prompt |
 | `disabled_skills`   | list[str] | `[]`              | Skills to disable. Use `["*"]` to disable all skills        |
 | `required_skills`   | list[str] | `[]`              | Skills that must be available before running                |
 | `mcp_servers`       | object    | —                 | MCP server configurations for the evaluation                |
+
+### Trigger-precision evals
+
+Set `inject_skill_body: false` when the eval is measuring whether the agent invokes a skill rather than whether it can complete the work after already seeing the skill body:
+
+```yaml
+name: xyz-trigger
+description: Trigger-precision tasks for the xyz skill
+skill: xyz
+version: "1.0"
+
+config:
+  trials_per_task: 1
+  timeout_seconds: 300
+  parallel: false
+  executor: copilot-sdk
+  model: claude-sonnet-4.6
+  inject_skill_body: false
+
+metrics:
+  - name: trigger_precision
+    weight: 1.0
+    threshold: 0.8
+
+tasks:
+  - "tasks/trigger/*.yaml"
+```
+
+With this setting, Waza still discovers skills, passes them to the Copilot SDK, and includes the compact `<available_skills>` summary with skill names and descriptions. It only suppresses the full target `<skill_context>` body, so `behavior` graders with `required_tools` or `forbidden_tools` and `skill_invocation` graders can observe whether the `skill` tool was used. If you also set `disabled_skills: ["*"]`, all skill loading is disabled and this setting has no effect.
 
 **Common Timeouts:**
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -231,6 +231,20 @@ config:
     - .github/instructions/project.instructions.md
 ```
 
+### inject_skill_body
+
+**Type:** boolean
+**Default:** true
+
+Controls whether Waza injects the full target `SKILL.md` or `.agent.md` body into the system prompt when `skill:` is set.
+
+```yaml
+config:
+  inject_skill_body: false
+```
+
+When `false`, Waza keeps skill discovery enabled and still includes the compact `<available_skills>` summary with names and descriptions, but it does not add the target `<skill_context>` block. This is useful for trigger-precision evals that use `behavior` or `skill_invocation` graders to measure whether the agent actually invokes the `skill` tool. `disabled_skills: ["*"]` takes precedence and disables all skill loading.
+
 ### required_skills
 
 **Type:** list[string]  


### PR DESCRIPTION
Trigger-precision evals need to measure whether an agent invokes a skill, but the existing `skill:` path injected the full target skill body into the system prompt. This adds an explicit opt-out so evals can keep their skill association while requiring the agent to use the `skill` tool for the body.

## Summary

- Adds `config.inject_skill_body`, defaulting to true to preserve existing behavior.
- Threads the setting through normal eval execution and `waza trigger` so `false` suppresses only the target `<skill_context>` block.
- Keeps skill discovery, SDK skill directories, and compact `<available_skills>` summaries active unless skills are fully disabled.
- Updates schema, README, and docs site guidance for trigger-precision evals.

## Testing

- `go test ./...`
- `cd site && npm ci --silent && npm run build`

## Notes

This task was flagged as "needs review" because it touches medium-complexity CLI/execution behavior. Please have a squad member review before merging.

Fixes: #285