### PR TITLE
fix: skip --model CLI startup arg when BYOK provider is configured (#305)

### DIFF
--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -168,7 +168,8 @@ type CopilotEngineBuilderOptions struct {
 func NewCopilotEngineBuilder(defaultModelID string, options *CopilotEngineBuilderOptions) *CopilotEngineBuilder {
 	var client CopilotClient
 	ownsClient := false
-	cliArgs := modelCLIArgs(defaultModelID)
+	provider := providerFromEnv()
+	cliArgs := modelCLIArgs(defaultModelID, provider.enabled())
 
 	if options == nil || options.NewCopilotClient == nil {
 		// Production: share one SDK process across all engines + graders.
@@ -191,7 +192,7 @@ func NewCopilotEngineBuilder(defaultModelID string, options *CopilotEngineBuilde
 		engine: &CopilotEngine{
 			defaultModelID: defaultModelID,
 			ownsClient:     ownsClient,
-			provider:       providerFromEnv(),
+			provider:       provider,
 		},
 	}
 
@@ -199,8 +200,20 @@ func NewCopilotEngineBuilder(defaultModelID string, options *CopilotEngineBuilde
 	return builder
 }
 
-func modelCLIArgs(defaultModelID string) []string {
-	if defaultModelID == "" {
+// modelCLIArgs returns the startup CLI args needed to pin the embedded
+// Copilot CLI to defaultModelID, or an empty slice when no pinning should
+// occur.
+//
+// When customProvider is true (a BYOK provider is configured via
+// COPILOT_BASE_URL / COPILOT_PROVIDER_BASE_URL), we deliberately omit
+// --model: the Copilot CLI validates the startup --model against the
+// GitHub Copilot catalog before per-session ProviderConfig is applied, so
+// provider-only model IDs (e.g. minimax-m2.7) would fail startup with
+// `Model "..." is not available`. The per-session SessionConfig.Model +
+// SessionConfig.Provider passed in Execute still selects the right model
+// against the custom provider. See #305.
+func modelCLIArgs(defaultModelID string, customProvider bool) []string {
+	if defaultModelID == "" || customProvider {
 		return []string{}
 	}
 	// --model forces the configured model at CLI startup, overriding any

--- a/internal/execution/copilot_engine_test.go
+++ b/internal/execution/copilot_engine_test.go
@@ -428,6 +428,15 @@ func clearCustomProviderEnv(t *testing.T) {
 		"COPILOT_API_KEY", "COPILOT_PROVIDER_API_KEY",
 		"COPILOT_BEARER_TOKEN", "COPILOT_PROVIDER_BEARER_TOKEN",
 	} {
-		t.Setenv(name, "")
+		name := name // capture loop variable
+		prev, existed := os.LookupEnv(name)
+		os.Unsetenv(name)
+		t.Cleanup(func() {
+			if existed {
+				os.Setenv(name, prev)
+			} else {
+				os.Unsetenv(name)
+			}
+		})
 	}
 }

--- a/internal/execution/copilot_engine_test.go
+++ b/internal/execution/copilot_engine_test.go
@@ -430,12 +430,12 @@ func clearCustomProviderEnv(t *testing.T) {
 	} {
 		name := name // capture loop variable
 		prev, existed := os.LookupEnv(name)
-		os.Unsetenv(name)
+		_ = os.Unsetenv(name)
 		t.Cleanup(func() {
 			if existed {
-				os.Setenv(name, prev)
+				_ = os.Setenv(name, prev)
 			} else {
-				os.Unsetenv(name)
+				_ = os.Unsetenv(name)
 			}
 		})
 	}

--- a/internal/execution/copilot_engine_test.go
+++ b/internal/execution/copilot_engine_test.go
@@ -336,6 +336,7 @@ func TestCopilotEngine_Shutdown_StopsClientAndCleansWorkspaces(t *testing.T) {
 // SessionConfig.Model is silently ignored by the embedded CLI and evals run
 // against the wrong model.
 func TestCopilotEngineBuilder_CLIArgsCarriesModel(t *testing.T) {
+	clearCustomProviderEnv(t)
 	ctrl := gomock.NewController(t)
 	clientMock := NewMockCopilotClient(ctrl)
 
@@ -359,6 +360,7 @@ func TestCopilotEngineBuilder_CLIArgsCarriesModel(t *testing.T) {
 // is configured. This preserves the embedded CLI's own fallback model selection
 // (settings.json / experiment flights) for callers that explicitly opt out.
 func TestCopilotEngineBuilder_CLIArgsEmptyWhenNoDefaultModel(t *testing.T) {
+	clearCustomProviderEnv(t)
 	ctrl := gomock.NewController(t)
 	clientMock := NewMockCopilotClient(ctrl)
 
@@ -373,4 +375,59 @@ func TestCopilotEngineBuilder_CLIArgsEmptyWhenNoDefaultModel(t *testing.T) {
 	require.NotNil(t, captured, "NewCopilotClient must receive non-nil ClientOptions")
 	require.Empty(t, captured.CLIArgs,
 		"CLIArgs must be empty when no defaultModelID is provided so the embedded CLI can pick its own fallback")
+}
+
+// TestCopilotEngineBuilder_CLIArgsEmptyWhenCustomProvider is a regression test
+// for #305: when a BYOK / custom provider is configured via environment
+// variables, the embedded Copilot CLI must NOT receive --model at startup.
+// The Copilot CLI validates the startup --model against the GitHub Copilot
+// catalog before the per-session ProviderConfig is applied, so passing a
+// provider-only model ID (e.g. "minimax-m2.7") causes startup to fail with
+// `Model "..." is not available`. SessionConfig.Model + SessionConfig.Provider
+// passed in Execute still select the right model against the custom provider.
+func TestCopilotEngineBuilder_CLIArgsEmptyWhenCustomProvider(t *testing.T) {
+	clearCustomProviderEnv(t)
+	t.Setenv("COPILOT_BASE_URL", "https://api.example.com/v1")
+	t.Setenv("COPILOT_PROVIDER", "openai")
+	t.Setenv("COPILOT_API_KEY", "test-key")
+
+	ctrl := gomock.NewController(t)
+	clientMock := NewMockCopilotClient(ctrl)
+
+	const defaultModelID = "minimax-m2.7"
+
+	var captured *copilot.ClientOptions
+	engine := NewCopilotEngineBuilder(defaultModelID, &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(clientOptions *copilot.ClientOptions) CopilotClient {
+			captured = clientOptions
+			return clientMock
+		},
+	}).Build()
+
+	require.NotNil(t, captured, "NewCopilotClient must receive non-nil ClientOptions")
+	require.Empty(t, captured.CLIArgs,
+		"CLIArgs must be empty when a custom BYOK provider is configured so the embedded CLI does not pre-validate a provider-only model ID against the GitHub Copilot catalog (#305)")
+
+	// The engine should still know the defaultModelID and provider for
+	// per-session SessionConfig assembly.
+	require.Equal(t, defaultModelID, engine.defaultModelID,
+		"defaultModelID must still be retained on the engine so Execute can apply it via SessionConfig.Model")
+	require.True(t, engine.provider.enabled(),
+		"custom provider must be detected from env and retained for per-session ProviderConfig")
+}
+
+// clearCustomProviderEnv unsets every COPILOT_* variable that
+// providerFromEnv() reads so the surrounding shell cannot influence
+// CLIArgs assertions.
+func clearCustomProviderEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"COPILOT_BASE_URL", "COPILOT_PROVIDER_BASE_URL",
+		"COPILOT_PROVIDER", "COPILOT_PROVIDER_TYPE",
+		"COPILOT_WIRE_API", "COPILOT_PROVIDER_WIRE_API",
+		"COPILOT_API_KEY", "COPILOT_PROVIDER_API_KEY",
+		"COPILOT_BEARER_TOKEN", "COPILOT_PROVIDER_BEARER_TOKEN",
+	} {
+		t.Setenv(name, "")
+	}
 }


### PR DESCRIPTION
Closes #305

## Problem

PR #263 added `--model <defaultModelID>` to `copilot.ClientOptions.CLIArgs`
so the embedded Copilot CLI honors the eval-configured model. However, the
Copilot CLI validates that startup `--model` against the GitHub Copilot
catalog **before** the per-session `ProviderConfig` (from PR #240) is
applied. For BYOK / custom provider model IDs that are not in the Copilot
catalog (e.g. `minimax-m2.7`), startup fails with:

```
failed to create session: failed to create session: JSON-RPC Error -32603:
Request session.create failed with message: Model "minimax-m2.7" is not available.
```

even though the same model works fine when supplied as
`SessionConfig.Model` with `SessionConfig.Provider`.

## Fix

Suppress the startup `--model` arg whenever `providerFromEnv()` reports
an enabled custom provider. `SessionConfig.Model` + `SessionConfig.Provider`
are still passed per session via `Execute`, so the SDK selects the right
model against the custom provider without pre-validating against the
GitHub catalog. Normal GitHub Copilot models retain the #263 startup
override behavior.

| `defaultModelID` | BYOK env set | `CLIArgs` |
|------------------|--------------|-----------|
| `""`             | no           | `[]` |
| `"claude-..."`   | no           | `["--model","claude-..."]` |
| `"minimax-..."`  | **yes**      | `[]` ✨ |
| `""`             | yes          | `[]` |

## Changes

- `internal/execution/copilot.go` — compute `providerFromEnv()` once
  before `cliArgs`, extend `modelCLIArgs` to accept a `customProvider bool`
  and skip `--model` when true. Reuse the same provider for
  `engine.provider` (avoids reading env vars twice).
- `internal/execution/copilot_engine_test.go` — adds
  `TestCopilotEngineBuilder_CLIArgsEmptyWhenCustomProvider` as the
  regression test for #305. Hardens the existing two `CLIArgs` tests by
  explicitly clearing all `COPILOT_*` BYOK env vars so they stay
  deterministic regardless of the surrounding shell.

## Validation

- `go test ./... -count=1` — all packages pass
- `go vet ./...` — clean
- `make lint` — golangci-lint not installed locally; CI will run it