### PR TITLE
fix(execution): add a first-event watchdog to catch session-start hangs

### DIFF
--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -478,21 +478,35 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	// turns — turning a fast failure into a multi-minute (or multi-hour) stall.
 	// We arm a short timer that cancels sendCtx with a distinct cause if no
 	// event arrives in time, and disarm it the moment the first event lands (the
-	// turn has started; the overall deadline governs the rest).
+	// turn has started; the overall deadline governs the rest) or SendAndWait
+	// returns for any other reason.
 	sendCtx := ctx
+	stopFirstEventWatchdog := func() {}
 	if req.FirstEventTimeout > 0 {
 		var cancelFirst context.CancelCauseFunc
 		sendCtx, cancelFirst = context.WithCancelCause(ctx)
-		defer cancelFirst(nil)
 		timer := time.AfterFunc(req.FirstEventTimeout, func() {
 			cancelFirst(errFirstEventTimeout)
 		})
+
+		watchdogDone := make(chan struct{})
+		var stopWatchdog sync.Once
+		stopFirstEventWatchdog = func() {
+			stopWatchdog.Do(func() {
+				timer.Stop()
+				cancelFirst(nil)
+				close(watchdogDone)
+			})
+		}
+		defer stopFirstEventWatchdog()
+
 		go func() {
 			select {
 			case <-eventsCollector.FirstEvent():
-				timer.Stop()
+				stopFirstEventWatchdog()
 			case <-sendCtx.Done():
-				timer.Stop()
+				stopFirstEventWatchdog()
+			case <-watchdogDone:
 			}
 		}()
 	}
@@ -502,6 +516,7 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 		Prompt: req.Message,
 		Mode:   string(req.MessageMode),
 	})
+	stopFirstEventWatchdog()
 
 	var errMsg string
 

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -17,6 +18,13 @@ import (
 	"github.com/microsoft/waza/internal/skill"
 	"github.com/microsoft/waza/internal/utils"
 )
+
+// errFirstEventTimeout is the cancellation cause used when a session produces no
+// first event within ExecutionRequest.FirstEventTimeout — i.e. the embedded
+// engine launched but never started the agent's first turn. It is distinct from
+// the overall turn deadline (context.DeadlineExceeded) so callers can tell a
+// session-start hang apart from a genuinely long-running turn that timed out.
+var errFirstEventTimeout = errors.New("no first session event within first-event timeout")
 
 // CopilotEngine integrates with GitHub Copilot SDK
 type CopilotEngine struct {
@@ -463,8 +471,34 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	unsubscribe := session.On(utils.NewSessionToSlog())
 	defer unsubscribe()
 
+	// First-event watchdog. SendAndWait blocks until the session reaches a
+	// terminal state (session.idle / session.error) or sendCtx is canceled. A
+	// session-start hang emits NO events, so without this it would block until
+	// the overall turn deadline — which must be large to allow legitimate long
+	// turns — turning a fast failure into a multi-minute (or multi-hour) stall.
+	// We arm a short timer that cancels sendCtx with a distinct cause if no
+	// event arrives in time, and disarm it the moment the first event lands (the
+	// turn has started; the overall deadline governs the rest).
+	sendCtx := ctx
+	if req.FirstEventTimeout > 0 {
+		var cancelFirst context.CancelCauseFunc
+		sendCtx, cancelFirst = context.WithCancelCause(ctx)
+		defer cancelFirst(nil)
+		timer := time.AfterFunc(req.FirstEventTimeout, func() {
+			cancelFirst(errFirstEventTimeout)
+		})
+		go func() {
+			select {
+			case <-eventsCollector.FirstEvent():
+				timer.Stop()
+			case <-sendCtx.Done():
+				timer.Stop()
+			}
+		}()
+	}
+
 	// Send prompt with updated API
-	_, err = session.SendAndWait(ctx, copilot.MessageOptions{
+	_, err = session.SendAndWait(sendCtx, copilot.MessageOptions{
 		Prompt: req.Message,
 		Mode:   string(req.MessageMode),
 	})
@@ -477,6 +511,12 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 		// termination. We clear the error so the response reports success.
 		if canceledForSkill && ctx.Err() == context.Canceled {
 			err = nil
+		} else if errors.Is(context.Cause(sendCtx), errFirstEventTimeout) {
+			// Session-start hang: no first event arrived within the budget.
+			// Surface a distinct, actionable error rather than the opaque
+			// context-canceled / deadline message SendAndWait returns.
+			err = fmt.Errorf("session start timeout: no first turn within %s (engine launched but produced no events): %w", req.FirstEventTimeout, errFirstEventTimeout)
+			errMsg = err.Error()
 		} else {
 			// errors that are returned inline, as part of the conversation, also come back
 			// in the returned error. Rather than having one of those fun functions that returns

--- a/internal/execution/copilot_first_event_test.go
+++ b/internal/execution/copilot_first_event_test.go
@@ -54,7 +54,7 @@ func TestCopilotExecute_FirstEventTimeout_AbortsSessionStartHang(t *testing.T) {
 	clientMock.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).AnyTimes()
 	sessionMock.EXPECT().SessionID().Return("session-first-event").AnyTimes()
 	sessionMock.EXPECT().Disconnect().AnyTimes()
-	sessionMock.EXPECT().On(gomock.Any()).Times(3).Return(func() {})
+	sessionMock.EXPECT().On(gomock.Any()).AnyTimes().Return(func() {})
 
 	// SendAndWait emits no event — it just blocks until its context is canceled
 	// (which the first-event watchdog must do) and returns that error.
@@ -109,7 +109,7 @@ func TestCopilotExecute_FirstEventTimeout_DisarmsOnFirstEvent(t *testing.T) {
 	sessionMock.EXPECT().Disconnect().AnyTimes()
 
 	var handlers []func(copilot.SessionEvent)
-	sessionMock.EXPECT().On(gomock.Any()).Times(3).DoAndReturn(func(h func(copilot.SessionEvent)) func() {
+	sessionMock.EXPECT().On(gomock.Any()).AnyTimes().DoAndReturn(func(h func(copilot.SessionEvent)) func() {
 		handlers = append(handlers, h)
 		return func() {}
 	})
@@ -118,6 +118,7 @@ func TestCopilotExecute_FirstEventTimeout_DisarmsOnFirstEvent(t *testing.T) {
 	// successfully — NOT with a context error.
 	sessionMock.EXPECT().SendAndWait(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ copilot.MessageOptions) (*copilot.SessionEvent, error) {
+			require.NotEmpty(t, handlers)
 			for _, h := range handlers {
 				h(copilot.SessionEvent{Data: &copilot.SkillInvokedData{Name: "s", Path: "p"}})
 			}

--- a/internal/execution/copilot_first_event_test.go
+++ b/internal/execution/copilot_first_event_test.go
@@ -1,0 +1,147 @@
+package execution
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// The first-event signal is open until the first event of any type arrives, then
+// closed, and stays closed (idempotent) for every subsequent event.
+func TestSessionEventsCollector_FirstEvent_ClosesOnFirstEvent(t *testing.T) {
+	coll := NewSessionEventsCollector()
+
+	select {
+	case <-coll.FirstEvent():
+		t.Fatal("FirstEvent must be open before any event is received")
+	default:
+	}
+
+	coll.On(copilot.SessionEvent{Data: &copilot.SkillInvokedData{Name: "s", Path: "p"}})
+
+	select {
+	case <-coll.FirstEvent():
+	default:
+		t.Fatal("FirstEvent must be closed after the first event")
+	}
+
+	// A second event must not re-close the channel (would panic without the once).
+	coll.On(copilot.SessionEvent{Data: &copilot.SkillInvokedData{Name: "s2", Path: "p2"}})
+
+	select {
+	case <-coll.FirstEvent():
+	default:
+		t.Fatal("FirstEvent must remain closed after subsequent events")
+	}
+}
+
+// A session that launches but never produces a first event is a session-start
+// hang. The first-event watchdog must abort it WELL before the (necessarily
+// large) overall turn deadline and surface a distinct, actionable error.
+func TestCopilotExecute_FirstEventTimeout_AbortsSessionStartHang(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clientMock := newClientMock(ctrl)
+	sessionMock := NewMockCopilotSession(ctrl)
+
+	sourceDir := t.TempDir()
+
+	clientMock.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(sessionMock, nil)
+	clientMock.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).AnyTimes()
+	sessionMock.EXPECT().SessionID().Return("session-first-event").AnyTimes()
+	sessionMock.EXPECT().Disconnect().AnyTimes()
+	sessionMock.EXPECT().On(gomock.Any()).Times(3).Return(func() {})
+
+	// SendAndWait emits no event — it just blocks until its context is canceled
+	// (which the first-event watchdog must do) and returns that error.
+	sessionMock.EXPECT().SendAndWait(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ copilot.MessageOptions) (*copilot.SessionEvent, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	)
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(_ *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+	defer func() { require.NoError(t, engine.Shutdown(context.Background())) }()
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	// Overall deadline is generous (30s); the first-event budget is tiny (50ms).
+	// A working watchdog returns in well under a second.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := engine.Execute(ctx, &ExecutionRequest{
+		Message:           "hello?",
+		SourceDir:         sourceDir,
+		FirstEventTimeout: 50 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err) // the failure is reported in the response, not returned
+	require.False(t, resp.Success)
+	require.Contains(t, resp.ErrorMsg, "session start timeout")
+	require.Contains(t, resp.ErrorMsg, "no first turn")
+	require.Less(t, elapsed, 5*time.Second,
+		"first-event watchdog must fire near its 50ms budget, not the 30s overall deadline (took %s)", elapsed)
+}
+
+// When the first event arrives within the budget, the watchdog disarms and the
+// run completes normally — the overall deadline (not the first-event budget)
+// governs the rest of the turn. This guards against false-aborting a slow-to-
+// start but live first turn.
+func TestCopilotExecute_FirstEventTimeout_DisarmsOnFirstEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clientMock := newClientMock(ctrl)
+	sessionMock := NewMockCopilotSession(ctrl)
+
+	sourceDir := t.TempDir()
+
+	clientMock.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(sessionMock, nil)
+	clientMock.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).AnyTimes()
+	sessionMock.EXPECT().SessionID().Return("session-first-event-ok").AnyTimes()
+	sessionMock.EXPECT().Disconnect().AnyTimes()
+
+	var handlers []func(copilot.SessionEvent)
+	sessionMock.EXPECT().On(gomock.Any()).Times(3).DoAndReturn(func(h func(copilot.SessionEvent)) func() {
+		handlers = append(handlers, h)
+		return func() {}
+	})
+
+	// Emit a first event right away (disarms the watchdog), then complete
+	// successfully — NOT with a context error.
+	sessionMock.EXPECT().SendAndWait(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ copilot.MessageOptions) (*copilot.SessionEvent, error) {
+			for _, h := range handlers {
+				h(copilot.SessionEvent{Data: &copilot.SkillInvokedData{Name: "s", Path: "p"}})
+			}
+			return &copilot.SessionEvent{}, nil
+		},
+	)
+
+	engine := NewCopilotEngineBuilder("gpt-4o-mini", &CopilotEngineBuilderOptions{
+		NewCopilotClient: func(_ *copilot.ClientOptions) CopilotClient { return clientMock },
+	}).Build()
+	defer func() { require.NoError(t, engine.Shutdown(context.Background())) }()
+	require.NoError(t, engine.Initialize(context.Background()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := engine.Execute(ctx, &ExecutionRequest{
+		Message:           "hello?",
+		SourceDir:         sourceDir,
+		FirstEventTimeout: 10 * time.Second,
+	})
+
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+	require.False(t, strings.Contains(resp.ErrorMsg, "session start timeout"),
+		"a run that produced a first event must not be reported as a session-start hang")
+}

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/copilotevents"
@@ -58,6 +59,14 @@ type ExecutionRequest struct {
 
 	MessageMode MessageMode
 	Streaming   bool
+
+	// FirstEventTimeout bounds how long Execute waits for the FIRST session
+	// event before treating the run as a session-start hang and aborting it
+	// with a distinct error. It is intentionally much shorter than the overall
+	// turn deadline (the ctx passed to Execute), which must be sized for the
+	// slowest legitimate full turn and therefore cannot also catch a
+	// no-first-turn wedge quickly. Zero disables the check (the prior behavior).
+	FirstEventTimeout time.Duration
 
 	// EphemeralSession keeps one-off sessions out of engine shutdown tracking.
 	// New ephemeral sessions are deleted at the end of Execute. Resumed

--- a/internal/execution/session_events_collector.go
+++ b/internal/execution/session_events_collector.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/copilotevents"
@@ -19,6 +20,8 @@ type SessionEventsCollector struct {
 	outputParts    []string
 	errorMsg       string
 	done           chan struct{}
+	firstEvent     chan struct{}
+	firstEventOnce sync.Once
 	intentToolIDs  map[string]bool
 	onSkillInvoked func(SkillInvocation) // optional callback fired on each SkillInvoked event
 }
@@ -27,6 +30,7 @@ type SessionEventsCollector struct {
 func NewSessionEventsCollector() *SessionEventsCollector {
 	return &SessionEventsCollector{
 		done:          make(chan struct{}),
+		firstEvent:    make(chan struct{}),
 		intentToolIDs: map[string]bool{},
 	}
 }
@@ -51,6 +55,17 @@ func (coll *SessionEventsCollector) Done() <-chan struct{} {
 	return coll.done
 }
 
+// FirstEvent returns a channel that is closed when the FIRST session event of
+// any type is received. A healthy session emits events promptly once the agent
+// starts its first turn; a session-start hang (the embedded engine launches but
+// never produces a turn) emits nothing at all. Callers use this to arm a
+// short "time to first event" deadline distinct from the overall turn timeout,
+// so a no-first-turn wedge is caught in seconds instead of running out the full
+// (necessarily large) turn budget.
+func (coll *SessionEventsCollector) FirstEvent() <-chan struct{} {
+	return coll.firstEvent
+}
+
 // SetOnSkillInvoked registers a callback that fires every time a SkillInvoked
 // event is received. The callback runs synchronously inside On(), so it can
 // safely cancel a context to abort an in-flight SendAndWait.
@@ -61,6 +76,13 @@ func (coll *SessionEventsCollector) SetOnSkillInvoked(fn func(SkillInvocation)) 
 // On is a callback, intended to be passed to [copilot.Session.On] to receive
 // events in real-time.
 func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
+	// Signal first contact before anything else: ANY event proves the engine is
+	// alive and has begun the turn, which disarms the first-event watchdog. We
+	// deliberately fire on the first event of any type (not only assistant/tool
+	// events) and err toward never false-aborting a slow-but-live first turn —
+	// a true session-start hang emits no events at all.
+	coll.firstEventOnce.Do(func() { close(coll.firstEvent) })
+
 	switch event.Type() {
 	case copilot.SessionEventTypeAssistantMessage:
 		if content, ok := copilotevents.Content(event); ok {

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -35,22 +35,28 @@ type SpecIdentity struct {
 
 // Config controls execution behavior
 type Config struct {
-	TrialsPerTask    int            `yaml:"trials_per_task" json:"runs_per_test"`
-	TimeoutSec       int            `yaml:"timeout_seconds" json:"timeout_sec"`
-	Concurrent       bool           `yaml:"parallel" json:"concurrent"`
-	Workers          int            `yaml:"workers,omitempty" json:"workers,omitempty"`
-	StopOnError      bool           `yaml:"fail_fast,omitempty" json:"stop_on_error,omitempty"`
-	EngineType       string         `yaml:"executor" json:"engine_type"`
-	ModelID          string         `yaml:"model" json:"model_id"`
-	SkillPaths       []string       `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
-	InstructionFiles []string       `yaml:"instruction_files,omitempty" json:"instruction_files,omitempty"`
-	InjectSkillBody  *bool          `yaml:"inject_skill_body,omitempty" json:"inject_skill_body,omitempty"`
-	DisabledSkills   []string       `yaml:"disabled_skills,omitempty" json:"disabled_skills,omitempty"`
-	RequiredSkills   []string       `yaml:"required_skills,omitempty" json:"required_skills,omitempty"`
-	ServerConfigs    map[string]any `yaml:"mcp_servers,omitempty" json:"server_configs,omitempty"`
-	MaxAttempts      int            `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty"`
-	GroupBy          string         `yaml:"group_by,omitempty" json:"group_by,omitempty"`
-	JudgeModel       string         `yaml:"judge_model,omitempty" json:"judge_model,omitempty"`
+	TrialsPerTask int `yaml:"trials_per_task" json:"runs_per_test"`
+	TimeoutSec    int `yaml:"timeout_seconds" json:"timeout_sec"`
+	// FirstEventTimeoutSec bounds how long to wait for the first session event
+	// before treating a run as a session-start hang (the engine launched but
+	// never started the agent's first turn). It is much shorter than
+	// TimeoutSec, which must cover the slowest legitimate full turn. 0 (the
+	// default) disables the check. Per-task overrides live on TestCase.
+	FirstEventTimeoutSec int            `yaml:"first_event_timeout_seconds,omitempty" json:"first_event_timeout_sec,omitempty"`
+	Concurrent           bool           `yaml:"parallel" json:"concurrent"`
+	Workers              int            `yaml:"workers,omitempty" json:"workers,omitempty"`
+	StopOnError          bool           `yaml:"fail_fast,omitempty" json:"stop_on_error,omitempty"`
+	EngineType           string         `yaml:"executor" json:"engine_type"`
+	ModelID              string         `yaml:"model" json:"model_id"`
+	SkillPaths           []string       `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
+	InstructionFiles     []string       `yaml:"instruction_files,omitempty" json:"instruction_files,omitempty"`
+	InjectSkillBody      *bool          `yaml:"inject_skill_body,omitempty" json:"inject_skill_body,omitempty"`
+	DisabledSkills       []string       `yaml:"disabled_skills,omitempty" json:"disabled_skills,omitempty"`
+	RequiredSkills       []string       `yaml:"required_skills,omitempty" json:"required_skills,omitempty"`
+	ServerConfigs        map[string]any `yaml:"mcp_servers,omitempty" json:"server_configs,omitempty"`
+	MaxAttempts          int            `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty"`
+	GroupBy              string         `yaml:"group_by,omitempty" json:"group_by,omitempty"`
+	JudgeModel           string         `yaml:"judge_model,omitempty" json:"judge_model,omitempty"`
 }
 
 // ShouldInjectSkillBody returns true unless the eval explicitly opts out of
@@ -291,6 +297,9 @@ func (s *EvalSpec) Validate() error {
 	}
 	if s.Config.TimeoutSec < 1 {
 		return fmt.Errorf("timeout_seconds must be at least 1, got %d", s.Config.TimeoutSec)
+	}
+	if s.Config.FirstEventTimeoutSec < 0 {
+		return fmt.Errorf("first_event_timeout_seconds must not be negative, got %d", s.Config.FirstEventTimeoutSec)
 	}
 	return nil
 }

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -7,8 +7,36 @@ package models
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestEvalSpec_Validate_FirstEventTimeout(t *testing.T) {
+	mk := func(sec int) *EvalSpec {
+		return &EvalSpec{
+			SpecIdentity: SpecIdentity{Name: "b"},
+			Config: Config{
+				TrialsPerTask:        1,
+				TimeoutSec:           60,
+				FirstEventTimeoutSec: sec,
+			},
+		}
+	}
+
+	if err := mk(-1).Validate(); err == nil {
+		t.Fatal("expected error for negative first_event_timeout_seconds")
+	} else if !strings.Contains(err.Error(), "first_event_timeout_seconds must not be negative, got -1") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// 0 disables the watchdog; a positive value enables it — both valid.
+	if err := mk(0).Validate(); err != nil {
+		t.Errorf("expected first_event_timeout_seconds: 0 to be valid, got: %v", err)
+	}
+	if err := mk(120).Validate(); err != nil {
+		t.Errorf("expected first_event_timeout_seconds: 120 to be valid, got: %v", err)
+	}
+}
 
 func TestLoadEvalSpec_StrictYAML(t *testing.T) {
 	tests := []struct {

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -12,18 +12,21 @@ import (
 
 // TestCase represents a single evaluation test
 type TestCase struct {
-	Active           *bool             `yaml:"enabled,omitempty" json:"active,omitempty"`
-	ContextRoot      string            `yaml:"context_dir,omitempty" json:"context_root,omitempty"`
-	DisplayName      string            `yaml:"name" json:"display_name"`
-	Expectation      TaskExpectation   `yaml:"expected,omitempty" json:"expectation,omitempty"`
-	InstructionFiles []string          `yaml:"instruction_files,omitempty" json:"instruction_files,omitempty"`
-	SkillPaths       []string          `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
-	Stimulus         TaskStimulus      `yaml:"inputs" json:"stimulus"`
-	Summary          string            `yaml:"description,omitempty" json:"summary,omitempty"`
-	Tags             []string          `yaml:"tags,omitempty" json:"labels,omitempty"`
-	TestID           string            `yaml:"id" json:"test_id"`
-	TimeoutSec       *int              `yaml:"timeout_seconds,omitempty" json:"timeout_sec,omitempty"`
-	Validators       []ValidatorInline `yaml:"graders,omitempty" json:"validators,omitempty"`
+	Active           *bool           `yaml:"enabled,omitempty" json:"active,omitempty"`
+	ContextRoot      string          `yaml:"context_dir,omitempty" json:"context_root,omitempty"`
+	DisplayName      string          `yaml:"name" json:"display_name"`
+	Expectation      TaskExpectation `yaml:"expected,omitempty" json:"expectation,omitempty"`
+	InstructionFiles []string        `yaml:"instruction_files,omitempty" json:"instruction_files,omitempty"`
+	SkillPaths       []string        `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
+	Stimulus         TaskStimulus    `yaml:"inputs" json:"stimulus"`
+	Summary          string          `yaml:"description,omitempty" json:"summary,omitempty"`
+	Tags             []string        `yaml:"tags,omitempty" json:"labels,omitempty"`
+	TestID           string          `yaml:"id" json:"test_id"`
+	TimeoutSec       *int            `yaml:"timeout_seconds,omitempty" json:"timeout_sec,omitempty"`
+	// FirstEventTimeoutSec overrides Config.FirstEventTimeoutSec for this task.
+	// nil inherits the eval-level value; 0 disables the check for this task.
+	FirstEventTimeoutSec *int              `yaml:"first_event_timeout_seconds,omitempty" json:"first_event_timeout_sec,omitempty"`
+	Validators           []ValidatorInline `yaml:"graders,omitempty" json:"validators,omitempty"`
 }
 
 // TaskStimulus defines the input for a task.
@@ -318,6 +321,16 @@ func (tc *TestCase) Validate() error {
 			return fmt.Errorf("test case %q timeout_seconds must be at least 1, got %d", name, *tc.TimeoutSec)
 		}
 		return fmt.Errorf("timeout_seconds must be at least 1, got %d", *tc.TimeoutSec)
+	}
+	if tc.FirstEventTimeoutSec != nil && *tc.FirstEventTimeoutSec < 0 {
+		name := tc.TestID
+		if name == "" {
+			name = tc.DisplayName
+		}
+		if name != "" {
+			return fmt.Errorf("test case %q first_event_timeout_seconds must not be negative, got %d", name, *tc.FirstEventTimeoutSec)
+		}
+		return fmt.Errorf("first_event_timeout_seconds must not be negative, got %d", *tc.FirstEventTimeoutSec)
 	}
 	return nil
 }

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -125,6 +125,52 @@ inputs:
 	}
 }
 
+func TestLoadTestCase_NegativeFirstEventTimeoutRejected(t *testing.T) {
+	yamlData := `id: tc-bad-first-event
+name: bad first event
+first_event_timeout_seconds: -1
+inputs:
+  prompt: do something
+`
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tc.yaml")
+	if err := os.WriteFile(p, []byte(yamlData), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := LoadTestCase(p)
+	if err == nil {
+		t.Fatal("expected error for first_event_timeout_seconds: -1, got nil")
+	}
+	if !strings.Contains(err.Error(), `test case "tc-bad-first-event" first_event_timeout_seconds must not be negative, got -1`) {
+		t.Errorf("error should describe invalid first_event_timeout_seconds, got: %v", err)
+	}
+}
+
+func TestLoadTestCase_ZeroFirstEventTimeoutAllowed(t *testing.T) {
+	// Unlike timeout_seconds, 0 is valid for first_event_timeout_seconds — it
+	// disables the first-event watchdog for the task.
+	yamlData := `id: tc-zero-first-event
+name: zero first event
+first_event_timeout_seconds: 0
+inputs:
+  prompt: do something
+`
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tc.yaml")
+	if err := os.WriteFile(p, []byte(yamlData), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tc, err := LoadTestCase(p)
+	if err != nil {
+		t.Fatalf("expected first_event_timeout_seconds: 0 to be accepted, got: %v", err)
+	}
+	if tc.FirstEventTimeoutSec == nil || *tc.FirstEventTimeoutSec != 0 {
+		t.Errorf("expected FirstEventTimeoutSec == 0, got %v", tc.FirstEventTimeoutSec)
+	}
+}
+
 func TestLoadTestCase_OutputContainsAny(t *testing.T) {
 	yamlData := `id: tc-may
 name: test may-include

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1191,6 +1191,7 @@ func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) (*execution.Exec
 		NoSkills:          noSkills,
 		SuppressSkillBody: !spec.Config.ShouldInjectSkillBody(),
 		MCPServers:        convertMCPServers(spec.Config.ServerConfigs),
+		FirstEventTimeout: r.firstEventTimeout(tc),
 	}, nil
 }
 
@@ -1203,6 +1204,21 @@ func (r *EvalRunner) executionTimeout(tc *models.TestCase) (time.Duration, error
 		timeout = *tc.TimeoutSec
 	}
 	return time.Duration(timeout) * time.Second, nil
+}
+
+// firstEventTimeout resolves the per-run "time to first session event" budget:
+// the task-level override when set, otherwise the eval-level default. A value of
+// 0 (the default) disables the first-event watchdog so existing specs that never
+// configure it keep their prior behavior.
+func (r *EvalRunner) firstEventTimeout(tc *models.TestCase) time.Duration {
+	sec := r.cfg.Spec().Config.FirstEventTimeoutSec
+	if tc.FirstEventTimeoutSec != nil {
+		sec = *tc.FirstEventTimeoutSec
+	}
+	if sec <= 0 {
+		return 0
+	}
+	return time.Duration(sec) * time.Second
 }
 
 func rejectRelativePathPromptWithEmptySandbox(tc *models.TestCase, resources []execution.ResourceFile) error {

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -265,6 +265,44 @@ func TestExecutionTimeout_InvalidTaskOverride(t *testing.T) {
 	assert.Contains(t, err.Error(), `test case "test-001" timeout_seconds must be at least 1, got 0`)
 }
 
+func TestFirstEventTimeout_Resolution(t *testing.T) {
+	mkRunner := func(specSec int) *EvalRunner {
+		spec := &models.EvalSpec{
+			SpecIdentity: models.SpecIdentity{Name: "test-benchmark"},
+			SkillName:    "my-skill",
+			Config: models.Config{
+				EngineType:           "mock",
+				ModelID:              "gpt-4",
+				TimeoutSec:           120,
+				FirstEventTimeoutSec: specSec,
+			},
+		}
+		return NewEvalRunner(config.NewEvalConfig(spec), nil)
+	}
+	mkTask := func(override *int) *models.TestCase {
+		return &models.TestCase{
+			TestID:               "test-001",
+			DisplayName:          "Test Case",
+			Stimulus:             models.TaskStimulus{Message: "Hello world"},
+			FirstEventTimeoutSec: override,
+		}
+	}
+
+	// Spec-level default applies when the task carries no override.
+	assert.Equal(t, 90*time.Second, mkRunner(90).firstEventTimeout(mkTask(nil)))
+
+	// Disabled by default: spec 0 + no override → zero duration (watchdog off).
+	assert.Equal(t, time.Duration(0), mkRunner(0).firstEventTimeout(mkTask(nil)))
+
+	// Task override wins over the spec default.
+	override := 30
+	assert.Equal(t, 30*time.Second, mkRunner(90).firstEventTimeout(mkTask(&override)))
+
+	// A task can explicitly disable the watchdog even when the spec enables it.
+	disabled := 0
+	assert.Equal(t, time.Duration(0), mkRunner(90).firstEventTimeout(mkTask(&disabled)))
+}
+
 func TestExecuteRun_InvalidTaskTimeoutReturnsConfigError(t *testing.T) {
 	spec := &models.EvalSpec{
 		SpecIdentity: models.SpecIdentity{Name: "test-benchmark"},

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -111,6 +111,11 @@
           "minimum": 1,
           "description": "Maximum time in seconds for each task execution."
         },
+        "first_event_timeout_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum time in seconds to wait for the first session event before treating a run as a session-start hang and aborting it. Intended to be much shorter than timeout_seconds, which must cover the slowest legitimate full turn. 0 (the default) disables the check."
+        },
         "parallel": {
           "type": "boolean",
           "default": false,

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -114,6 +114,7 @@
         "first_event_timeout_seconds": {
           "type": "integer",
           "minimum": 0,
+          "default": 0,
           "description": "Maximum time in seconds to wait for the first session event before treating a run as a session-start hang and aborting it. Intended to be much shorter than timeout_seconds, which must cover the slowest legitimate full turn. 0 (the default) disables the check."
         },
         "parallel": {

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -41,6 +41,7 @@
     "first_event_timeout_seconds": {
       "type": "integer",
       "minimum": 0,
+      "default": 0,
       "description": "Per-task override for the eval-level first_event_timeout_seconds. 0 disables the first-event (session-start hang) watchdog for this task."
     },
     "tags": {

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -38,6 +38,11 @@
       "minimum": 1,
       "description": "Per-task timeout in seconds, overriding the eval-level default."
     },
+    "first_event_timeout_seconds": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Per-task override for the eval-level first_event_timeout_seconds. 0 disables the first-event (session-start hang) watchdog for this task."
+    },
     "tags": {
       "type": "array",
       "items": {

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -107,6 +107,7 @@ config:
 | ------------------- | --------- | ----------------- | ----------------------------------------------------------- |
 | `trials_per_task`   | int       | 1                 | Number of times each task runs (for statistical analysis)   |
 | `timeout_seconds`   | int       | 300               | Task timeout in seconds                                     |
+| `first_event_timeout_seconds` | int | 0 (off)      | Abort a run that produces no first event within N seconds (session-start hang); 0 disables |
 | `parallel`          | bool      | false             | Run tasks concurrently                                      |
 | `workers`           | int       | 0                 | Number of parallel workers; 0 auto-sizes                    |
 | `model`             | string    | _required_        | Default model for tasks (override with `--model` flag)      |

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -115,6 +115,26 @@ Common values:
 - `300` — Standard code analysis
 - `600` — Complex multi-file tasks
 
+### first_event_timeout_seconds
+
+**Type:** integer  
+**Default:** 0 (disabled)
+
+Maximum seconds to wait for the **first** session event before treating a run as
+a session-start hang and aborting it. The embedded engine can occasionally launch
+but never start the agent's first turn (no events at all); without this guard such
+a run blocks until `timeout_seconds`, which must be sized for the slowest
+legitimate full turn and is therefore a poor catch-all for a fast failure. Keep
+this comfortably above realistic first-turn latency so a slow-but-live first turn
+is never aborted. `0` disables the check. Override per task with the task-level
+field of the same name (`0` disables it for that task).
+
+```yaml
+config:
+  timeout_seconds: 1800 # 30 min — the slowest legitimate full turn
+  first_event_timeout_seconds: 300 # but the first turn must start within 5 min
+```
+
 ### parallel
 
 **Type:** boolean  


### PR DESCRIPTION
## Summary

A run whose embedded engine launches but never produces a **first session event**
is currently only caught by the overall per-task turn timeout (`timeout_seconds`).
Because that timeout must be sized for the slowest legitimate full turn, a
session-start hang can block for many minutes (or hours) and surfaces as the
generic `session.idle: context deadline exceeded`. This adds an opt-in
**time-to-first-event** watchdog (`first_event_timeout_seconds`) that aborts such
a wedge in seconds with a distinct, actionable error, while never false-aborting a
slow-but-live first turn.

## Related issue

Closes #320

## Agent handoff

- **Scope:** `internal/execution` (engine + collector), `internal/models` (config),
  `internal/orchestration` (wiring), plus JSON schema + docs. No behavior change
  unless `first_event_timeout_seconds` is set (default `0` = disabled).
- **Key files changed:**
  - `internal/execution/session_events_collector.go` — `FirstEvent()` channel,
    closed on the first event of any type.
  - `internal/execution/copilot.go` — arms a first-event timer before
    `SendAndWait`, cancels a child context with a distinct cause
    (`errFirstEventTimeout`) on timeout, disarms on the first event, and maps the
    cause to a distinct `session start timeout: no first turn within …` error.
  - `internal/execution/engine.go` — `ExecutionRequest.FirstEventTimeout`.
  - `internal/models/spec.go` / `testcase.go` — `first_event_timeout_seconds`
    (eval `Config` + per-task `*int` override) and validation (`>= 0`; `0` disables).
  - `internal/orchestration/runner.go` — `firstEventTimeout(tc)` resolver, set on
    every request in `buildExecutionRequest` (covers initial + follow-up turns).
  - `schemas/eval.schema.json`, `schemas/task.schema.json` — new field (required
    because `config` uses `additionalProperties: false`).
  - `site/.../reference/schema.mdx`, `site/.../guides/eval-yaml.mdx` — docs.
- **Important decisions:**
  - **Opt-in, default `0` (disabled)** so existing specs are byte-for-byte
    unchanged; downstream long-turn suites enable it explicitly.
  - **Fire on the first event of ANY type** — a true session-start hang emits no
    events at all, so any event proves the engine is live; this errs toward never
    false-aborting a slow first turn.
  - **`context.WithCancelCause` + `context.Cause`** is used (race-free) to
    distinguish a first-event abort from the overall `timeout_seconds` deadline and
    from `CancelOnSkillInvocation`.
- **Follow-ups / known gaps:** the underlying stall likely also warrants a
  bootstrap/first-request deadline in `github/copilot-sdk` (surface a
  `session.error` instead of silence); waza defends regardless. Choosing a
  sensible non-zero default could be a later change once it's been exercised in CI.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor or maintenance
- [ ] CI/CD or release change

## Validation

- [x] `go test ./...` — full suite green locally (incl. the new tests below).
- [x] `make lint` or `golangci-lint run` — `golangci-lint` (v2) reports **zero
  issues on the changed files** (`gofmt`-clean, `govet enable-all`,
  `errcheck`, `staticcheck`).
- [x] Docs site checked, if docs changed — added the field to the schema
  reference and the eval-YAML config table.
- [ ] Web/dashboard checks run, if `web/` changed — n/a (no `web/` change).
- [x] Manual validation completed: new tests assert (a) the watchdog aborts a
  no-event session near its tiny budget rather than the large overall deadline,
  (b) it disarms when the first event arrives (no false abort), (c) the collector
  signal closes on the first event and is idempotent, (d) the runner resolves
  spec/task/disable, and (e) config validation rejects negatives / allows `0`.

New tests:
- `internal/execution/copilot_first_event_test.go` —
  `TestSessionEventsCollector_FirstEvent_ClosesOnFirstEvent`,
  `TestCopilotExecute_FirstEventTimeout_AbortsSessionStartHang`,
  `TestCopilotExecute_FirstEventTimeout_DisarmsOnFirstEvent`.
- `internal/orchestration/runner_test.go` — `TestFirstEventTimeout_Resolution`.
- `internal/models/{testcase,spec}_test.go` — negative-rejected / zero-allowed.

## Documentation

- [x] README updated, if user-facing behavior changed — n/a (no README surface).
- [x] `site/` docs updated — schema reference + eval-YAML config table.
- [ ] Examples updated, if relevant — n/a.
- [ ] Not applicable

## Risk and rollback

- **Risk level: Low.** The feature is fully opt-in: with `first_event_timeout_seconds`
  unset/`0`, `Execute` takes exactly the prior path (`sendCtx == ctx`, no timer,
  no goroutine) and all existing tests pass unchanged.
- **Rollback plan:** revert the commit; no migrations, no persisted state, no
  schema-breaking change (the new property is additive and optional).

## Notes for reviewers

- The core logic is the watchdog block in `copilot.go` around `SendAndWait`.
  Please scrutinize the cancellation precedence: `CancelOnSkillInvocation`
  (checked first) → `errFirstEventTimeout` (distinct cause) → the overall
  `context.DeadlineExceeded`. `context.Cause(sendCtx)` is what disambiguates them.
- The first-event signal lives at the top of `SessionEventsCollector.On` (guarded
  by a `sync.Once`), so it can't double-close and disarms on the very first event.
- Local lint shows 3 pre-existing `gofmt` hits on **untouched** files
  (`copilot_client_wrappers.go`, `generate.go`, `git.go`) — a Windows CRLF
  working-copy artifact, not present in the LF repo blobs and not in this diff.
