### PR TITLE
feat: add /api/events SSE endpoint for live run events (#178)

### DIFF
--- a/internal/webapi/handlers.go
+++ b/internal/webapi/handlers.go
@@ -14,6 +14,7 @@ var Version = "0.4.0-alpha.1"
 type Handlers struct {
 	store         RunStore
 	storageConfig *StorageConfig
+	broker        *Broker
 }
 
 // StorageConfig holds storage configuration for the status endpoint.
@@ -110,21 +111,30 @@ func (h *Handlers) HandleStorageStatus(w http.ResponseWriter, _ *http.Request) {
 // RegisterRoutes registers all web API routes on the given mux.
 func RegisterRoutes(mux *http.ServeMux, store RunStore) {
 	h := NewHandlers(store)
-	mux.HandleFunc("GET /api/health", h.HandleHealth)
-	mux.HandleFunc("GET /api/summary", h.HandleSummary)
-	mux.HandleFunc("GET /api/runs", h.HandleRuns)
-	mux.HandleFunc("GET /api/runs/{id}", h.HandleRunDetail)
-	mux.HandleFunc("GET /api/storage/status", h.HandleStorageStatus)
+	registerHandlerRoutes(mux, h)
 }
 
 // RegisterRoutesWithStorage registers all web API routes with storage config.
 func RegisterRoutesWithStorage(mux *http.ServeMux, store RunStore, cfg *StorageConfig) {
 	h := NewHandlersWithStorage(store, cfg)
+	registerHandlerRoutes(mux, h)
+}
+
+// RegisterRoutesWithHandlers registers all web API routes using a
+// caller-supplied Handlers value. Use this when the caller needs to
+// configure additional state (e.g., an SSE Broker) before exposing the
+// routes.
+func RegisterRoutesWithHandlers(mux *http.ServeMux, h *Handlers) {
+	registerHandlerRoutes(mux, h)
+}
+
+func registerHandlerRoutes(mux *http.ServeMux, h *Handlers) {
 	mux.HandleFunc("GET /api/health", h.HandleHealth)
 	mux.HandleFunc("GET /api/summary", h.HandleSummary)
 	mux.HandleFunc("GET /api/runs", h.HandleRuns)
 	mux.HandleFunc("GET /api/runs/{id}", h.HandleRunDetail)
 	mux.HandleFunc("GET /api/storage/status", h.HandleStorageStatus)
+	mux.HandleFunc("GET /api/events", h.HandleEvents)
 }
 
 // CORSMiddleware wraps a handler with CORS headers.

--- a/internal/webapi/sse.go
+++ b/internal/webapi/sse.go
@@ -1,0 +1,187 @@
+package webapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// SSEEvent is the wire-format event sent to dashboard SSE clients.
+// It matches the contract expected by web/src/hooks/useSSE.ts.
+type SSEEvent struct {
+	Type      string         `json:"type"`
+	Data      map[string]any `json:"data,omitempty"`
+	Timestamp time.Time      `json:"timestamp"`
+}
+
+// Allowed live event types. Other event types are dropped so the wire
+// contract stays narrow.
+var liveEventTypes = map[string]struct{}{
+	"task_start":    {},
+	"task_complete": {},
+	"grader_result": {},
+	"run_complete":  {},
+}
+
+// IsLiveEventType reports whether the given event type is published to
+// SSE subscribers.
+func IsLiveEventType(t string) bool {
+	_, ok := liveEventTypes[t]
+	return ok
+}
+
+// Default subscriber buffer size. Slow clients are dropped instead of
+// blocking the publisher.
+const sseSubscriberBuffer = 64
+
+// Broker fans out SSEEvents to all current SSE subscribers.
+//
+// The zero value is not ready for use; call NewBroker. Broker is safe for
+// concurrent use.
+type Broker struct {
+	mu          sync.Mutex
+	subscribers map[chan SSEEvent]struct{}
+}
+
+// NewBroker creates a Broker with no subscribers.
+func NewBroker() *Broker {
+	return &Broker{subscribers: make(map[chan SSEEvent]struct{})}
+}
+
+// Subscribe registers a new subscriber and returns the channel it should
+// read from along with an unsubscribe func. The channel is buffered;
+// when full, the oldest events are dropped for that subscriber so a
+// slow client never blocks the publisher.
+func (b *Broker) Subscribe() (<-chan SSEEvent, func()) {
+	ch := make(chan SSEEvent, sseSubscriberBuffer)
+	b.mu.Lock()
+	b.subscribers[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch, func() {
+		b.mu.Lock()
+		if _, ok := b.subscribers[ch]; ok {
+			delete(b.subscribers, ch)
+			close(ch)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// Publish sends an event to all current subscribers. Events whose Type is
+// not a recognized live event are dropped. Subscribers whose buffer is
+// full have their oldest event dropped to make room — the publisher is
+// never blocked.
+func (b *Broker) Publish(ev SSEEvent) {
+	if !IsLiveEventType(ev.Type) {
+		return
+	}
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now().UTC()
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subscribers {
+		select {
+		case ch <- ev:
+		default:
+			// Drop oldest, then enqueue the new event. Best-effort.
+			select {
+			case <-ch:
+			default:
+			}
+			select {
+			case ch <- ev:
+			default:
+			}
+		}
+	}
+}
+
+// SubscriberCount returns the current number of subscribers. Primarily
+// useful for tests.
+func (b *Broker) SubscriberCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.subscribers)
+}
+
+// HandleEvents serves a long-lived SSE stream of live run events.
+//
+// Behavior:
+//   - Sends `Content-Type: text/event-stream` (plus no-cache, keep-alive,
+//     and X-Accel-Buffering: no for proxies).
+//   - Sends an initial `: connected` comment so EventSource fires onopen.
+//   - Sends a heartbeat comment every 15 seconds so idle connections
+//     don't get dropped by intermediaries.
+//   - Closes when the request context is canceled (client disconnect or
+//     server shutdown).
+func (h *Handlers) HandleEvents(w http.ResponseWriter, r *http.Request) {
+	if h.broker == nil {
+		writeError(w, http.StatusServiceUnavailable, "live events broker not configured")
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming unsupported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := fmt.Fprint(w, ": connected\n\n"); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	ch, unsubscribe := h.broker.Subscribe()
+	defer unsubscribe()
+
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			payload, err := json.Marshal(ev)
+			if err != nil {
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// SetBroker attaches a Broker so /api/events can stream live events.
+func (h *Handlers) SetBroker(b *Broker) { h.broker = b }
+
+// Broker exposes the configured broker. May be nil if SSE is disabled.
+func (h *Handlers) Broker() *Broker { return h.broker }
+
+// PublishLiveEvent is a convenience helper that publishes an event when
+// a broker is configured. Safe to call when no broker is set.
+func (h *Handlers) PublishLiveEvent(ev SSEEvent) {
+	if h.broker == nil {
+		return
+	}
+	h.broker.Publish(ev)
+}

--- a/internal/webapi/sse_tailer.go
+++ b/internal/webapi/sse_tailer.go
@@ -1,0 +1,331 @@
+package webapi
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SessionLogTailer watches a directory for `*-session.jsonl` files
+// (the format written by `waza run --session-log`) and publishes the
+// decoded session events to a Broker as SSE-shaped events.
+//
+// It is intentionally simple: it polls the directory for the most
+// recently modified `*-session.jsonl` file and tails it. When a newer
+// session log appears, it switches to the new file. The previous file
+// is closed and any unread tail is read first to flush late events.
+type SessionLogTailer struct {
+	dir      string
+	broker   *Broker
+	logger   *slog.Logger
+	interval time.Duration
+}
+
+// NewSessionLogTailer creates a tailer that watches dir and publishes
+// to broker. interval controls how often the directory is rescanned
+// for newer session files; pass 0 for the default (500ms).
+func NewSessionLogTailer(dir string, broker *Broker, logger *slog.Logger, interval time.Duration) *SessionLogTailer {
+	if interval <= 0 {
+		interval = 500 * time.Millisecond
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SessionLogTailer{
+		dir:      dir,
+		broker:   broker,
+		logger:   logger,
+		interval: interval,
+	}
+}
+
+// Run blocks until ctx is canceled, watching the directory for
+// session log files and publishing events to the broker.
+func (t *SessionLogTailer) Run(ctx context.Context) {
+	if t.broker == nil {
+		return
+	}
+
+	var (
+		curPath string
+		curFile *os.File
+		reader  *bufio.Reader
+	)
+
+	closeCurrent := func() {
+		if curFile != nil {
+			_ = curFile.Close()
+		}
+		curFile = nil
+		reader = nil
+		curPath = ""
+	}
+	defer closeCurrent()
+
+	tick := time.NewTicker(t.interval)
+	defer tick.Stop()
+
+	// Track which files we've already seen so we don't re-publish
+	// historical events when serve starts after a run completes. We
+	// only tail files that appear OR change after the tailer starts.
+	startTime := time.Now()
+	seenInitial := make(map[string]struct{})
+	if entries, err := listSessionLogs(t.dir); err == nil {
+		for _, e := range entries {
+			seenInitial[e.path] = struct{}{}
+		}
+	}
+
+	var emitter sessionEmitter
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+
+		newest, err := newestSessionLog(t.dir)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				t.logger.Debug("session-log tailer: scan error", "error", err)
+			}
+			continue
+		}
+		if newest.path == "" {
+			continue
+		}
+
+		// Skip files that already existed when we started AND haven't
+		// been modified since we started. This avoids replaying
+		// completed runs into new clients.
+		if _, ok := seenInitial[newest.path]; ok && !newest.modTime.After(startTime) {
+			continue
+		}
+
+		if newest.path != curPath {
+			closeCurrent()
+			f, err := os.Open(newest.path)
+			if err != nil {
+				t.logger.Debug("session-log tailer: open failed", "path", newest.path, "error", err)
+				continue
+			}
+			curFile = f
+			curPath = newest.path
+			reader = bufio.NewReader(f)
+			emitter = sessionEmitter{}
+			t.logger.Debug("session-log tailer: tailing new file", "path", newest.path)
+		}
+
+		// Read any new lines available.
+		for {
+			line, err := reader.ReadString('\n')
+			if len(line) > 0 {
+				emitter.emit(t.broker, strings.TrimRight(line, "\r\n"))
+			}
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				t.logger.Debug("session-log tailer: read error", "path", curPath, "error", err)
+				break
+			}
+		}
+	}
+}
+
+// sessionEmitter converts decoded session.Event lines into SSE events
+// and tracks per-run aggregates needed to synthesize the run_complete
+// event when the underlying log records session_complete.
+type sessionEmitter struct {
+	totalTasks int
+	passCount  int
+}
+
+func (e *sessionEmitter) emit(broker *Broker, line string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+	var raw struct {
+		Timestamp time.Time      `json:"timestamp"`
+		Type      string         `json:"type"`
+		Data      map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return
+	}
+	switch raw.Type {
+	case "task_start":
+		broker.Publish(SSEEvent{
+			Type:      "task_start",
+			Timestamp: raw.Timestamp,
+			Data: map[string]any{
+				"taskName": stringField(raw.Data, "task_name"),
+			},
+		})
+	case "task_complete":
+		passed := stringField(raw.Data, "status") == "pass"
+		if passed {
+			e.passCount++
+		}
+		e.totalTasks++
+		broker.Publish(SSEEvent{
+			Type:      "task_complete",
+			Timestamp: raw.Timestamp,
+			Data: map[string]any{
+				"taskName": stringField(raw.Data, "task_name"),
+				"outcome":  stringField(raw.Data, "status"),
+				"score":    floatField(raw.Data, "score"),
+				"duration": floatField(raw.Data, "duration_ms"),
+			},
+		})
+	case "grader_result":
+		broker.Publish(SSEEvent{
+			Type:      "grader_result",
+			Timestamp: raw.Timestamp,
+			Data: map[string]any{
+				"graderName": stringField(raw.Data, "grader_name"),
+				"graderType": stringField(raw.Data, "grader_type"),
+				"passed":     boolField(raw.Data, "passed"),
+				"score":      floatField(raw.Data, "score"),
+				"message":    stringField(raw.Data, "feedback"),
+			},
+		})
+	case "session_complete":
+		total := intField(raw.Data, "total_tests")
+		pass := intField(raw.Data, "passed")
+		if total == 0 {
+			total = e.totalTasks
+		}
+		if pass == 0 {
+			pass = e.passCount
+		}
+		broker.Publish(SSEEvent{
+			Type:      "run_complete",
+			Timestamp: raw.Timestamp,
+			Data: map[string]any{
+				"totalTasks": total,
+				"passCount":  pass,
+			},
+		})
+		e.totalTasks = 0
+		e.passCount = 0
+	}
+}
+
+type sessionLogEntry struct {
+	path    string
+	modTime time.Time
+}
+
+func listSessionLogs(dir string) ([]sessionLogEntry, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []sessionLogEntry
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, "-session.jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		out = append(out, sessionLogEntry{
+			path:    filepath.Join(dir, name),
+			modTime: info.ModTime(),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].modTime.After(out[j].modTime)
+	})
+	return out, nil
+}
+
+func newestSessionLog(dir string) (sessionLogEntry, error) {
+	entries, err := listSessionLogs(dir)
+	if err != nil {
+		return sessionLogEntry{}, err
+	}
+	if len(entries) == 0 {
+		return sessionLogEntry{}, nil
+	}
+	return entries[0], nil
+}
+
+// StartSessionLogTailer is a convenience that spawns a goroutine
+// running the tailer for the lifetime of ctx.
+func StartSessionLogTailer(ctx context.Context, dir string, broker *Broker, logger *slog.Logger) {
+	t := NewSessionLogTailer(dir, broker, logger, 0)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		t.Run(ctx)
+	}()
+	go func() {
+		<-ctx.Done()
+		wg.Wait()
+	}()
+}
+
+func stringField(m map[string]any, k string) string {
+	if v, ok := m[k]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func boolField(m map[string]any, k string) bool {
+	if v, ok := m[k]; ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+func floatField(m map[string]any, k string) float64 {
+	if v, ok := m[k]; ok {
+		switch n := v.(type) {
+		case float64:
+			return n
+		case int:
+			return float64(n)
+		case int64:
+			return float64(n)
+		}
+	}
+	return 0
+}
+
+func intField(m map[string]any, k string) int {
+	if v, ok := m[k]; ok {
+		switch n := v.(type) {
+		case float64:
+			return int(n)
+		case int:
+			return n
+		case int64:
+			return int(n)
+		}
+	}
+	return 0
+}

--- a/internal/webapi/sse_test.go
+++ b/internal/webapi/sse_test.go
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBrokerPublishFanOut(t *testing.T) {
+	t.Parallel()
+	b := NewBroker()
+
+	a, unsubA := b.Subscribe()
+	defer unsubA()
+	c, unsubC := b.Subscribe()
+	defer unsubC()
+
+	if got := b.SubscriberCount(); got != 2 {
+		t.Fatalf("subscriber count = %d, want 2", got)
+	}
+
+	b.Publish(SSEEvent{Type: "task_start", Data: map[string]any{"taskName": "t1"}})
+
+	for i, ch := range []<-chan SSEEvent{a, c} {
+		select {
+		case ev := <-ch:
+			if ev.Type != "task_start" {
+				t.Errorf("subscriber %d got type %q", i, ev.Type)
+			}
+			if ev.Timestamp.IsZero() {
+				t.Errorf("subscriber %d: timestamp not set", i)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("subscriber %d: timed out waiting for event", i)
+		}
+	}
+}
+
+func TestBrokerDropsUnknownEventTypes(t *testing.T) {
+	t.Parallel()
+	b := NewBroker()
+	ch, unsub := b.Subscribe()
+	defer unsub()
+
+	b.Publish(SSEEvent{Type: "session_start"})
+	b.Publish(SSEEvent{Type: "task_start", Data: map[string]any{"taskName": "t"}})
+
+	select {
+	case ev := <-ch:
+		if ev.Type != "task_start" {
+			t.Fatalf("expected task_start, got %q", ev.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected task_start event")
+	}
+
+	select {
+	case ev := <-ch:
+		t.Fatalf("unexpected extra event: %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBrokerUnsubscribeRemovesSubscriber(t *testing.T) {
+	t.Parallel()
+	b := NewBroker()
+	_, unsub := b.Subscribe()
+	if got := b.SubscriberCount(); got != 1 {
+		t.Fatalf("count = %d, want 1", got)
+	}
+	unsub()
+	if got := b.SubscriberCount(); got != 0 {
+		t.Fatalf("count after unsubscribe = %d, want 0", got)
+	}
+	// Calling unsubscribe twice must be safe.
+	unsub()
+}
+
+func TestHandleEventsServesEventStream(t *testing.T) {
+	t.Parallel()
+	h := NewHandlers(nil)
+	h.SetBroker(NewBroker())
+
+	mux := http.NewServeMux()
+	RegisterRoutesWithHandlers(mux, h)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/events", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", got)
+	}
+
+	// Publish from another goroutine.
+	go func() {
+		// Tiny delay so the SSE handler subscribes before we publish.
+		time.Sleep(50 * time.Millisecond)
+		h.PublishLiveEvent(SSEEvent{
+			Type: "task_start",
+			Data: map[string]any{"taskName": "alpha"},
+		})
+	}()
+
+	buf := make([]byte, 4096)
+	deadline := time.Now().Add(2 * time.Second)
+	var collected string
+	for time.Now().Before(deadline) {
+		_ = resp.Request.Context()
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			collected += string(buf[:n])
+			if strings.Contains(collected, `"type":"task_start"`) {
+				break
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	if !strings.Contains(collected, `"type":"task_start"`) {
+		t.Fatalf("did not receive task_start event; got: %q", collected)
+	}
+	if !strings.Contains(collected, `"taskName":"alpha"`) {
+		t.Errorf("expected taskName in payload; got: %q", collected)
+	}
+	if !strings.HasPrefix(collected, ": connected") {
+		t.Errorf("expected initial \": connected\" comment; got: %q", collected)
+	}
+}
+
+func TestHandleEventsReturns503WithoutBroker(t *testing.T) {
+	t.Parallel()
+	h := NewHandlers(nil)
+	mux := http.NewServeMux()
+	RegisterRoutesWithHandlers(mux, h)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rr.Code)
+	}
+}
+
+func TestRegisterRoutesIncludesEvents(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, nil)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusNotFound {
+		t.Fatalf("/api/events not registered (404)")
+	}
+}
+
+func TestSessionLogTailerPublishesEvents(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	broker := NewBroker()
+	ch, unsub := broker.Subscribe()
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tailer := NewSessionLogTailer(dir, broker, nil, 20*time.Millisecond)
+	go tailer.Run(ctx)
+
+	// Give the tailer a moment to record its initial-scan baseline.
+	time.Sleep(50 * time.Millisecond)
+
+	logPath := filepath.Join(dir, "20260101T000000Z-session.jsonl")
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	writeEvent := func(t *testing.T, kind string, data map[string]any) {
+		t.Helper()
+		ev := map[string]any{
+			"timestamp": time.Now().UTC(),
+			"type":      kind,
+			"data":      data,
+		}
+		b, err := json.Marshal(ev)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(append(b, '\n')); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeEvent(t, "task_start", map[string]any{"task_name": "alpha", "task_num": 1, "total_tasks": 2})
+	writeEvent(t, "task_complete", map[string]any{"task_name": "alpha", "status": "pass", "score": 1.0, "duration_ms": int64(123)})
+	writeEvent(t, "grader_result", map[string]any{"grader_name": "code", "grader_type": "code", "passed": true, "score": 1.0, "feedback": "ok"})
+	writeEvent(t, "session_complete", map[string]any{"total_tests": 1, "passed": 1, "failed": 0, "errors": 0, "duration_ms": int64(456)})
+
+	want := []string{"task_start", "task_complete", "grader_result", "run_complete"}
+	got := make([]string, 0, len(want))
+
+	timeout := time.After(3 * time.Second)
+	for len(got) < len(want) {
+		select {
+		case ev := <-ch:
+			got = append(got, ev.Type)
+		case <-timeout:
+			t.Fatalf("timed out; got events: %v", got)
+		}
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("event[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSessionLogTailerSkipsPreexistingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	logPath := filepath.Join(dir, "20260101T000000Z-session.jsonl")
+	pre := []byte(`{"timestamp":"2026-01-01T00:00:00Z","type":"task_start","data":{"task_name":"old"}}` + "\n")
+	if err := os.WriteFile(logPath, pre, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	broker := NewBroker()
+	ch, unsub := broker.Subscribe()
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tailer := NewSessionLogTailer(dir, broker, nil, 20*time.Millisecond)
+	go tailer.Run(ctx)
+
+	select {
+	case ev := <-ch:
+		t.Fatalf("unexpected event from pre-existing file: %+v", ev)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/internal/webserver/routes.go
+++ b/internal/webserver/routes.go
@@ -12,7 +12,7 @@ import (
 )
 
 // registerRoutes sets up API and SPA routes on the given mux.
-func registerRoutes(mux *http.ServeMux, cfg Config) error {
+func registerRoutes(mux *http.ServeMux, cfg Config, broker *webapi.Broker) error {
 	var runStore webapi.RunStore
 	var storageCfg *webapi.StorageConfig
 
@@ -57,8 +57,12 @@ func registerRoutes(mux *http.ServeMux, cfg Config) error {
 		}
 	}
 
-	// Register API routes with storage configuration.
-	webapi.RegisterRoutesWithStorage(mux, runStore, storageCfg)
+	// Register API routes with storage configuration and SSE broker.
+	h := webapi.NewHandlersWithStorage(runStore, storageCfg)
+	if broker != nil {
+		h.SetBroker(broker)
+	}
+	webapi.RegisterRoutesWithHandlers(mux, h)
 
 	// SPA static files with HTML5 history API fallback
 	handler, err := spaHandler()

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/microsoft/waza/internal/projectconfig"
+	"github.com/microsoft/waza/internal/webapi"
 )
 
 // Config holds the HTTP server configuration.
@@ -28,6 +29,7 @@ type Server struct {
 	cfg    Config
 	srv    *http.Server
 	logger *slog.Logger
+	broker *webapi.Broker
 }
 
 // New creates a new HTTP server with the given configuration.
@@ -43,9 +45,11 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	mux := http.NewServeMux()
+	broker := webapi.NewBroker()
 	s := &Server{
 		cfg:    cfg,
 		logger: cfg.Logger,
+		broker: broker,
 		srv: &http.Server{
 			Addr:              fmt.Sprintf("127.0.0.1:%d", cfg.Port),
 			Handler:           mux,
@@ -53,7 +57,7 @@ func New(cfg Config) (*Server, error) {
 		},
 	}
 
-	if err := registerRoutes(mux, cfg); err != nil {
+	if err := registerRoutes(mux, cfg, broker); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -64,6 +68,12 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 	url := fmt.Sprintf("http://localhost:%d", s.cfg.Port)
 	s.logger.Info("HTTP server starting", "address", s.srv.Addr, "url", url)
 	fmt.Printf("waza dashboard: %s\n", url)
+
+	// Tail session log files in the configured results directory and
+	// publish events to SSE subscribers. Stops when ctx is canceled.
+	if s.broker != nil && s.cfg.ResultsDir != "" {
+		webapi.StartSessionLogTailer(ctx, s.cfg.ResultsDir, s.broker, s.logger)
+	}
 
 	if !s.cfg.NoBrowser {
 		// Open browser in background after a short delay.


### PR DESCRIPTION
Closes #178.

## Summary
The Live view in the dashboard (`web/src/hooks/useSSE.ts` + `LiveView.tsx`) opens `EventSource('/api/events')` and expects `task_start`, `task_complete`, `grader_result`, and `run_complete` events. The backend never registered that route, so `curl /api/events` returned the dashboard HTML shell. This PR adds the SSE endpoint and wires it to the existing run/session event stream.

## Changes
- **`internal/webapi/sse.go`** — new `Broker` (drop-oldest pub/sub) + `HandleEvents` SSE handler. Sends `: connected` preamble, 15s heartbeats, JSON-encoded `{type, data, timestamp}` frames. Filters to the four contract event types.
- **`internal/webapi/sse_tailer.go`** — `SessionLogTailer` polls the results directory, tails new `*-session.jsonl` files written by `waza run --session-log`, and republishes events through the broker. Maps session-event field names (`task_name`, `duration_ms`, …) to the camelCase keys the frontend reads. Synthesizes `run_complete` from `session_complete`. Skips pre-existing finished runs.
- **`internal/webapi/handlers.go`** — adds `broker` to `Handlers`, factors out `registerHandlerRoutes`, exposes new `RegisterRoutesWithHandlers` so callers can pre-configure state. Registers `GET /api/events`.
- **`internal/webserver/{server,routes}.go`** — creates a `Broker` in `New`, calls `StartSessionLogTailer` against `cfg.ResultsDir` from `ListenAndServe`, threads the broker through `registerRoutes`.
- **`internal/webapi/sse_test.go`** — 8 new tests covering broker fan-out, unknown-type filtering, unsubscribe idempotency, response headers/body, route registration, the 503 path when no broker is configured, tailer event translation, and skipping pre-existing logs.

## Process model note
`waza serve` and `waza run` are separate processes. The only shared channel is the filesystem session log, which is why the wiring tails `*-session.jsonl` rather than using an in-process bus. If we later run dashboard + run in one process, we can additionally have `cmd_run` publish directly via `Handlers.PublishLiveEvent`.

## Validation
- `go test ./...` — all packages green
- `golangci-lint run ./...` — 0 issues
- Manual repro:
  ```
  waza serve --port 18080 --no-browser
  curl -i http://127.0.0.1:18080/api/events
  ```
  Now returns `HTTP/1.1 200`, `Content-Type: text/event-stream`, and a `: connected` body — previously returned the dashboard HTML.

## Out of scope
- No frontend changes; the existing `useSSE.ts` already speaks this contract.
- No changes to other backlog items in #66.