### PR TITLE
feat: ADC runner disk image (Dockerfile.adc-runner) — #177

### DIFF
--- a/.github/workflows/docker-adc-runner.yml
+++ b/.github/workflows/docker-adc-runner.yml
@@ -1,0 +1,175 @@
+name: ADC Runner Image
+
+# Builds and publishes the ADC sandbox disk image for the Waza Platform.
+#
+# Image: ghcr.io/microsoft/waza/adc-runner
+#
+# Triggers:
+#   • push to main (touching the runner inputs)   → :main, :sha-<sha>
+#   • tag push v*.*.*                             → :latest, :<version>, :v<major>, :v<major>.<minor>
+#   • pull_request to main (build-only, no push)  → smoke test
+#   • workflow_dispatch                           → manual rebuild
+#
+# Multi-arch: linux/amd64, linux/arm64.
+
+on:
+  push:
+    branches: [main]
+    paths: &adc-paths
+      - 'Dockerfile.adc-runner'
+      - '.dockerignore'
+      - 'go.mod'
+      - 'go.sum'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'web/**'
+      - 'schemas/**'
+      - 'docs.go'
+      - 'docs/graders/**'
+      - '.github/workflows/docker-adc-runner.yml'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches: [main]
+    paths: *adc-paths
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Additional tag to publish (in addition to sha-based tag)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/adc-runner
+
+jobs:
+  build-and-publish:
+    name: Build and Publish ADC Runner
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        # Only log in when we're going to push. PRs from forks can't access
+        # GHCR credentials anyway, so this also keeps fork CI green.
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="0.0.0-$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved WAZA_VERSION=${VERSION}"
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=short
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
+
+      # PR builds: single-arch, build-only, for fast verification.
+      - name: Build (PR — verify only, single arch)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.adc-runner
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: waza-adc-runner:pr-${{ github.event.pull_request.number }}
+          build-args: |
+            WAZA_VERSION=${{ steps.version.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+          cache-from: type=gha,scope=adc-runner
+          cache-to: type=gha,mode=max,scope=adc-runner
+
+      - name: Smoke test (PR build)
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm waza-adc-runner:pr-${{ github.event.pull_request.number }} \
+            /usr/local/bin/waza --version
+          docker run --rm --entrypoint /bin/bash \
+            waza-adc-runner:pr-${{ github.event.pull_request.number }} \
+            -c 'test -d "$XDG_CACHE_HOME/copilot-sdk" && ls "$XDG_CACHE_HOME/copilot-sdk"'
+
+      # Publish builds: multi-arch, pushed to GHCR.
+      - name: Build and Push (multi-arch)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.adc-runner
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            WAZA_VERSION=${{ steps.version.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+          cache-from: type=gha,scope=adc-runner
+          cache-to: type=gha,mode=max,scope=adc-runner
+          provenance: true
+          sbom: true
+
+      - name: Smoke test pushed image (amd64)
+        if: github.event_name != 'pull_request'
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.meta.outputs.digest || '' }}"
+          # Fall back to first tag if digest isn't exposed by this action version.
+          if [[ -z "${{ steps.meta.outputs.digest }}" ]]; then
+            IMAGE=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          fi
+          docker run --rm --platform linux/amd64 "$IMAGE" \
+            /usr/local/bin/waza --version
+          docker run --rm --platform linux/amd64 --entrypoint /bin/bash "$IMAGE" \
+            -c 'test -d "$XDG_CACHE_HOME/copilot-sdk" && echo "Copilot CLI cache OK:" && ls "$XDG_CACHE_HOME/copilot-sdk"'
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## ADC Runner Image"
+            echo ""
+            echo "**Version:** \`${{ steps.version.outputs.version }}\`"
+            echo ""
+            echo "**Tags:**"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ADC runner disk image** — New `Dockerfile.adc-runner` plus `.github/workflows/docker-adc-runner.yml` publish the pre-baked ADC sandbox image to `ghcr.io/microsoft/waza/adc-runner` (linux/amd64 + linux/arm64). Image bundles the `waza` CLI and pre-extracts the embedded Copilot CLI cache so first-boot sandbox start-up skips the ~50 MB extraction. See [`docs/ADC-RUNNER.md`](docs/ADC-RUNNER.md) (#177)
+
 ## [0.37.0] - 2026-06-18
 
 ### Added

--- a/Dockerfile.adc-runner
+++ b/Dockerfile.adc-runner
@@ -1,0 +1,165 @@
+# syntax=docker/dockerfile:1.7
+# ────────────────────────────────────────────────────────────────────────────
+# Dockerfile.adc-runner — ADC sandbox disk image for the Waza Platform
+#
+# Pre-bakes:
+#   • The waza CLI binary (built from this repo)
+#   • The embedded GitHub Copilot CLI extracted into the image cache
+#   • Skill-runtime essentials (bash, git, curl, ca-certs, jq, node, npm)
+#
+# Target consumer: the hosted Waza Platform (epic #168). The platform calls
+# `DiskImages.Create` against the ADC SDK with `BaseImage = ghcr.io/microsoft/waza/adc-runner:<tag>`
+# and starts sandboxes with `Entrypoint=["/bin/sleep"], Cmd=["infinity"]`,
+# then runs evals via `ExecuteShellCommand`.
+#
+# Image contract (consumed by internal/platform/execution):
+#   - waza is on PATH at /usr/local/bin/waza
+#   - HOME=/opt/waza and XDG_CACHE_HOME=/opt/waza/cache are pre-populated so
+#     the first `waza` invocation skips Copilot CLI extraction
+#   - /workspace is the default working directory for sandboxed evals
+#   - GITHUB_TOKEN is expected at runtime (Copilot SDK auth)
+#
+# Published as:
+#   ghcr.io/microsoft/waza/adc-runner:<tag>
+#   (see .github/workflows/docker-adc-runner.yml)
+# ────────────────────────────────────────────────────────────────────────────
+
+# ── Stage 1: Build the web dashboard ────────────────────────────────────────
+FROM node:22-alpine AS web-builder
+
+WORKDIR /build/web
+
+COPY web/package.json web/package-lock.json ./
+RUN npm ci --silent
+
+COPY web/ ./
+RUN npm run build
+
+
+# ── Stage 2: Build the waza binary + pre-extract the embedded Copilot CLI ──
+FROM golang:1.26-bookworm AS go-builder
+
+WORKDIR /build
+
+# Cache module downloads first.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Bring in the source and the prebuilt web assets.
+COPY . .
+COPY --from=web-builder /build/web/dist/ web/dist/
+
+ARG WAZA_VERSION=dev
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+ENV CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH}
+
+RUN go build \
+        -trimpath \
+        -ldflags "-s -w -X main.version=${WAZA_VERSION}" \
+        -o /out/waza \
+        ./cmd/waza \
+ && /out/waza --version
+
+# Pre-extract the embedded Copilot CLI by invoking the same code path waza uses
+# at runtime. This warms the cache so the first sandbox call doesn't have to
+# write ~50MB to disk. We keep the cache under /opt/waza/cache and copy it into
+# the runtime stage as-is.
+RUN <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p /opt/waza/cache /build/internal/cmd/extractcli
+cat > /build/internal/cmd/extractcli/main.go <<'EOF'
+// Build-time helper: extract the embedded Copilot CLI into the cache so the
+// ADC runner image ships with a pre-warmed CLI. Lives under internal/ so the
+// import rule allows it to reach internal/embedded.
+package main
+
+import (
+	"fmt"
+
+	"github.com/microsoft/waza/internal/embedded"
+)
+
+func main() {
+	p, err := embedded.Path()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(p)
+}
+EOF
+HOME=/opt/waza XDG_CACHE_HOME=/opt/waza/cache \
+    go run ./internal/cmd/extractcli
+ls -la /opt/waza/cache/copilot-sdk/
+BASH
+
+
+# ── Stage 3: Runtime image (Ubuntu — matches typical ADC sandbox base) ─────
+FROM ubuntu:24.04 AS runtime
+
+ARG WAZA_VERSION=dev
+
+# Skill-runtime essentials. Kept intentionally small; add packages only when
+# concretely required by a published skill. Node + npm are included because
+# many community skills (and the embedded Copilot SDK MCP plumbing) shell out
+# to `node`/`npx`.
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        nodejs \
+        npm \
+        openssh-client \
+        tini \
+        tzdata \
+        unzip \
+        xz-utils \
+ && rm -rf /var/lib/apt/lists/* \
+ && update-ca-certificates
+
+# Stable, predictable home for the sandboxed agent. HOME and XDG_CACHE_HOME
+# match what was used during pre-extraction so the cached Copilot CLI is
+# discovered without a rewrite on first boot.
+ENV HOME=/opt/waza \
+    XDG_CACHE_HOME=/opt/waza/cache \
+    WAZA_ADC_RUNNER=1 \
+    PATH=/usr/local/bin:/usr/bin:/bin
+
+RUN mkdir -p /opt/waza /opt/waza/cache /workspace \
+ && chmod -R 0777 /opt/waza /workspace
+
+COPY --from=go-builder /out/waza /usr/local/bin/waza
+COPY --from=go-builder /opt/waza/cache/ /opt/waza/cache/
+
+# Verify the binary launches and the pre-extracted CLI is reachable.
+RUN waza --version \
+ && ls -la /opt/waza/cache/copilot-sdk/ 1>/dev/null
+
+WORKDIR /workspace
+
+# ADC sandboxes are long-lived: ExecuteShellCommand is the primary surface,
+# so we keep PID 1 alive with sleep infinity under tini for proper signal
+# handling. Override with `--entrypoint` for one-shot invocations.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/bin/sleep", "infinity"]
+
+# OCI labels — populated by the publish workflow.
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.title="waza ADC runner" \
+      org.opencontainers.image.description="Pre-baked ADC sandbox image for the Waza Platform (waza CLI + embedded Copilot CLI)" \
+      org.opencontainers.image.source="https://github.com/microsoft/waza" \
+      org.opencontainers.image.url="https://github.com/microsoft/waza" \
+      org.opencontainers.image.documentation="https://github.com/microsoft/waza/blob/main/docs/ADC-RUNNER.md" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${WAZA_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.vendor="Microsoft"

--- a/docs/ADC-RUNNER.md
+++ b/docs/ADC-RUNNER.md
@@ -1,0 +1,136 @@
+# ADC Runner Disk Image (`Dockerfile.adc-runner`)
+
+> Pre-baked disk image for the Waza Platform's ADC (Azure Dev Compute) sandboxes.
+>
+> Tracks: [#177](https://github.com/microsoft/waza/issues/177) (parent epic [#168](https://github.com/microsoft/waza/issues/168))
+
+## What it is
+
+A multi-stage Docker image that bundles everything the hosted Waza Platform
+needs to execute an eval inside an ADC sandbox **without** a cold-start cost:
+
+- **`waza` CLI** — built from this repo at image build time
+- **GitHub Copilot CLI** — pre-extracted from the binary's embedded bundle and
+  written to `$XDG_CACHE_HOME/copilot-sdk/` so the first invocation skips the
+  ~50 MB cache rehydration that normally happens on a fresh machine
+- **Skill runtime essentials** — `bash`, `git`, `curl`, `ca-certificates`,
+  `jq`, `nodejs`, `npm`, `openssh-client`, `tini`, `unzip`, `xz-utils`
+
+The image is published to **`ghcr.io/microsoft/waza/adc-runner`** by
+[`.github/workflows/docker-adc-runner.yml`](../.github/workflows/docker-adc-runner.yml).
+
+## Image contract
+
+The hosted platform creates sandboxes via the ADC SDK. The image is designed
+around that contract:
+
+| Aspect | Value |
+|---|---|
+| Registry / repo | `ghcr.io/microsoft/waza/adc-runner` |
+| Architectures | `linux/amd64`, `linux/arm64` |
+| Default entrypoint | `tini -- /bin/sleep infinity` (sandbox stays alive; `ExecuteShellCommand` does the work) |
+| `waza` location | `/usr/local/bin/waza` |
+| `HOME` | `/opt/waza` |
+| `XDG_CACHE_HOME` | `/opt/waza/cache` (pre-populated with `copilot-sdk/`) |
+| Working directory | `/workspace` (mount your eval workspace here) |
+| Marker env var | `WAZA_ADC_RUNNER=1` |
+| Required runtime env | `GITHUB_TOKEN` for the Copilot SDK |
+
+### How the platform consumes it
+
+```go
+// internal/platform/execution (conceptual)
+img, _ := client.DiskImages.Create(ctx, models.CreateDiskImageOptions{
+    Labels:    map[string]string{"name": "waza-adc-runner", "version": "0.37.0"},
+    BaseImage: "ghcr.io/microsoft/waza/adc-runner:0.37.0",
+})
+
+sb, _ := client.Sandboxes.CreateFromDiskImage(ctx, models.CreateFromDiskImageOptions{
+    DiskImage:  models.SandboxSourceDiskImage{ID: img.ID},
+    CPU:        "2",
+    Memory:     "4096Mi",
+    Entrypoint: []string{"/bin/sleep"},
+    Cmd:        []string{"infinity"},
+    Labels:     map[string]string{"name": "waza-run-" + runID},
+})
+
+res, _ := sb.ExecuteShellCommand(ctx,
+    "cd /workspace && waza run eval.yaml --context-dir fixtures -o /tmp/results.json",
+    "/workspace",
+    map[string]string{"GITHUB_TOKEN": token},
+    "")
+```
+
+## Tagging strategy
+
+| Trigger | Tags pushed |
+|---|---|
+| Tag push `v1.2.3` | `:latest`, `:1.2.3`, `:1.2`, `:1`, `:sha-<short>` |
+| Push to `main` | `:main`, `:sha-<short>` |
+| Manual dispatch | `:sha-<short>` (+ optional `tag` input) |
+| PR | Built (single-arch) and smoke-tested but **not pushed** |
+
+`:latest` is only ever moved by a real release tag — never by a `main` push.
+
+## Build & test locally
+
+```bash
+# Build
+docker build \
+  -f Dockerfile.adc-runner \
+  --build-arg WAZA_VERSION=$(cat version.txt) \
+  -t waza-adc-runner:local .
+
+# Verify the binary
+docker run --rm waza-adc-runner:local /usr/local/bin/waza --version
+
+# Verify the embedded Copilot CLI is pre-extracted
+docker run --rm --entrypoint /bin/bash waza-adc-runner:local \
+  -c 'ls -lh "$XDG_CACHE_HOME/copilot-sdk"'
+
+# Run a one-shot eval against a workspace on the host
+docker run --rm \
+  -v "$PWD/examples/code-explainer:/workspace" \
+  -e GITHUB_TOKEN \
+  --entrypoint /usr/local/bin/waza \
+  waza-adc-runner:local \
+    run /workspace/eval.yaml --context-dir /workspace/fixtures -v
+```
+
+## Pulling a published image
+
+```bash
+docker pull ghcr.io/microsoft/waza/adc-runner:latest
+# or a pinned release
+docker pull ghcr.io/microsoft/waza/adc-runner:0.37.0
+```
+
+The package is published under the `microsoft/waza` org and inherits the
+repo's visibility (public). No PAT is needed to pull.
+
+## Security & provenance
+
+- The publish workflow emits **SLSA provenance** and an **SPDX SBOM**
+  (`provenance: true`, `sbom: true` on `docker/build-push-action`).
+- Image runs as `root` today to keep things compatible with skills that need
+  to install packages mid-eval. Hardening to a non-root user is tracked as a
+  follow-up — see "Open follow-ups" below.
+
+## Open follow-ups (intentional TODOs)
+
+These were *not* in scope for #177's first cut and should be split into their
+own issues when prioritized:
+
+- [ ] **Cosign signing.** Add `cosign sign --yes $IMAGE@$DIGEST` after the
+      push step once the platform team confirms the keyless OIDC trust root.
+- [ ] **Trivy / Grype scan gate.** Run a vuln scan on every PR and fail the
+      build on `HIGH+` findings (currently informational only).
+- [ ] **Non-root runtime user.** Switch `USER` to a dedicated `waza` UID once
+      the eval execution layer is audited for permission assumptions.
+- [ ] **Slim base.** Evaluate `gcr.io/distroless/base-nossl-debian12` once
+      we know the full skill-runtime surface; Ubuntu was chosen for parity
+      with the ADC reference base image.
+- [ ] **Image size budget.** Add a CI assertion that the image stays under a
+      fixed size (suggested cap: 800 MB compressed) so additions don't slip in.
+- [ ] **Platform wiring.** `internal/platform/execution` will pick up this
+      image in [#176](https://github.com/microsoft/waza/issues/176).


### PR DESCRIPTION
Closes #177
Part of #168 (Hosted Waza Platform)

## What this PR does

Adds a production-ready first pass for the ADC sandbox disk image so platform boots skip lazy `copilot-cli` extraction and land on a hot `waza` binary.

### Deliverables

- **`Dockerfile.adc-runner`** — multi-stage build
  - `node:22-alpine` → builds embedded `web/` assets
  - `golang:1.26-bookworm` → builds the `waza` binary, then pre-extracts the embedded copilot-cli into `/opt/waza/cache/copilot-sdk/` by invoking `internal/embedded.Path()` from a tiny in-module helper
  - `ubuntu:24.04` runtime with `bash`, `git`, `curl`, `jq`, `nodejs`, `npm`, `tini`
  - `HOME=/opt/waza`, `XDG_CACHE_HOME=/opt/waza/cache`, `WORKDIR=/workspace`, `WAZA_ADC_RUNNER=1`
  - `ENTRYPOINT ["/usr/bin/tini","--"]`, `CMD ["/bin/sleep","infinity"]` — matches the `.adc-sdk/` consumer contract (`ExecuteShellCommand` against a long-lived sandbox)
  - OCI labels populated from `WAZA_VERSION`, `VCS_REF`, `BUILD_DATE`
  - In-build smoke test: `RUN waza --version && ls /opt/waza/cache/copilot-sdk/`

- **`.github/workflows/docker-adc-runner.yml`** — publish workflow
  - Triggers: push to `main` (path-filtered), tags `v*.*.*`, PRs (build + smoke only), `workflow_dispatch`
  - Target: `ghcr.io/microsoft/waza/adc-runner`
  - Multi-arch `linux/amd64,linux/arm64` on push/tag; single-arch verify-only on PR
  - Tag strategy via `docker/metadata-action@v5`: `:<semver>`, `:<major>.<minor>`, `:<major>`, `:main`, `:sha-<short>`; `:latest` only on `v*.*.*` tags
  - SLSA provenance + SPDX SBOM enabled
  - GHA cache (`type=gha`) for layer reuse
  - Smoke tests on the built image: `waza --version` + cache directory check

- **`docs/ADC-RUNNER.md`** — user/operator contract, tagging strategy, local build/test commands, explicit follow-up list
- **`CHANGELOG.md`** — Unreleased entry referencing #177

## Local verification

Built and smoke-tested on `linux/arm64` (Apple Silicon):

```
$ docker run --rm waza-adc-runner:local waza --version
waza version dev-test

$ docker run --rm --entrypoint bash waza-adc-runner:local -c 'ls -lh "$XDG_CACHE_HOME/copilot-sdk"'
-rwxr-xr-x 1 root root 157M ... copilot_1.0.64-0
-rw-r--r-- 1 root root 2.9K ... copilot_1.0.64-0.license
```

Image size: **1.61 GB** (uncompressed). Tools verified: bash, git, curl, jq, node v18.19.1, npm 9.2.0, tini.

## Assumptions / conservative defaults (please confirm)

| Decision | Default chosen | Why | Action needed |
|---|---|---|---|
| **Registry** | `ghcr.io/microsoft/waza/adc-runner` | No new secrets, uses `GITHUB_TOKEN`, mirrors existing repo workflows | Confirm vs ACR / mirror to ACR if platform requires |
| **Image signing** | SLSA provenance + SPDX SBOM via buildx | Native, no extra setup | Add `cosign sign --keyless` step if required |
| **Vuln scanning** | Not gated | Out of scope for first pass | Add `trivy` / `grype` job + severity threshold |
| **Runtime user** | `root` | Matches existing repo `Dockerfile`; ADC may inject its own UID | Add non-root `waza` user if platform mandates |
| **Base image** | `ubuntu:24.04` | Matches `.adc-sdk` reference (`docker.io/library/ubuntu:latest`), broad tool compatibility | Consider `ubuntu:24.04` minimal / `chainguard/wolfi-base` for size |
| **Size** | 1.61 GB | Pre-extracted CLI is ~157 MB; node+npm contribute most of the rest | Set size budget + slim once skill runtime needs are known |
| **Platform wiring** | Not done — depends on #176 (`.adc-sdk` extraction) | Out of scope; image is consumable by any `.adc-sdk` caller as soon as #176 lands | Track in #176 |

## Explicit TODO follow-ups (also captured in `docs/ADC-RUNNER.md`)

- [ ] cosign keyless signing of published images
- [ ] trivy/grype scan gate
- [ ] non-root runtime user (`waza:waza`)
- [ ] slim base image evaluation + size budget
- [ ] platform `.adc-sdk` consumer wiring (#176)
- [ ] decide GHCR vs ACR (or mirror)
- [ ] add `:edge` tag for `main` consumers, separate from `:main`

## Files

- `Dockerfile.adc-runner` (new)
- `.github/workflows/docker-adc-runner.yml` (new)
- `docs/ADC-RUNNER.md` (new)
- `CHANGELOG.md` (modified)

## Test plan

CI on this PR will exercise the workflow's PR path (single-arch build + smoke test on `linux/amd64`). On merge to `main`, the multi-arch publish path runs and pushes `:main` + `:sha-<short>` to GHCR.

---

⚠️ Per `.squad/team.md`, infrastructure/Docker tasks are marked **🟡 needs review** for Coding Agent — please have a squad member review the workflow security posture and registry choice before merging.