### PR TITLE
Fix installer latest release selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download and install the latest pre-built binary with the Bash install script on
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
-The Bash script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the binary, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable).
+The Bash script auto-detects the OS and architecture of the environment where Bash is running (linux/darwin/windows, amd64/arm64), downloads the latest standalone `waza` CLI release, verifies the checksum, and installs to `/usr/local/bin` (or `~/bin` if not writable).
 
 For native Windows PowerShell:
 
@@ -22,7 +22,7 @@ For native Windows PowerShell:
 irm https://raw.githubusercontent.com/microsoft/waza/main/install.ps1 | iex
 ```
 
-The PowerShell script downloads the native Windows binary, verifies the checksum, and installs to an existing `waza.exe` location or `%LOCALAPPDATA%\Microsoft\Waza`. On Windows, piping the Bash command from PowerShell may invoke WSL and install the Linux binary inside WSL.
+The PowerShell script downloads the latest standalone native Windows `waza` binary, verifies the checksum, and installs to an existing `waza.exe` location or `%LOCALAPPDATA%\Microsoft\Waza`. On Windows, piping the Bash command from PowerShell may invoke WSL and install the Linux binary inside WSL.
 
 Or browse the [GitHub Releases](https://github.com/microsoft/waza/releases) page and choose the standalone waza binary assets for the version you want.
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -31,7 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | ba
 
 The script auto-detects the environment where Bash is running. If you run this from PowerShell and `bash` resolves to WSL, it installs the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
-This downloads the latest release, verifies the checksum, and installs the `waza` binary to:
+This downloads the latest standalone `waza` CLI release, verifies the checksum, and installs the `waza` binary to:
 - `/usr/local/bin/waza` (if writable), or
 - `~/bin/waza` (if `/usr/local/bin` is not writable)
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -29,7 +29,7 @@ The fastest way to get started on macOS, Linux, or Windows Bash environments suc
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
-The script auto-detects the environment where Bash is running. If you run this from PowerShell and `bash` resolves to WSL, it installs the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+The script auto-detects the environment where Bash is running. If you run this from PowerShell and `bash` resolves to WSL, it installs the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the newest stable `vX.Y.Z` CLI release on the [Releases page](https://github.com/microsoft/waza/releases), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 This downloads the latest standalone `waza` CLI release, verifies the checksum, and installs the `waza` binary to:
 - `/usr/local/bin/waza` (if writable), or

--- a/install.ps1
+++ b/install.ps1
@@ -34,8 +34,9 @@ function Get-InstallDirectory {
 }
 
 function Get-LatestReleaseTag {
-    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ 'User-Agent' = 'waza-installer' }
-    if (-not $release -or -not ($release.tag_name -like 'v*')) {
+    $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=100" -Headers @{ 'User-Agent' = 'waza-installer' }
+    $release = $releases | Where-Object { $_.tag_name -match '^v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$' } | Select-Object -First 1
+    if (-not $release) {
         throw 'Could not determine latest release.'
     }
     return $release.tag_name

--- a/install.ps1
+++ b/install.ps1
@@ -34,12 +34,18 @@ function Get-InstallDirectory {
 }
 
 function Get-LatestReleaseTag {
-    $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=100" -Headers @{ 'User-Agent' = 'waza-installer' }
-    $release = $releases | Where-Object { $_.tag_name -match '^v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$' } | Select-Object -First 1
-    if (-not $release) {
-        throw 'Could not determine latest release.'
+    $page = 1
+    while ($true) {
+        $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=100&page=$page" -Headers @{ 'User-Agent' = 'waza-installer' }
+        $release = $releases | Where-Object { $_.tag_name -match '^v\d+\.\d+\.\d+$' } | Select-Object -First 1
+        if ($release) {
+            return $release.tag_name
+        }
+        if (-not $releases -or $releases.Count -eq 0) {
+            throw 'Could not determine latest release.'
+        }
+        $page++
     }
-    return $release.tag_name
 }
 
 function ConvertTo-SingleQuotedPowerShellLiteral([string] $Value) {

--- a/install.sh
+++ b/install.sh
@@ -62,9 +62,12 @@ main() {
     echo "For native Windows, download waza-windows-${arch}.exe from https://github.com/${REPO}/releases/latest."
   fi
 
-  # Get latest stable binary release tag.
-  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name": "v' | head -1 | cut -d'"' -f4)"
+  # Get latest stable CLI release tag. The repository also publishes azd
+  # extension releases, so scan releases and pick the first semver "vX.Y.Z" tag.
+  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" \
+    | grep -Eo '"tag_name"[[:space:]]*:[[:space:]]*"v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?"' \
+    | head -1 \
+    | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
 
   if [ -z "$tag" ]; then
     echo "Error: could not determine latest release." >&2

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,29 @@ install_dir() {
   fi
 }
 
+latest_release_tag() {
+  local page response tag
+  page=1
+
+  while true; do
+    response="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100&page=${page}")"
+    tag="$(printf '%s\n' "$response" \
+      | grep -Eo '"tag_name"[[:space:]]*:[[:space:]]*"v[0-9]+\.[0-9]+\.[0-9]+"' \
+      | head -1 \
+      | cut -d'"' -f4 || true)"
+
+    if [ -n "$tag" ]; then
+      echo "$tag"
+      return 0
+    fi
+    if ! printf '%s\n' "$response" | grep -q '"tag_name"'; then
+      return 1
+    fi
+
+    page=$((page + 1))
+  done
+}
+
 main() {
   local os arch version tag asset_name install_path
 
@@ -59,15 +82,12 @@ main() {
   echo "Detected platform: ${os}/${arch}"
   if [ "$os" = "linux" ] && is_wsl; then
     echo "Note: Detected WSL; installing the Linux binary inside WSL."
-    echo "For native Windows, download waza-windows-${arch}.exe from https://github.com/${REPO}/releases/latest."
+    echo "For native Windows, download waza-windows-${arch}.exe from the newest vX.Y.Z CLI release at https://github.com/${REPO}/releases."
   fi
 
   # Get latest stable CLI release tag. The repository also publishes azd
-  # extension releases, so scan releases and pick the first semver "vX.Y.Z" tag.
-  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" \
-    | grep -Eo '"tag_name"[[:space:]]*:[[:space:]]*"v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?"' \
-    | head -1 \
-    | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+  # extension releases, so scan releases and pick the first stable vX.Y.Z tag.
+  tag="$(latest_release_tag || true)"
 
   if [ -z "$tag" ]; then
     echo "Error: could not determine latest release." >&2

--- a/install_scripts_test.go
+++ b/install_scripts_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package waza_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInstallShSelectsFirstSemverReleaseTag(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash installer test uses POSIX shell helpers")
+	}
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	curlLog := filepath.Join(tempDir, "curl.log")
+	installLog := filepath.Join(tempDir, "install.log")
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), `#!/bin/sh
+case "$1" in
+  -s) echo Darwin ;;
+  -m) echo arm64 ;;
+  *) exit 2 ;;
+esac
+`)
+	writeExecutable(t, filepath.Join(binDir, "curl"), `#!/bin/sh
+out=""
+last=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  last="$1"
+  shift
+done
+echo "$last" >> "$CURL_LOG"
+case "$last" in
+  */releases?per_page=100)
+    printf '[{"tag_name":"azd-ext-microsoft-azd-waza_0.33.0"},{"tag_name":"v0.34.0"},{"tag_name":"v0.33.0"}]'
+    ;;
+  */releases/download/v0.34.0/waza-darwin-arm64)
+    printf 'binary' > "$out"
+    ;;
+  */releases/download/v0.34.0/checksums.txt)
+    printf 'abc  waza-darwin-arm64\n' > "$out"
+    ;;
+  *)
+    echo "unexpected curl URL: $last" >&2
+    exit 9
+    ;;
+esac
+`)
+	writeExecutable(t, filepath.Join(binDir, "shasum"), `#!/bin/sh
+cat >/dev/null
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "cp"), `#!/bin/sh
+echo "$@" >> "$INSTALL_LOG"
+`)
+	writeExecutable(t, filepath.Join(binDir, "chmod"), `#!/bin/sh
+exit 0
+`)
+
+	cmd := exec.Command(bashPath, "install.sh")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+tempDir,
+		"CURL_LOG="+curlLog,
+		"INSTALL_LOG="+installLog,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.sh failed: %v\n%s", err, output)
+	}
+
+	out := string(output)
+	if !strings.Contains(out, "Latest version: 0.34.0 (v0.34.0)") {
+		t.Fatalf("install.sh did not select CLI release tag; output:\n%s", out)
+	}
+	urls := readFile(t, curlLog)
+	if strings.Contains(urls, "/releases/latest") {
+		t.Fatalf("install.sh should not use /releases/latest; curl URLs:\n%s", urls)
+	}
+	if !strings.Contains(urls, "/releases/download/v0.34.0/waza-darwin-arm64") {
+		t.Fatalf("install.sh downloaded from wrong release; curl URLs:\n%s", urls)
+	}
+}
+
+func TestInstallPs1SelectsFirstSemverReleaseTag(t *testing.T) {
+	pwshPath, err := exec.LookPath("pwsh")
+	if err != nil {
+		t.Skip("pwsh not available")
+	}
+
+	script := readFile(t, "install.ps1")
+	start := strings.Index(script, "function Get-LatestReleaseTag {")
+	if start < 0 {
+		t.Fatal("Get-LatestReleaseTag function not found")
+	}
+	end := strings.Index(script[start:], "\nfunction ConvertTo-SingleQuotedPowerShellLiteral")
+	if end < 0 {
+		t.Fatal("could not find end of Get-LatestReleaseTag function")
+	}
+	functionBlock := script[start : start+end]
+
+	harness := `$ErrorActionPreference = 'Stop'
+$Repo = 'microsoft/waza'
+function Invoke-RestMethod {
+    param([string] $Uri, [hashtable] $Headers)
+    if ($Uri -ne 'https://api.github.com/repos/microsoft/waza/releases?per_page=100') {
+        throw "Unexpected releases URI: $Uri"
+    }
+    return @(
+        [pscustomobject]@{ tag_name = 'azd-ext-microsoft-azd-waza_0.33.0' },
+        [pscustomobject]@{ tag_name = 'v0.34.0' },
+        [pscustomobject]@{ tag_name = 'v0.33.0' }
+    )
+}
+` + functionBlock + `
+$tag = Get-LatestReleaseTag
+if ($tag -ne 'v0.34.0') {
+    throw "Expected v0.34.0, got $tag"
+}
+`
+	harnessPath := filepath.Join(t.TempDir(), "test-install.ps1")
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(pwshPath, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", harnessPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.ps1 release selection failed: %v\n%s", err, output)
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/install_scripts_test.go
+++ b/install_scripts_test.go
@@ -49,8 +49,11 @@ while [ "$#" -gt 0 ]; do
 done
 echo "$last" >> "$CURL_LOG"
 case "$last" in
-  */releases?per_page=100)
-    printf '[{"tag_name":"azd-ext-microsoft-azd-waza_0.33.0"},{"tag_name":"v0.34.0"},{"tag_name":"v0.33.0"}]'
+  *'/releases?per_page=100&page=1')
+    printf '[{"tag_name":"azd-ext-microsoft-azd-waza_0.33.0"},{"tag_name":"v0.35.0-rc.1"}]'
+    ;;
+  *'/releases?per_page=100&page=2')
+    printf '[{"tag_name":"v0.34.0"},{"tag_name":"v0.33.0"}]'
     ;;
   */releases/download/v0.34.0/waza-darwin-arm64)
     printf 'binary' > "$out"
@@ -121,14 +124,19 @@ func TestInstallPs1SelectsFirstSemverReleaseTag(t *testing.T) {
 $Repo = 'microsoft/waza'
 function Invoke-RestMethod {
     param([string] $Uri, [hashtable] $Headers)
-    if ($Uri -ne 'https://api.github.com/repos/microsoft/waza/releases?per_page=100') {
-        throw "Unexpected releases URI: $Uri"
+    if ($Uri -eq 'https://api.github.com/repos/microsoft/waza/releases?per_page=100&page=1') {
+        return @(
+            [pscustomobject]@{ tag_name = 'azd-ext-microsoft-azd-waza_0.33.0' },
+            [pscustomobject]@{ tag_name = 'v0.35.0-rc.1' }
+        )
     }
-    return @(
-        [pscustomobject]@{ tag_name = 'azd-ext-microsoft-azd-waza_0.33.0' },
-        [pscustomobject]@{ tag_name = 'v0.34.0' },
-        [pscustomobject]@{ tag_name = 'v0.33.0' }
-    )
+    if ($Uri -eq 'https://api.github.com/repos/microsoft/waza/releases?per_page=100&page=2') {
+        return @(
+            [pscustomobject]@{ tag_name = 'v0.34.0' },
+            [pscustomobject]@{ tag_name = 'v0.33.0' }
+        )
+    }
+    throw "Unexpected releases URI: $Uri"
 }
 ` + functionBlock + `
 $tag = Get-LatestReleaseTag

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -21,9 +21,9 @@ The fastest way to get started on macOS, Linux, or Windows Bash environments suc
 curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
 ```
 
-The script auto-detects the environment where Bash is running. If you run this from PowerShell and `bash` resolves to WSL, it installs the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+The script auto-detects the environment where Bash is running. If you run this from PowerShell and `bash` resolves to WSL, it installs the Linux binary inside WSL. For native Windows, download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the newest stable `vX.Y.Z` CLI release on the [Releases page](https://github.com/microsoft/waza/releases), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
-This downloads the latest release, verifies the checksum, and installs the `waza` binary to:
+This downloads the latest standalone `waza` CLI release, verifies the checksum, and installs the `waza` binary to:
 
 - `/usr/local/bin/waza` (if writable), or
 - `~/bin/waza` (if `/usr/local/bin` is not writable)
@@ -281,7 +281,7 @@ Opens http://localhost:3000. View runs, detailed results, comparisons, and trend
 
 ### Install script fails or binary not found
 
-If the install script exits with a download error or 404, check the [Releases page](https://github.com/microsoft/waza/releases/latest) to confirm a binary for your platform is available. You can also install manually:
+If the install script exits with a download error or 404, check the [Releases page](https://github.com/microsoft/waza/releases) to confirm a binary for your platform is available in the newest stable `vX.Y.Z` CLI release. You can also install manually:
 
 ```bash
 # Example: macOS ARM64 (Apple Silicon) — replace <version> with the latest tag (e.g. v0.34.0)

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -30,7 +30,7 @@ The Bash installer detects the environment where Bash is running. From PowerShel
 </TabItem>
 
 <TabItem label="Windows">
-Download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the [latest release](https://github.com/microsoft/waza/releases/latest), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+Download `waza-windows-amd64.exe` or `waza-windows-arm64.exe` from the newest stable `vX.Y.Z` CLI release on the [Releases page](https://github.com/microsoft/waza/releases), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 ```powershell
 waza --version

--- a/site/src/content/docs/reference/releases.mdx
+++ b/site/src/content/docs/reference/releases.mdx
@@ -66,7 +66,7 @@ On Windows, use this command only from Git Bash, MSYS2, or Cygwin. If PowerShell
 irm https://raw.githubusercontent.com/microsoft/waza/main/install.ps1 | iex
 ```
 
-The PowerShell installer downloads `waza-windows-amd64.exe` or `waza-windows-arm64.exe`, verifies the checksum, and installs `waza.exe`. You can also download the Windows binary from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.34.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+The installers choose the latest standalone `waza` CLI release, download the matching binary, verify the checksum, and install it. You can also download the Windows binary from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.34.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary
- Update Bash and PowerShell installers to scan GitHub releases and select the first standalone CLI semver tag (`vX.Y.Z`) instead of relying on `/releases/latest`.
- Add installer regression tests that ensure azd extension releases are skipped and the CLI release is used.
- Clarify install docs to describe standalone CLI release selection.

## Validation
- `go test ./...`
- `go vet ./...`
- `cd site && npm ci && npm run build`

Closes #296