### PR TITLE
fix: prevent Copilot CLI PATH fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ go build -o waza ./cmd/waza
 ./waza <waza command line>
 ```
 
+Waza bundles the GitHub Copilot CLI used by the `copilot-sdk` executor and extracts it to the local user cache on first use. Set `COPILOT_CLI_PATH` only when you need to force a specific Copilot CLI binary.
+
 ### Azure Developer CLI (azd) Extension
 
 Waza is also available as an [azd extension](https://learn.microsoft.com/azure/developer/azure-developer-cli/extensions/overview):

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -15,6 +15,8 @@ This guide explains how to run real integration tests using the GitHub Copilot S
    # Follow prompts to authenticate
    ```
 
+   Waza bundles the GitHub Copilot CLI used by the `copilot-sdk` executor and extracts it to the local user cache on first use. Set `COPILOT_CLI_PATH` only when you need to force a specific Copilot CLI binary.
+
 ## Configuration
 
 ### Eval Spec Configuration

--- a/internal/embedded/path.go
+++ b/internal/embedded/path.go
@@ -92,7 +92,7 @@ func writeEmbeddedCLI(finalPath string, expectedHash []byte) error {
 	h := sha256.New()
 	reader := cliReader()
 	if closer, ok := reader.(io.Closer); ok {
-		defer closer.Close()
+		defer func() { _ = closer.Close() }()
 	}
 	if _, err := io.Copy(tmp, io.TeeReader(reader, h)); err != nil {
 		_ = tmp.Close()
@@ -150,7 +150,7 @@ func writeEmbeddedCLILicense(cliPath string) error {
 func hashEmbeddedCLI() ([]byte, error) {
 	reader := cliReader()
 	if closer, ok := reader.(io.Closer); ok {
-		defer closer.Close()
+		defer func() { _ = closer.Close() }()
 	}
 	h := sha256.New()
 	if _, err := io.Copy(h, reader); err != nil {
@@ -164,7 +164,7 @@ func hashFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return nil, err

--- a/internal/embedded/path.go
+++ b/internal/embedded/path.go
@@ -1,0 +1,195 @@
+package embedded
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+const embeddedCLIVersion = "1.0.49"
+
+var pathOnce = sync.OnceValues(installEmbeddedCLI)
+
+// Path installs the embedded Copilot CLI, if needed, and returns its path.
+func Path() (string, error) {
+	return pathOnce()
+}
+
+func installEmbeddedCLI() (string, error) {
+	installDir, err := embeddedCLIInstallDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		return "", fmt.Errorf("creating embedded Copilot CLI install directory: %w", err)
+	}
+
+	finalPath := filepath.Join(installDir, embeddedCLIBinaryName())
+	expectedHash, err := hashEmbeddedCLI()
+	if err != nil {
+		return "", err
+	}
+
+	if existingHash, err := hashFile(finalPath); err == nil {
+		if bytes.Equal(existingHash, expectedHash) {
+			if err := writeEmbeddedCLILicense(finalPath); err != nil {
+				return "", err
+			}
+			return finalPath, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("checking existing embedded Copilot CLI: %w", err)
+	}
+
+	if err := writeEmbeddedCLI(finalPath, expectedHash); err != nil {
+		return "", err
+	}
+	if err := writeEmbeddedCLILicense(finalPath); err != nil {
+		return "", err
+	}
+	return finalPath, nil
+}
+
+func embeddedCLIInstallDir() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		cacheDir = os.TempDir()
+	}
+	if cacheDir == "" {
+		return "", fmt.Errorf("could not determine a cache directory for the embedded Copilot CLI")
+	}
+	return filepath.Join(cacheDir, "copilot-sdk"), nil
+}
+
+func embeddedCLIBinaryName() string {
+	ext := ""
+	if runtime.GOOS == "windows" {
+		ext = ".exe"
+	}
+	return fmt.Sprintf("copilot_%s%s", sanitizeVersion(embeddedCLIVersion), ext)
+}
+
+func writeEmbeddedCLI(finalPath string, expectedHash []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(finalPath), ".copilot-cli-*")
+	if err != nil {
+		return fmt.Errorf("creating temporary embedded Copilot CLI file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	h := sha256.New()
+	reader := cliReader()
+	if closer, ok := reader.(io.Closer); ok {
+		defer closer.Close()
+	}
+	if _, err := io.Copy(tmp, io.TeeReader(reader, h)); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing embedded Copilot CLI: %w", err)
+	}
+	if err := tmp.Chmod(0755); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("marking embedded Copilot CLI executable: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing embedded Copilot CLI file: %w", err)
+	}
+	if !bytes.Equal(h.Sum(nil), expectedHash) {
+		return fmt.Errorf("embedded Copilot CLI hash mismatch while writing")
+	}
+
+	if err := replaceFile(tmpPath, finalPath); err != nil {
+		return err
+	}
+	removeTmp = false
+	return nil
+}
+
+func replaceFile(src, dst string) error {
+	var err error
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		err = os.Rename(src, dst)
+		if err == nil {
+			return nil
+		}
+		if runtime.GOOS == "windows" {
+			_ = os.Remove(dst)
+			err = os.Rename(src, dst)
+			if err == nil {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("installing embedded Copilot CLI (file may be locked by antivirus or another process): %w", err)
+}
+
+func writeEmbeddedCLILicense(cliPath string) error {
+	if len(localEmbeddedCopilotCLILicense) == 0 {
+		return nil
+	}
+	if err := os.WriteFile(cliPath+".license", localEmbeddedCopilotCLILicense, 0644); err != nil {
+		return fmt.Errorf("writing embedded Copilot CLI license: %w", err)
+	}
+	return nil
+}
+
+func hashEmbeddedCLI() ([]byte, error) {
+	reader := cliReader()
+	if closer, ok := reader.(io.Closer); ok {
+		defer closer.Close()
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, reader); err != nil {
+		return nil, fmt.Errorf("hashing embedded Copilot CLI: %w", err)
+	}
+	return h.Sum(nil), nil
+}
+
+func hashFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+func sanitizeVersion(version string) string {
+	if version == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range version {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '.' || r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}

--- a/internal/embedded/path.go
+++ b/internal/embedded/path.go
@@ -1,3 +1,5 @@
+//go:build (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)) || (windows && (amd64 || arm64))
+
 package embedded
 
 import (

--- a/internal/embedded/path_unsupported.go
+++ b/internal/embedded/path_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !((linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)) || (windows && (amd64 || arm64)))
+
+package embedded
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Path reports that this platform does not have a bundled Copilot CLI.
+func Path() (string, error) {
+	return "", fmt.Errorf("embedded Copilot CLI is not bundled for %s/%s; set COPILOT_CLI_PATH to use an explicit GitHub Copilot CLI binary", runtime.GOOS, runtime.GOARCH)
+}

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -15,9 +15,6 @@ import (
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/skill"
 	"github.com/microsoft/waza/internal/utils"
-
-	// auto-loads the embedded copilot CLI, over using the copilot CLI on the machine.
-	_ "github.com/microsoft/waza/internal/embedded"
 )
 
 // CopilotEngine integrates with GitHub Copilot SDK

--- a/internal/execution/sdkclient.go
+++ b/internal/execution/sdkclient.go
@@ -54,7 +54,7 @@ func SharedClient(opts SharedClientOptions) CopilotClient {
 		}
 		clientOptions, err := sharedClientOptions(logLevel)
 		if err != nil {
-			slog.Warn("embedded Copilot CLI unavailable; refusing PATH fallback", "error", err)
+			slog.Warn("Copilot CLI path resolution failed; refusing PATH fallback", "error", err)
 			sharedClient = &startupErrorClient{err: err}
 			return
 		}

--- a/internal/execution/sdkclient.go
+++ b/internal/execution/sdkclient.go
@@ -2,9 +2,13 @@ package execution
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"os"
 	"sync"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/embedded"
 	"github.com/microsoft/waza/internal/utils"
 )
 
@@ -23,6 +27,7 @@ var (
 	sharedShutdown  sync.Once
 	sharedErr       error
 	sharedConstruct = newCopilotClient // overridable for tests
+	embeddedCLIPath = embedded.Path    // overridable for tests
 )
 
 // SharedClient returns a lazily-constructed, process-wide [CopilotClient].
@@ -47,13 +52,76 @@ func SharedClient(opts SharedClientOptions) CopilotClient {
 		if logLevel == "" {
 			logLevel = "error"
 		}
-		sharedClient = sharedConstruct(&copilot.ClientOptions{
-			LogLevel:    logLevel,
-			AutoStart:   utils.Ptr(false),
-			AutoRestart: utils.Ptr(true),
-		})
+		clientOptions, err := sharedClientOptions(logLevel)
+		if err != nil {
+			slog.Warn("embedded Copilot CLI unavailable; refusing PATH fallback", "error", err)
+			sharedClient = &startupErrorClient{err: err}
+			return
+		}
+		sharedClient = sharedConstruct(clientOptions)
 	})
 	return sharedClient
+}
+
+func sharedClientOptions(logLevel string) (*copilot.ClientOptions, error) {
+	opts := &copilot.ClientOptions{
+		LogLevel:    logLevel,
+		AutoStart:   utils.Ptr(false),
+		AutoRestart: utils.Ptr(true),
+	}
+
+	if cliPath := os.Getenv("COPILOT_CLI_PATH"); cliPath != "" {
+		info, err := os.Stat(cliPath)
+		if err != nil {
+			return nil, fmt.Errorf("COPILOT_CLI_PATH %q is not usable: %w", cliPath, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("COPILOT_CLI_PATH %q is not usable: path is a directory", cliPath)
+		}
+		opts.CLIPath = cliPath
+		slog.Info("using Copilot CLI", "source", "COPILOT_CLI_PATH", "path", cliPath)
+		return opts, nil
+	}
+
+	cliPath, err := embeddedCLIPath()
+	if err != nil {
+		return nil, fmt.Errorf("embedded Copilot CLI is unavailable and COPILOT_CLI_PATH is not set; refusing to fall back to PATH: %w", err)
+	}
+	opts.CLIPath = cliPath
+	slog.Info("using Copilot CLI", "source", "embedded", "path", cliPath)
+	return opts, nil
+}
+
+type startupErrorClient struct {
+	err error
+}
+
+func (c *startupErrorClient) CreateSession(context.Context, *copilot.SessionConfig) (CopilotSession, error) {
+	return nil, c.err
+}
+
+func (c *startupErrorClient) GetAuthStatus(context.Context) (*copilot.GetAuthStatusResponse, error) {
+	return nil, c.err
+}
+
+func (c *startupErrorClient) Start(context.Context) error {
+	return c.err
+}
+
+func (c *startupErrorClient) Stop() error {
+	return nil
+}
+
+func (c *startupErrorClient) ResumeSessionWithOptions(context.Context, string, *copilot.ResumeSessionConfig) (CopilotSession, error) {
+	return nil, c.err
+}
+
+func (c *startupErrorClient) DeleteSession(context.Context, string) error {
+	return c.err
+}
+
+func (c *startupErrorClient) ListModels(context.Context) ([]copilot.ModelInfo, error) {
+	return nil, c.err
 }
 
 // ShutdownSharedClient stops the underlying Copilot SDK process if a shared

--- a/internal/execution/sdkclient_test.go
+++ b/internal/execution/sdkclient_test.go
@@ -2,9 +2,14 @@ package execution
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/embedded"
 )
 
 // stubClient is a no-op CopilotClient used only to verify SharedClient
@@ -30,8 +35,11 @@ func (s *stubClient) ListModels(context.Context) ([]copilot.ModelInfo, error) {
 func TestSharedClient_ReturnsSameInstance(t *testing.T) {
 	resetSharedClientForTest()
 	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
 
 	stub := &stubClient{}
+	embeddedCLIPath = func() (string, error) { return "/tmp/embedded-copilot", nil }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
 	sharedConstruct = func(*copilot.ClientOptions) CopilotClient { return stub }
 	t.Cleanup(func() { sharedConstruct = newCopilotClient })
 
@@ -48,8 +56,11 @@ func TestSharedClient_ReturnsSameInstance(t *testing.T) {
 func TestShutdownSharedClient_Idempotent(t *testing.T) {
 	resetSharedClientForTest()
 	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
 
 	stub := &stubClient{}
+	embeddedCLIPath = func() (string, error) { return "/tmp/embedded-copilot", nil }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
 	sharedConstruct = func(*copilot.ClientOptions) CopilotClient { return stub }
 	t.Cleanup(func() { sharedConstruct = newCopilotClient })
 
@@ -77,8 +88,11 @@ func TestShutdownSharedClient_NoClientNeverConstructed(t *testing.T) {
 func TestShutdownSharedClient_BeforeConstructDoesNotPoisonShutdown(t *testing.T) {
 	resetSharedClientForTest()
 	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
 
 	stub := &stubClient{}
+	embeddedCLIPath = func() (string, error) { return "/tmp/embedded-copilot", nil }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
 	sharedConstruct = func(*copilot.ClientOptions) CopilotClient { return stub }
 	t.Cleanup(func() { sharedConstruct = newCopilotClient })
 
@@ -91,5 +105,117 @@ func TestShutdownSharedClient_BeforeConstructDoesNotPoisonShutdown(t *testing.T)
 	}
 	if stub.stops != 1 {
 		t.Fatalf("expected client Stop to be called once, got %d", stub.stops)
+	}
+}
+
+func TestSharedClient_UsesEmbeddedCLIPath(t *testing.T) {
+	resetSharedClientForTest()
+	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
+
+	embeddedCLIPath = func() (string, error) { return "/cache/copilot-sdk/copilot_1.0.49", nil }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
+
+	stub := &stubClient{}
+	var gotOptions *copilot.ClientOptions
+	sharedConstruct = func(opts *copilot.ClientOptions) CopilotClient {
+		gotOptions = opts
+		return stub
+	}
+	t.Cleanup(func() { sharedConstruct = newCopilotClient })
+
+	_ = SharedClient(SharedClientOptions{})
+	if gotOptions == nil {
+		t.Fatalf("expected shared client to be constructed")
+	}
+	if gotOptions.CLIPath != "/cache/copilot-sdk/copilot_1.0.49" {
+		t.Fatalf("expected embedded CLI path, got %q", gotOptions.CLIPath)
+	}
+}
+
+func TestSharedClient_UsesCOPILOTCLIPathOverride(t *testing.T) {
+	resetSharedClientForTest()
+	t.Cleanup(resetSharedClientForTest)
+
+	cliPath := filepath.Join(t.TempDir(), "copilot")
+	if err := os.WriteFile(cliPath, []byte("fake"), 0755); err != nil {
+		t.Fatalf("write fake cli: %v", err)
+	}
+	t.Setenv("COPILOT_CLI_PATH", cliPath)
+
+	embeddedCLIPath = func() (string, error) {
+		t.Fatalf("embedded CLI should not be installed when COPILOT_CLI_PATH is set")
+		return "", nil
+	}
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
+
+	stub := &stubClient{}
+	var gotOptions *copilot.ClientOptions
+	sharedConstruct = func(opts *copilot.ClientOptions) CopilotClient {
+		gotOptions = opts
+		return stub
+	}
+	t.Cleanup(func() { sharedConstruct = newCopilotClient })
+
+	_ = SharedClient(SharedClientOptions{})
+	if gotOptions == nil {
+		t.Fatalf("expected shared client to be constructed")
+	}
+	if gotOptions.CLIPath != cliPath {
+		t.Fatalf("expected COPILOT_CLI_PATH override, got %q", gotOptions.CLIPath)
+	}
+}
+
+func TestSharedClient_InvalidCOPILOTCLIPathReturnsStartupError(t *testing.T) {
+	resetSharedClientForTest()
+	t.Cleanup(resetSharedClientForTest)
+
+	cliPath := filepath.Join(t.TempDir(), "missing-copilot")
+	t.Setenv("COPILOT_CLI_PATH", cliPath)
+
+	embeddedCLIPath = func() (string, error) {
+		t.Fatalf("embedded CLI should not be installed when COPILOT_CLI_PATH is invalid")
+		return "", nil
+	}
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
+	sharedConstruct = func(*copilot.ClientOptions) CopilotClient {
+		t.Fatalf("SDK client should not be constructed with an invalid COPILOT_CLI_PATH")
+		return nil
+	}
+	t.Cleanup(func() { sharedConstruct = newCopilotClient })
+
+	client := SharedClient(SharedClientOptions{})
+	err := client.Start(context.Background())
+	if err == nil {
+		t.Fatalf("expected startup error")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing file error, got %v", err)
+	}
+}
+
+func TestSharedClient_EmbeddedInstallFailureReturnsStartupError(t *testing.T) {
+	resetSharedClientForTest()
+	t.Cleanup(resetSharedClientForTest)
+	t.Setenv("COPILOT_CLI_PATH", "")
+
+	embeddedCLIPath = func() (string, error) { return "", errors.New("install failed") }
+	t.Cleanup(func() { embeddedCLIPath = embedded.Path })
+	sharedConstruct = func(*copilot.ClientOptions) CopilotClient {
+		t.Fatalf("SDK client should not be constructed when embedded install fails")
+		return nil
+	}
+	t.Cleanup(func() { sharedConstruct = newCopilotClient })
+
+	client := SharedClient(SharedClientOptions{})
+	err := client.Start(context.Background())
+	if err == nil {
+		t.Fatalf("expected startup error")
+	}
+	if got := err.Error(); !strings.Contains(got, "refusing to fall back to PATH") || !strings.Contains(got, "install failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ShutdownSharedClient(context.Background()); err != nil {
+		t.Fatalf("startup error client shutdown should be a no-op, got %v", err)
 	}
 }

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -68,6 +68,8 @@ copilot login
 
 This opens your browser to authenticate. After login, you're ready to go.
 
+Waza bundles the GitHub Copilot CLI used by the `copilot-sdk` executor and extracts it to the local user cache on first use. Set `COPILOT_CLI_PATH` only when you need to force a specific Copilot CLI binary.
+
 <Aside type="note" title="Custom Provider">
 If your Copilot SDK setup uses a custom provider, set `COPILOT_BASE_URL` or `COPILOT_PROVIDER_BASE_URL` instead. Waza will pass the provider configuration to the SDK and skip the default Copilot auth check.
 </Aside>

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -977,6 +977,7 @@ A newer version of waza is available: v0.24.0 → v0.28.0. Run: curl -fsSL ... |
 | Variable | Description |
 |----------|-------------|
 | `GITHUB_TOKEN` | Token for Copilot SDK execution |
+| `COPILOT_CLI_PATH` | Explicit path to a GitHub Copilot CLI binary. When unset, Waza uses its bundled CLI and does not fall back to an unrelated `copilot` on `PATH`. |
 | `COPILOT_BASE_URL` / `COPILOT_PROVIDER_BASE_URL` | Custom Copilot SDK provider endpoint. When set, Waza skips the default Copilot auth check and passes provider config to the SDK. |
 | `COPILOT_PROVIDER` / `COPILOT_PROVIDER_TYPE` | Provider type passed through to the Copilot SDK. |
 | `COPILOT_WIRE_API` / `COPILOT_PROVIDER_WIRE_API` | Wire format passed through to the Copilot SDK, for example `responses` or `completions`, depending on provider. |


### PR DESCRIPTION
## Summary
- install and resolve Waza's embedded Copilot CLI before constructing the shared SDK client
- refuse to fall back to an unrelated `copilot` on `PATH` when embedded extraction fails
- validate `COPILOT_CLI_PATH` overrides and document the bundled CLI behavior

Closes #297

## Validation
- `go test ./...`
- `cd site && npm run build -- --silent`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/embedded -o /tmp/waza-embedded-windows-amd64.test.exe`
- `GOOS=windows GOARCH=arm64 go test -c ./internal/embedded -o /tmp/waza-embedded-windows-arm64.test.exe`