### PR TITLE
fix(graders): make prompt-grader timeout configurable via WAZA_PROMPT_GRADER_TIMEOUT

### DIFF
--- a/docs/graders/prompt.md
+++ b/docs/graders/prompt.md
@@ -22,6 +22,14 @@ Uses a language model to evaluate skill execution quality via an explicit grader
 | `model` | string | Model to use for the judge session |
 | `continue_session` | bool | Reuse the task session context by session ID (default: `false`) |
 
+**Timeout:**
+
+Each judge send waits up to **120s** for the session to finish (reach `session.idle`). Long multi-turn judge sessions can need more, so the budget is overridable with the `WAZA_PROMPT_GRADER_TIMEOUT` environment variable. It accepts a Go duration (`5m`, `300s`) or a bare number of seconds (`300`); empty, invalid, zero, or negative values keep the 120s default.
+
+```bash
+WAZA_PROMPT_GRADER_TIMEOUT=5m waza run eval.yaml --context-dir fixtures
+```
+
 **Result semantics:**
 
 - The judge should call `set_waza_grade_pass` and/or `set_waza_grade_fail`.

--- a/internal/graders/prompt_grader.go
+++ b/internal/graders/prompt_grader.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,7 +19,43 @@ import (
 const AllPromptsPassed = "All prompts passed"
 const wazaPassToolName = "set_waza_grade_pass"
 const wazaFailToolName = "set_waza_grade_fail"
-const promptGraderTimeout = 120 * time.Second
+
+// defaultPromptGraderTimeout bounds how long a single prompt-grader send waits
+// for the judge session to reach session.idle (see Session.SendAndWait). Heavy
+// multi-turn judge sessions — e.g. a long lifecycle transcript graded by a cheap
+// model — can need longer than this to settle, so the value is overridable via
+// promptGraderTimeoutEnv.
+const defaultPromptGraderTimeout = 120 * time.Second
+
+// promptGraderTimeoutEnv overrides defaultPromptGraderTimeout. Accepts a Go
+// duration string ("5m", "300s") or a bare integer number of seconds ("300").
+const promptGraderTimeoutEnv = "WAZA_PROMPT_GRADER_TIMEOUT"
+
+// resolvePromptGraderTimeout returns the prompt-grader send timeout, honoring the
+// promptGraderTimeoutEnv override when it parses to a positive duration. Empty,
+// invalid, zero, or negative values fall back to defaultPromptGraderTimeout so a
+// misconfiguration can never disable the timeout entirely.
+func resolvePromptGraderTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(promptGraderTimeoutEnv))
+	if raw == "" {
+		return defaultPromptGraderTimeout
+	}
+	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+		return d
+	}
+	if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+		// Guard against int64 overflow: secs * time.Second wraps negative for
+		// absurdly large values, which would make context.WithTimeout produce an
+		// already-expired context — the very "context deadline exceeded" failure
+		// this timeout exists to avoid. Reject and fall back to the default.
+		if d := time.Duration(secs) * time.Second; d > 0 {
+			return d
+		}
+	}
+	slog.Warn("ignoring invalid "+promptGraderTimeoutEnv+", using default",
+		"value", raw, "default", defaultPromptGraderTimeout)
+	return defaultPromptGraderTimeout
+}
 
 type promptGrader struct {
 	args models.PromptGraderParameters
@@ -147,7 +185,7 @@ func executePromptGrader(ctx context.Context, gradingContext *Context, req *exec
 	if gradingContext.Executor == nil {
 		return nil, errors.New("prompt grader requires an execution engine")
 	}
-	execCtx, cancel := context.WithTimeout(ctx, promptGraderTimeout)
+	execCtx, cancel := context.WithTimeout(ctx, resolvePromptGraderTimeout())
 	defer cancel()
 	return gradingContext.Executor.Execute(execCtx, req)
 }

--- a/internal/graders/prompt_grader_test.go
+++ b/internal/graders/prompt_grader_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/copilotevents"
@@ -499,4 +500,29 @@ type fakePromptExecutor struct {
 func (f *fakePromptExecutor) Execute(ctx context.Context, req *execution.ExecutionRequest) (*execution.ExecutionResponse, error) {
 	f.calls++
 	return f.execute(req)
+}
+
+func TestResolvePromptGraderTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset uses default", "", defaultPromptGraderTimeout},
+		{"go duration minutes", "5m", 5 * time.Minute},
+		{"go duration seconds", "300s", 300 * time.Second},
+		{"bare integer seconds", "300", 300 * time.Second},
+		{"whitespace is trimmed", "  90s  ", 90 * time.Second},
+		{"invalid falls back to default", "not-a-duration", defaultPromptGraderTimeout},
+		{"zero falls back to default", "0", defaultPromptGraderTimeout},
+		{"negative falls back to default", "-30s", defaultPromptGraderTimeout},
+		{"negative bare integer falls back to default", "-30", defaultPromptGraderTimeout},
+		{"overflowing bare integer falls back to default", "10000000000", defaultPromptGraderTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(promptGraderTimeoutEnv, tc.env)
+			require.Equal(t, tc.want, resolvePromptGraderTimeout())
+		})
+	}
 }

--- a/internal/graders/prompt_grader_test.go
+++ b/internal/graders/prompt_grader_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -503,25 +504,41 @@ func (f *fakePromptExecutor) Execute(ctx context.Context, req *execution.Executi
 }
 
 func TestResolvePromptGraderTimeout(t *testing.T) {
+	// Invalid / zero / negative inputs intentionally trigger slog.Warn inside
+	// resolvePromptGraderTimeout. Route slog to io.Discard for the duration of
+	// the test so the suite stays quiet while still exercising the warn paths.
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
 	cases := []struct {
-		name string
-		env  string
-		want time.Duration
+		name     string
+		env      string
+		unsetEnv bool
+		want     time.Duration
 	}{
-		{"unset uses default", "", defaultPromptGraderTimeout},
-		{"go duration minutes", "5m", 5 * time.Minute},
-		{"go duration seconds", "300s", 300 * time.Second},
-		{"bare integer seconds", "300", 300 * time.Second},
-		{"whitespace is trimmed", "  90s  ", 90 * time.Second},
-		{"invalid falls back to default", "not-a-duration", defaultPromptGraderTimeout},
-		{"zero falls back to default", "0", defaultPromptGraderTimeout},
-		{"negative falls back to default", "-30s", defaultPromptGraderTimeout},
-		{"negative bare integer falls back to default", "-30", defaultPromptGraderTimeout},
-		{"overflowing bare integer falls back to default", "10000000000", defaultPromptGraderTimeout},
+		{name: "unset uses default", unsetEnv: true, want: defaultPromptGraderTimeout},
+		{name: "empty uses default", env: "", want: defaultPromptGraderTimeout},
+		{name: "go duration minutes", env: "5m", want: 5 * time.Minute},
+		{name: "go duration seconds", env: "300s", want: 300 * time.Second},
+		{name: "bare integer seconds", env: "300", want: 300 * time.Second},
+		{name: "whitespace is trimmed", env: "  90s  ", want: 90 * time.Second},
+		{name: "invalid falls back to default", env: "not-a-duration", want: defaultPromptGraderTimeout},
+		{name: "zero falls back to default", env: "0", want: defaultPromptGraderTimeout},
+		{name: "negative falls back to default", env: "-30s", want: defaultPromptGraderTimeout},
+		{name: "negative bare integer falls back to default", env: "-30", want: defaultPromptGraderTimeout},
+		{name: "overflowing bare integer falls back to default", env: "10000000000", want: defaultPromptGraderTimeout},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(promptGraderTimeoutEnv, tc.env)
+			if tc.unsetEnv {
+				// t.Setenv only sets values; force a truly-unset state and let
+				// the framework restore it after the test.
+				t.Setenv(promptGraderTimeoutEnv, "")
+				require.NoError(t, os.Unsetenv(promptGraderTimeoutEnv))
+			} else {
+				t.Setenv(promptGraderTimeoutEnv, tc.env)
+			}
 			require.Equal(t, tc.want, resolvePromptGraderTimeout())
 		})
 	}


### PR DESCRIPTION
## What

Make the prompt grader's send timeout configurable via a new `WAZA_PROMPT_GRADER_TIMEOUT` environment variable. The 120s default is unchanged.

## Why

The prompt grader hardcodes a 120s timeout on the judge `SendAndWait`:

```go
const promptGraderTimeout = 120 * time.Second
...
execCtx, cancel := context.WithTimeout(ctx, promptGraderTimeout)
```

For long multi-turn judge sessions (a cheap judge model evaluating a large lifecycle transcript), the judge session can need longer than 120s to reach `session.idle`, so grading fails with:

```
running graders: failed to run grader rubric_judge: failed to send prompt: waiting for session.idle: context deadline exceeded
```

— even when the agent run itself was fine and gradeable. The agent execution gets the full suite timeout (often hours) while the judge gets only 120s.

This PR adds an escape hatch so operators can extend the judge budget without a code change. It is **not** a root-cause fix — the deeper problem is the SDK `SendAndWait` `session.idle` wait (it detects completion only via a `session.idle` event and "does not abort in-flight agent work"). That is documented in #318.

## What changed

- `WAZA_PROMPT_GRADER_TIMEOUT` accepts a Go duration (`5m`, `300s`) or a bare number of seconds (`300`).
- Empty / invalid / zero / negative values fall back to the 120s default, so a misconfiguration can never disable the timeout entirely.
- Default behavior is unchanged when the variable is unset.
- Documented in `docs/graders/prompt.md`.

## Test plan

- New `TestResolvePromptGraderTimeout` covers: unset → default; Go duration (`5m`, `300s`); bare seconds (`300`); whitespace trimming; and invalid / zero / negative → default.
- `go test ./internal/graders/` passes; `gofmt -l` clean; `go vet ./internal/graders/` clean; `go build ./internal/...` succeeds.

## Notes

The 120s default is arguably low for multi-turn lifecycle grading (the agent gets the full suite timeout); this PR keeps the default unchanged for safety and only adds the override. Revisiting the default, and the deeper "return as soon as grades are collected instead of waiting out the unnecessary post-grade follow-up turn" improvement, are called out in #318 for maintainer consideration.

Refs #318
