### PR TITLE
Add agent-friendly PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,66 @@
+## Summary
+
+<!-- 2-4 sentences: describe the bug, feature request, documentation gap, or task. -->
+
+## Type of issue
+
+- [ ] Bug
+- [ ] Feature request
+- [ ] Documentation
+- [ ] Maintenance
+- [ ] Question or investigation
+
+## Agent instructions
+
+<!-- Make this actionable for a coding agent. Include constraints, likely files, and what not to change. -->
+
+- Goal:
+- In scope:
+- Out of scope:
+- Likely files or areas:
+- Dependencies or related issues:
+
+## Current behavior
+
+<!-- What happens today? For bugs, include the actual result and error output if available. -->
+
+## Expected behavior
+
+<!-- What should happen instead? For feature requests, describe the desired outcome. -->
+
+## Steps to reproduce
+
+<!-- For bugs, provide the smallest reproducible example. Delete if not applicable. -->
+
+1.
+2.
+3.
+
+## Environment
+
+<!-- Fill in what you know. Delete fields that are not relevant. -->
+
+- OS:
+- Waza version or commit:
+- Go version:
+- Command run:
+
+## Acceptance criteria
+
+<!-- Use checkboxes so an agent can verify completion directly. -->
+
+- [ ]
+
+## Validation expectations
+
+<!-- List expected automated or manual checks, or say why validation is not applicable. -->
+
+- [ ] `go test ./...`
+- [ ] `make lint` or `golangci-lint run`
+- [ ] Docs site checked, if docs change
+- [ ] Web/dashboard checks run, if `web/` changes
+- [ ] Other:
+
+## Additional context
+
+<!-- Add links, screenshots, logs, related issues, or implementation notes. -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -57,7 +57,7 @@
 
 - [ ] `go test ./...`
 - [ ] `make lint` or `golangci-lint run`
-- [ ] Docs site checked, if docs change
+- [ ] Docs site checked, if docs changed
 - [ ] Web/dashboard checks run, if `web/` changes
 - [ ] Other:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+## Summary
+
+<!-- 2-4 sentences: what changed, why it changed, and the user-visible outcome. -->
+
+## Related issue
+
+<!-- Use "Closes #123", "Fixes #123", or "Related to #123" when applicable. -->
+
+## Agent handoff
+
+<!-- Keep this concrete so another human or agent can continue the work if needed. -->
+
+- Scope:
+- Key files changed:
+- Important decisions:
+- Follow-ups or known gaps:
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactor or maintenance
+- [ ] CI/CD or release change
+
+## Validation
+
+<!-- Check every command or manual check that applies. If skipped, explain why. -->
+
+- [ ] `go test ./...`
+- [ ] `make lint` or `golangci-lint run`
+- [ ] Docs site checked, if docs changed
+- [ ] Web/dashboard checks run, if `web/` changed
+- [ ] Manual validation completed:
+- [ ] Not applicable; reason:
+
+## Documentation
+
+- [ ] README updated, if user-facing behavior changed
+- [ ] `site/` docs updated, if CLI, YAML, dashboard, or validator behavior changed
+- [ ] Examples updated, if relevant
+- [ ] Not applicable
+
+## Risk and rollback
+
+<!-- Note compatibility risks, migration steps, or how to safely revert if needed. -->
+
+- Risk level: Low / Medium / High
+- Rollback plan:
+
+## Notes for reviewers
+
+<!-- Call out tradeoffs, risky areas, or specific files/logic reviewers should focus on. -->


### PR DESCRIPTION
## Summary

This adds lightweight GitHub templates so contributors and agents provide consistent context when opening issues and pull requests. The templates capture the why, scope, validation, documentation impact, and handoff details without introducing a heavy process.

## Related issue

N/A

## Agent handoff

- Scope: Adds repository-level PR and issue templates under `.github/`.
- Key files changed: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE.md`.
- Important decisions: Kept both templates simple but complete, with explicit agent-friendly fields for scope, likely files, acceptance criteria, validation, and known gaps.
- Follow-ups or known gaps: N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor or maintenance
- [ ] CI/CD or release change

## Validation

- [ ] `go test ./...`
- [ ] `make lint` or `golangci-lint run`
- [x] Docs site checked, if docs changed
- [ ] Web/dashboard checks run, if `web/` changed
- [x] Manual validation completed: checked Markdown formatting with `git diff --check`.
- [x] Not applicable; reason: code tests and web checks are not applicable because this only adds GitHub Markdown templates.

## Documentation

- [ ] README updated, if user-facing behavior changed
- [ ] `site/` docs updated, if CLI, YAML, dashboard, or validator behavior changed
- [ ] Examples updated, if relevant
- [x] Not applicable

## Risk and rollback

- Risk level: Low
- Rollback plan: Revert the template files if the repository prefers a different issue or PR intake format.

## Notes for reviewers

Please review whether the requested fields strike the right balance between agent-friendly handoff detail and keeping contributor friction low.