### PR TITLE
feat: add ADC runner container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !docs.go
 !docs/graders/
 !version.txt
+!Dockerfile.adc-runner
 
 # Re-exclude some files pulled in by the allowlist above
 **/*_test.go

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,10 +1,14 @@
 name: Docker Build and Verify
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
+    tags:
+      - 'v*.*.*'
     paths: &docker-paths
       - 'Dockerfile'
+      - 'Dockerfile.adc-runner'
       - '.dockerignore'
       - 'go.mod'
       - 'go.sum'
@@ -19,10 +23,28 @@ on:
     branches: [main]
     paths: *docker-paths
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker-build:
-    name: Build and Verify Docker Image
+    name: Build and Verify ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: waza
+            file: Dockerfile
+            local-tag: waza
+            verify-command: --version
+            publish: false
+          - name: adc-runner
+            file: Dockerfile.adc-runner
+            local-tag: waza-adc-runner
+            verify-command: waza --version
+            publish: true
 
     steps:
       - name: Checkout Repository
@@ -33,15 +55,56 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
+      - name: Build Docker image locally
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ${{ matrix.file }}
           push: false
           load: true
-          tags: waza:ci-${{ github.sha }}
+          tags: ${{ matrix.local-tag }}:ci-${{ github.sha }}
+          build-args: |
+            WAZA_VERSION=ci-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
 
       - name: Verify
-        run: docker run --rm waza:ci-${{ github.sha }} --version
+        run: docker run --rm ${{ matrix.local-tag }}:ci-${{ github.sha }} ${{ matrix.verify-command }}
+
+      - name: Verify ADC runner Copilot CLI
+        if: matrix.publish
+        run: docker run --rm ${{ matrix.local-tag }}:ci-${{ github.sha }} copilot-cli --version
+
+      - name: Log in to GitHub Container Registry
+        if: matrix.publish && github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate ADC runner image metadata
+        if: matrix.publish && github.event_name != 'pull_request'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/adc-runner
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Publish ADC runner image
+        if: matrix.publish && github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            WAZA_VERSION=${{ github.ref_type == 'tag' && github.ref_name || format('sha-{0}', github.sha) }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min

--- a/Dockerfile.adc-runner
+++ b/Dockerfile.adc-runner
@@ -1,0 +1,97 @@
+# syntax=docker/dockerfile:1.7
+
+# ADC runner image for fast sandbox startup.
+# It pre-bakes the waza binary and extracts the bundled GitHub Copilot CLI into
+# a stable path so the copilot-sdk executor avoids first-run decompression.
+
+FROM node:22-bookworm-slim AS web-builder
+
+WORKDIR /build/web
+
+COPY web/package.json web/package-lock.json ./
+RUN npm ci --silent
+
+COPY web/ ./
+RUN npm run build
+
+FROM golang:1.26-bookworm AS builder
+
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+ARG WAZA_VERSION=dev
+
+WORKDIR /build
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+COPY --from=web-builder /build/web/dist/ web/dist/
+
+RUN CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
+	go build -trimpath -ldflags "-s -w -X main.version=${WAZA_VERSION}" -o /out/waza ./cmd/waza
+
+RUN <<'EOF'
+set -eu
+mkdir -p .adc-preload
+cat > .adc-preload/main.go <<'GOEOF'
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/microsoft/waza/internal/embedded"
+)
+
+func main() {
+	path, err := embedded.Path()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println(path)
+}
+GOEOF
+XDG_CACHE_HOME=/opt/waza-cache go run ./.adc-preload > /tmp/copilot-cli-path
+install -m 0755 "$(cat /tmp/copilot-cli-path)" /out/copilot
+install -m 0644 "$(cat /tmp/copilot-cli-path).license" /out/copilot.license
+rm -rf .adc-preload /tmp/copilot-cli-path
+EOF
+
+RUN /out/waza --version && /out/copilot --version
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		bash \
+		ca-certificates \
+		curl \
+		git \
+		openssh-client \
+		tini \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash --uid 10001 waza
+
+WORKDIR /workspace
+
+COPY --from=builder /out/waza /usr/local/bin/waza
+COPY --from=builder /out/copilot /usr/local/bin/copilot
+COPY --from=builder /out/copilot.license /usr/local/bin/copilot.license
+
+RUN ln -s /usr/local/bin/copilot /usr/local/bin/copilot-cli \
+	&& mkdir -p /workspace /home/waza/.cache \
+	&& chown -R waza:waza /workspace /home/waza
+
+ENV COPILOT_CLI_PATH=/usr/local/bin/copilot \
+	HOME=/home/waza \
+	WAZA_NO_UPDATE_CHECK=1
+
+USER waza
+
+RUN waza --version && "$COPILOT_CLI_PATH" --version
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ The PowerShell script downloads the latest standalone native Windows `waza` bina
 
 Or browse the [GitHub Releases](https://github.com/microsoft/waza/releases) page and choose the standalone waza binary assets for the version you want.
 
+### Container Images
+
+The standard Docker image packages the `waza` CLI for containerized CI jobs:
+
+```bash
+docker build -t waza:local .
+docker run --rm -v "$PWD:/workspace" waza:local run eval.yaml
+```
+
+Waza also ships an ADC runner image definition at `Dockerfile.adc-runner`. It pre-bakes the `waza` binary plus the bundled GitHub Copilot CLI at `/usr/local/bin/copilot` and sets `COPILOT_CLI_PATH` so ADC sandboxes avoid first-run Copilot CLI extraction. The image defaults to `sleep infinity` for sandbox lifecycle compatibility, while commands can still be executed directly:
+
+```bash
+docker build -f Dockerfile.adc-runner -t waza-adc-runner:local .
+docker run --rm waza-adc-runner:local waza --version
+docker run --rm waza-adc-runner:local copilot-cli --version
+```
+
+The CI workflow publishes the ADC runner image to `ghcr.io/microsoft/waza/adc-runner` on `main`, version tags, and manual dispatch. Promotion from that OCI image into an ADC disk image still depends on the target ADC space, labels, and release policy.
+
 ### Install from Source
 
 Requires Go 1.26+:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This document describes how the Waza release process works. All releases are handled by the unified workflow at `.github/workflows/release.yml`.
+This document describes how the Waza release process works. CLI and azd extension releases are handled by the unified workflow at `.github/workflows/release.yml`; container image verification and ADC runner image publishing are handled by `.github/workflows/docker-ci.yml`.
 
 ## Cutting a Release
 
@@ -11,15 +11,16 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-This triggers the full pipeline: CLI build → extension build → GitHub Release → extension publish → version sync → GitHub Pages deploy.
+This triggers the full pipeline: CLI build -> extension build -> GitHub Release -> extension publish -> ADC runner image publish -> version sync -> GitHub Pages deploy.
 
 ## What the Workflow Does
 
-1. **setup-version** — Extracts the version from the pushed tag (strips `v`) and validates semver format.
-2. **build-cli** — Matrix build for 6 platforms (linux, darwin, windows × amd64, arm64). Builds the web UI then produces `waza-{os}-{arch}` binaries.
-3. **release-cli** — Downloads CLI artifacts, generates SHA256 checksums, and creates the **CLI GitHub Release** (`Waza vX.Y.Z`) with standalone binaries attached.
-4. **release-extension** — Syncs `version.txt` and `extension.yaml`, builds the web UI, builds and packs the azd extension, creates the **Extension GitHub Release** (`Waza azd Extension vX.Y.Z`), publishes to the azd registry, then opens a PR with updated `registry.json` and synced version files.
-5. **pages.yml** — Deploys the documentation site after the `Release` workflow completes successfully, ensuring release notes and download links published to `site/` are pushed to GitHub Pages.
+1. **setup-version** - Extracts the version from the pushed tag (strips `v`) and validates semver format.
+2. **build-cli** - Matrix build for 6 platforms (linux, darwin, windows x amd64, arm64). Builds the web UI then produces `waza-{os}-{arch}` binaries.
+3. **release-cli** - Downloads CLI artifacts, generates SHA256 checksums, and creates the **CLI GitHub Release** (`Waza vX.Y.Z`) with standalone binaries attached.
+4. **release-extension** - Syncs `version.txt` and `extension.yaml`, builds the web UI, builds and packs the azd extension, creates the **Extension GitHub Release** (`Waza azd Extension vX.Y.Z`), publishes to the azd registry, then opens a PR with updated `registry.json` and synced version files.
+5. **docker-ci.yml** - Builds and verifies container images. For `Dockerfile.adc-runner`, publishes `ghcr.io/microsoft/waza/adc-runner` on `main`, `vX.Y.Z` tags, and manual dispatch.
+6. **pages.yml** - Deploys the documentation site after the `Release` workflow completes successfully, ensuring release notes and download links published to `site/` are pushed to GitHub Pages.
 
 ## Version File Locations
 

--- a/docs/SKILLS_CI_INTEGRATION.md
+++ b/docs/SKILLS_CI_INTEGRATION.md
@@ -48,6 +48,16 @@ docker build -t waza:local .
 docker run -v $(pwd):/workspace waza:local run eval.yaml
 ```
 
+For ADC sandboxes, build the dedicated runner image instead:
+
+```bash
+docker build -f Dockerfile.adc-runner -t waza-adc-runner:local .
+docker run --rm waza-adc-runner:local waza --version
+docker run --rm waza-adc-runner:local copilot-cli --version
+```
+
+`Dockerfile.adc-runner` pre-bakes the `waza` binary and extracts the bundled GitHub Copilot CLI to `/usr/local/bin/copilot`, with `COPILOT_CLI_PATH` set for the `copilot-sdk` executor. The published OCI image is `ghcr.io/microsoft/waza/adc-runner`; ADC disk-image promotion requires environment-specific ADC space and labeling details.
+
 Benefits:
 - Isolated environment
 - Reproducible builds

--- a/site/src/content/docs/guides/ci-cd.mdx
+++ b/site/src/content/docs/guides/ci-cd.mdx
@@ -45,6 +45,25 @@ cd waza
 go build -o waza ./cmd/waza
 ```
 
+### Via Container
+
+Use the standard Docker image for containerized CI jobs:
+
+```bash
+docker build -t waza:local .
+docker run --rm -v "$PWD:/workspace" waza:local run eval.yaml
+```
+
+ADC sandbox runners should use `Dockerfile.adc-runner` instead. It pre-bakes the `waza` binary and extracts the bundled GitHub Copilot CLI to `/usr/local/bin/copilot`, with `COPILOT_CLI_PATH` already set:
+
+```bash
+docker build -f Dockerfile.adc-runner -t waza-adc-runner:local .
+docker run --rm waza-adc-runner:local waza --version
+docker run --rm waza-adc-runner:local copilot-cli --version
+```
+
+CI publishes the ADC runner OCI image to `ghcr.io/microsoft/waza/adc-runner` on `main`, `vX.Y.Z` tags, and manual dispatch. Promoting that OCI image into an ADC disk image still requires environment-specific ADC space, label, and release-policy details.
+
 ## GitHub Actions
 
 ### Quick Start ΓÇö Scaffold with waza init


### PR DESCRIPTION
## Summary

Closes #177

Implemented a production-ready first pass for the ADC runner container image:

- Added `Dockerfile.adc-runner` that builds the web assets, builds a static Linux `waza` binary, pre-extracts the bundled GitHub Copilot CLI, installs it at `/usr/local/bin/copilot`, exposes `/usr/local/bin/copilot-cli`, and sets `COPILOT_CLI_PATH` for `copilot-sdk` startup speed.
- Uses a sandbox-friendly runtime contract: Debian slim, non-root `waza` user, common runtime tools (`bash`, `git`, `curl`, `openssh-client`, `tini`), `/workspace` workdir, and default `sleep infinity` command.
- Extended Docker CI to build and verify both the standard `Dockerfile` image and the new ADC runner image.
- Added GHCR publishing for the ADC runner image at `ghcr.io/microsoft/waza/adc-runner` on `main`, `v*.*.*` tags, and manual workflow dispatch.
- Updated README, CI integration docs, release docs, and the public docs site CI/CD guide.

## Conservative defaults chosen

- Registry: `ghcr.io/microsoft/waza/adc-runner`.
- Tags: branch refs, version tags, `sha-*`, and `latest` only on the default branch.
- Runtime: Debian slim rather than Alpine for broader CLI/tool compatibility inside ADC sandboxes.
- Sandbox lifecycle: default command keeps the sandbox alive; callers can override with `waza`, `copilot-cli`, or shell commands.

## Pending clarification / TODOs

- Confirm the final ADC disk-image promotion mechanism from the GHCR OCI image, including target ADC space ID, labels, and whether promotion should happen in this repo or a downstream platform pipeline.
- Confirm whether image signing, SBOM generation, vulnerability thresholds, or attestations are required before the image is considered release-ready.
- Confirm whether additional sandbox tools should be preinstalled beyond the conservative shell/git/curl/ssh baseline.
- Confirm whether the release tag passed into `WAZA_VERSION` should keep the leading `v` for container builds or be normalized to match standalone CLI release binaries.

## Validation

- `go test ./...`
- `git diff --check`
- Parsed `.github/workflows/docker-ci.yml` with PyYAML
- Verified the Copilot CLI pre-extraction logic by importing `internal/embedded`, extracting to a fresh cache, and running the extracted CLI `--version`
- `cd site && npm ci --silent && npm run build`

## Not run

- `docker build -f Dockerfile.adc-runner ...` could not run locally because the Docker daemon is unavailable in this environment (`Cannot connect to the Docker daemon at unix:///Users/shboyer/.docker/run/docker.sock`). The Docker CI workflow now covers this build and runtime verification.