### PR TITLE
feat: synthetic test case generation flags for waza suggest (#357)

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,16 +566,29 @@ Use an LLM to analyze `SKILL.md` and generate suggested evaluation artifacts.
 | `--model <model>` | Model to use for suggestions (default: project default model) |
 | `--dry-run` | Print suggested output to stdout (default) |
 | `--apply` | Write files to disk |
+| `--force` | Allow `--apply` to overwrite existing eval/task/fixture files (requires `--apply`) |
+| `--count <n>` | Generate exactly N tasks (default: at least 3 + 1 negative) |
+| `--focus <category>` | Steer generation toward one of `triggers`, `negative-triggers`, `edge-fixtures`, `do-not-use-for`, `parameters` |
 | `--output-dir <dir>` | Output directory (default: `<skill-path>/evals`) |
 | `--format yaml\|json` | Output format (default: `yaml`) |
+
+Each generated task entry carries a `confidence` score in `[0, 1]` and a `rationale` string pointing to the SKILL.md span it was derived from. Both appear in dry-run output but are kept outside the written task YAML (the task schema rejects unknown fields).
+
+`--apply` is merge-safe: an existing `eval.yaml` is never overwritten (new task files are picked up by its existing `tasks:` glob), and existing task / fixture files (by path or by task `id`) cause `--apply` to fail unless `--force` is also passed.
 
 **Examples:**
 ```bash
 # Preview generated eval/task/fixture files as YAML
 waza suggest skills/code-explainer --dry-run
 
+# Generate exactly 5 negative-trigger tasks and merge them into the existing suite
+waza suggest skills/code-explainer --focus negative-triggers --count 5 --apply
+
 # Write generated files to disk
 waza suggest skills/code-explainer --apply
+
+# Overwrite a previously generated suite
+waza suggest skills/code-explainer --apply --force
 
 # Print JSON-formatted suggestion payload
 waza suggest skills/code-explainer --format json

--- a/cmd/waza/cmd_suggest.go
+++ b/cmd/waza/cmd_suggest.go
@@ -25,8 +25,11 @@ type suggestFlags struct {
 	model     string
 	dryRun    bool
 	apply     bool
+	force     bool
 	outputDir string
 	format    string
+	count     int
+	focus     string
 }
 
 func newSuggestCommand() *cobra.Command {
@@ -44,7 +47,12 @@ func newSuggestCommand() *cobra.Command {
 
 This command is experimental. Because an LLM generates suggestions, they should be
 reviewed by a human before applying. By default, suggestions are printed to stdout
-(--dry-run). Use --apply to write suggested eval.yaml, tasks, and fixtures to disk.`,
+(--dry-run). Use --apply to write suggested eval.yaml, tasks, and fixtures to disk.
+
+Use --count to control how many cases are proposed, --focus to steer generation
+toward a category (` + strings.Join(suggestpkg.AvailableFocusCategories(), ", ") + `),
+and --force to overwrite existing files (default is merge-safe: existing eval.yaml
+and task ids are preserved).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSuggestCommand(cmd, args[0], flags)
@@ -55,8 +63,11 @@ reviewed by a human before applying. By default, suggestions are printed to stdo
 	cmd.Flags().StringVar(&flags.model, "model", flags.model, "Model to use for suggestions")
 	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", true, "Print suggestions to stdout without writing files")
 	cmd.Flags().BoolVar(&flags.apply, "apply", false, "Write suggested files to disk")
+	cmd.Flags().BoolVar(&flags.force, "force", false, "Overwrite existing files and duplicate task ids (use with --apply)")
 	cmd.Flags().StringVar(&flags.outputDir, "output-dir", "", "Directory for output (default: <skill-path>/evals)")
 	cmd.Flags().StringVar(&flags.format, "format", "yaml", "Output format: yaml|json")
+	cmd.Flags().IntVar(&flags.count, "count", 0, "Number of test cases to propose (0 = model default)")
+	cmd.Flags().StringVar(&flags.focus, "focus", "", "Steer generation toward a category: "+strings.Join(suggestpkg.AvailableFocusCategories(), "|"))
 
 	return cmd
 }
@@ -65,11 +76,20 @@ func runSuggestCommand(cmd *cobra.Command, skillPath string, flags *suggestFlags
 	if flags.format != "yaml" && flags.format != "json" {
 		return fmt.Errorf("invalid format %q: must be yaml or json", flags.format)
 	}
+	if err := suggestpkg.ValidateFocus(flags.focus); err != nil {
+		return err
+	}
+	if flags.count < 0 {
+		return fmt.Errorf("invalid --count %d: must be >= 0", flags.count)
+	}
 	if flags.apply {
 		flags.dryRun = false
 	}
 	if !flags.apply && !flags.dryRun {
 		return errors.New("either --dry-run or --apply must be enabled")
+	}
+	if flags.force && !flags.apply {
+		return errors.New("--force requires --apply")
 	}
 
 	outputDir := flags.outputDir
@@ -93,6 +113,8 @@ func runSuggestCommand(cmd *cobra.Command, skillPath string, flags *suggestFlags
 	suggestion, err := suggestpkg.Generate(cmd.Context(), engine, suggestpkg.Options{
 		SkillPath:  skillPath,
 		GraderDocs: waza.GraderDocsFS,
+		Count:      flags.count,
+		Focus:      flags.focus,
 	})
 	if err != nil {
 		return err
@@ -110,7 +132,7 @@ func runSuggestCommand(cmd *cobra.Command, skillPath string, flags *suggestFlags
 		return nil
 	}
 
-	written, err := suggestion.WriteToDir(outputDir)
+	written, err := suggestion.WriteToDir(outputDir, suggestpkg.WriteOptions{Force: flags.force})
 	if err != nil {
 		return err
 	}

--- a/internal/suggest/prompt.go
+++ b/internal/suggest/prompt.go
@@ -68,6 +68,41 @@ type promptData struct {
 	ContentSummary string
 	GraderTypes    string
 	SkillContent   string
+	// Count is the desired number of test cases (<= 0 means use default).
+	Count int
+	// Focus is an optional focus category that steers the kinds of cases
+	// the LLM should emit (e.g. "negative-triggers"). Empty means balanced.
+	Focus string
+}
+
+// focusDirective returns prompt text that steers generation toward a focus
+// category. Returns "" when focus is empty.
+func focusDirective(focus string) string {
+	switch FocusCategory(focus) {
+	case "":
+		return ""
+	case FocusTriggers:
+		return "FOCUS: Generate tasks that exercise the skill's positive trigger phrases " +
+			"(the 'USE FOR' list). Each task should match a distinct trigger so we can verify " +
+			"the skill activates when it should."
+	case FocusNegativeTriggers:
+		return "FOCUS: Generate tasks that look superficially like triggers but should NOT " +
+			"invoke this skill. Use skill_invocation graders with forbidden_skills to assert " +
+			"the skill stays out of these cases."
+	case FocusEdgeFixtures:
+		return "FOCUS: Generate tasks that stress edge cases in the input fixtures — empty " +
+			"files, very large files, malformed inputs, unicode, ambiguous content. Each task " +
+			"should carry a realistic edge-case fixture under fixtures/."
+	case FocusDoNotUseFor:
+		return "FOCUS: Generate tasks drawn from the skill's 'DO NOT USE FOR' anti-trigger " +
+			"list. Each task must assert the skill refuses or routes elsewhere (use " +
+			"skill_invocation forbidden_skills, or text graders that check for refusal language)."
+	case FocusParameters:
+		return "FOCUS: Generate tasks that vary the parameters and tool arguments the skill " +
+			"would supply — required vs optional, valid vs invalid values, boundary numerics. " +
+			"Use tool_constraint or action_sequence graders where appropriate."
+	}
+	return ""
 }
 
 // renderSelectionPrompt builds the pass-1 prompt that asks the LLM
@@ -102,6 +137,8 @@ func renderImplementationPrompt(data promptData, graderDocs string) string {
 	b.WriteString("  <full eval.yaml content>\n")
 	b.WriteString("tasks:\n")
 	b.WriteString("  - path: tasks/<task-file>.yaml\n")
+	b.WriteString("    confidence: 0.0-1.0\n")
+	b.WriteString("    rationale: <one sentence pointing to the SKILL.md span this case came from>\n")
 	b.WriteString("    content: |\n")
 	b.WriteString("      <task yaml>\n")
 	b.WriteString("fixtures:\n")
@@ -113,11 +150,21 @@ func renderImplementationPrompt(data promptData, graderDocs string) string {
 	b.WriteString("- Each grader entry MUST be an object with at least 'type' and 'name' fields. NEVER use bare strings like '- grader_name'. Always use '- name: grader_name' with a 'type' field.\n")
 	b.WriteString("- Include required config fields for each grader type (see grader documentation below).\n")
 	b.WriteString("- For skill_invocation graders, use required_skills + mode (exact_match, in_order, any_order) for positive checks, forbidden_skills for negative checks, or both together.\n")
-	b.WriteString("- Include at least 3 diverse tasks and at least 1 negative/anti-trigger task.\n")
+	if data.Count > 0 {
+		fmt.Fprintf(&b, "- Generate EXACTLY %d tasks. Do not generate more or fewer.\n", data.Count)
+	} else {
+		b.WriteString("- Include at least 3 diverse tasks and at least 1 negative/anti-trigger task.\n")
+	}
 	b.WriteString("- Use grader types from the allowed list only.\n")
 	b.WriteString("- Keep task IDs deterministic and kebab-case.\n")
 	b.WriteString("- Task YAML must use inputs: { prompt: ... } (do not use a top-level prompt field).\n")
-	b.WriteString("- Make fixtures minimal and realistic for the tasks.\n\n")
+	b.WriteString("- Task YAML must NOT include 'confidence' or 'rationale' inside the task content; those belong on the outer suggestion entry and will be stripped before writing.\n")
+	b.WriteString("- Each task entry MUST carry a 'confidence' float in [0,1] and a 'rationale' string citing the SKILL.md span (e.g. \"matches USE FOR: summarize bullet 2\").\n")
+	b.WriteString("- Make fixtures minimal and realistic for the tasks.\n")
+	if directive := focusDirective(data.Focus); directive != "" {
+		b.WriteString("- " + directive + "\n")
+	}
+	b.WriteString("\n")
 	b.WriteString("Skill metadata:\n")
 	fmt.Fprintf(&b, "- Name: %s\n", data.SkillName)
 	fmt.Fprintf(&b, "- Description: %s\n", data.Description)

--- a/internal/suggest/resolve_test.go
+++ b/internal/suggest/resolve_test.go
@@ -163,7 +163,7 @@ func TestWriteToDir_EmptyTaskPath(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	written, err := s.WriteToDir(dir)
+	written, err := s.WriteToDir(dir, WriteOptions{})
 	require.NoError(t, err)
 	assert.Len(t, written, 2) // eval.yaml + auto-named task
 }
@@ -177,7 +177,7 @@ func TestWriteToDir_EmptyFixturePath(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	written, err := s.WriteToDir(dir)
+	written, err := s.WriteToDir(dir, WriteOptions{})
 	require.NoError(t, err)
 	assert.Len(t, written, 2) // eval.yaml + auto-named fixture
 }
@@ -195,7 +195,7 @@ func TestWriteToDir_AbsolutePathRejected(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	_, err := s.WriteToDir(dir)
+	_, err := s.WriteToDir(dir, WriteOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid generated path")
 }
@@ -209,7 +209,7 @@ func TestWriteToDir_TraversalPathRejected(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	_, err := s.WriteToDir(dir)
+	_, err := s.WriteToDir(dir, WriteOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid generated path")
 }
@@ -220,7 +220,7 @@ func TestWriteToDir_InvalidEvalYAML(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	_, err := s.WriteToDir(dir)
+	_, err := s.WriteToDir(dir, WriteOptions{})
 	require.Error(t, err)
 }
 

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -14,22 +14,73 @@ import (
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/scaffold"
 	"github.com/microsoft/waza/internal/skill"
+	"github.com/microsoft/waza/internal/validation"
 	"gopkg.in/yaml.v3"
 )
 
 const defaultTimeoutSec = 120
+
+// FocusCategory steers the kinds of test cases the LLM should generate.
+type FocusCategory string
+
+const (
+	FocusTriggers         FocusCategory = "triggers"
+	FocusNegativeTriggers FocusCategory = "negative-triggers"
+	FocusEdgeFixtures     FocusCategory = "edge-fixtures"
+	FocusDoNotUseFor      FocusCategory = "do-not-use-for"
+	FocusParameters       FocusCategory = "parameters"
+)
+
+// AvailableFocusCategories returns all supported --focus values.
+func AvailableFocusCategories() []string {
+	return []string{
+		string(FocusTriggers),
+		string(FocusNegativeTriggers),
+		string(FocusEdgeFixtures),
+		string(FocusDoNotUseFor),
+		string(FocusParameters),
+	}
+}
+
+// ValidateFocus returns nil if focus is empty or a known category.
+func ValidateFocus(focus string) error {
+	if strings.TrimSpace(focus) == "" {
+		return nil
+	}
+	for _, c := range AvailableFocusCategories() {
+		if focus == c {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid --focus %q: must be one of %s", focus, strings.Join(AvailableFocusCategories(), ", "))
+}
 
 // Options configures suggestion generation.
 type Options struct {
 	SkillPath  string
 	TimeoutSec int
 	GraderDocs fs.FS // embedded grader documentation (optional)
+	// Count is how many test cases to propose. <= 0 means "use model default".
+	Count int
+	// Focus narrows generation toward a category. Empty means "balanced".
+	Focus string
 }
 
-// GeneratedFile is a single generated artifact.
+// WriteOptions controls how a Suggestion is applied to disk.
+type WriteOptions struct {
+	// Force overwrites existing files and duplicate task ids when true.
+	Force bool
+}
+
+// GeneratedFile is a single generated artifact. For tasks, Confidence and
+// Rationale carry per-case metadata that is shown in dry-run output but is
+// *not* written into the task YAML file (which must satisfy the strict task
+// schema).
 type GeneratedFile struct {
-	Path    string `yaml:"path" json:"path"`
-	Content string `yaml:"content" json:"content"`
+	Path       string  `yaml:"path" json:"path"`
+	Content    string  `yaml:"content" json:"content"`
+	Confidence float64 `yaml:"confidence,omitempty" json:"confidence,omitempty"`
+	Rationale  string  `yaml:"rationale,omitempty" json:"rationale,omitempty"`
 }
 
 // Suggestion is the structured output returned by the LLM.
@@ -47,6 +98,9 @@ type Suggestion struct {
 //
 // When opts.GraderDocs is nil, falls back to a single-pass prompt.
 func Generate(ctx context.Context, engine execution.AgentEngine, opts Options) (*Suggestion, error) {
+	if err := ValidateFocus(opts.Focus); err != nil {
+		return nil, err
+	}
 	skillFile, err := resolveSkillFile(opts.SkillPath)
 	if err != nil {
 		return nil, err
@@ -63,6 +117,8 @@ func Generate(ctx context.Context, engine execution.AgentEngine, opts Options) (
 	}
 
 	data := buildPromptData(sk, skillContent)
+	data.Count = opts.Count
+	data.Focus = opts.Focus
 
 	// Determine grader docs for the implementation prompt.
 	var graderDocs string
@@ -238,9 +294,60 @@ func ParseResponse(raw string) (*Suggestion, error) {
 }
 
 // WriteToDir writes suggested files to outputDir and returns written paths.
-func (s *Suggestion) WriteToDir(outputDir string) ([]string, error) {
+// Existing files are preserved unless opts.Force is true. Generated task
+// YAML files are validated against the task schema before being written.
+func (s *Suggestion) WriteToDir(outputDir string, opts WriteOptions) ([]string, error) {
 	if err := validateEvalYAML(s.EvalYAML); err != nil {
 		return nil, err
+	}
+
+	// Pre-flight: validate each task against the schema *and* check for
+	// id collisions with existing tasks in outputDir.
+	existingIDs, err := collectExistingTaskIDs(outputDir)
+	if err != nil {
+		return nil, err
+	}
+
+	type plannedTask struct {
+		target string
+		id     string
+		body   []byte
+	}
+	planned := make([]plannedTask, 0, len(s.Tasks))
+	seenIDs := make(map[string]string, len(s.Tasks))
+
+	for i, task := range s.Tasks {
+		path, err := normalizeGeneratedPath(task.Path, fmt.Sprintf("tasks/task-%02d.yaml", i+1))
+		if err != nil {
+			return nil, err
+		}
+		body := []byte(strings.TrimSpace(task.Content) + "\n")
+		if errs := validation.ValidateTaskBytes(body); len(errs) > 0 {
+			return nil, fmt.Errorf("generated task %s failed schema validation: %s", path, strings.Join(errs, "; "))
+		}
+		id := extractTaskID(body)
+		if id == "" {
+			return nil, fmt.Errorf("generated task %s is missing required 'id' field", path)
+		}
+		if dup, ok := seenIDs[id]; ok {
+			return nil, fmt.Errorf("generated tasks contain duplicate id %q (%s and %s)", id, dup, path)
+		}
+		seenIDs[id] = path
+
+		target := filepath.Join(outputDir, path)
+		if !opts.Force {
+			if _, err := os.Stat(target); err == nil {
+				return nil, fmt.Errorf("refusing to overwrite existing task file %s (use --force to override)", target)
+			}
+			if existingPath, ok := existingIDs[id]; ok {
+				rel, _ := filepath.Rel(outputDir, existingPath)
+				if rel == "" {
+					rel = existingPath
+				}
+				return nil, fmt.Errorf("refusing to overwrite task with existing id %q (already defined in %s; use --force to override)", id, rel)
+			}
+		}
+		planned = append(planned, plannedTask{target: target, id: id, body: body})
 	}
 
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
@@ -249,21 +356,24 @@ func (s *Suggestion) WriteToDir(outputDir string) ([]string, error) {
 
 	var written []string
 	evalPath := filepath.Join(outputDir, "eval.yaml")
-	if err := os.WriteFile(evalPath, []byte(strings.TrimSpace(s.EvalYAML)+"\n"), 0o644); err != nil {
-		return nil, fmt.Errorf("writing eval.yaml: %w", err)
+	if _, err := os.Stat(evalPath); err == nil && !opts.Force {
+		// Merge-safe: don't overwrite a curated eval.yaml.
+		// New task files will be picked up by its existing tasks: glob pattern.
+	} else {
+		if err := os.WriteFile(evalPath, []byte(strings.TrimSpace(s.EvalYAML)+"\n"), 0o644); err != nil {
+			return nil, fmt.Errorf("writing eval.yaml: %w", err)
+		}
+		written = append(written, evalPath)
 	}
-	written = append(written, evalPath)
 
-	for i, task := range s.Tasks {
-		path, err := normalizeGeneratedPath(task.Path, fmt.Sprintf("tasks/task-%02d.yaml", i+1))
-		if err != nil {
-			return nil, err
+	for _, pt := range planned {
+		if err := os.MkdirAll(filepath.Dir(pt.target), 0o755); err != nil {
+			return nil, fmt.Errorf("creating directory for %s: %w", pt.target, err)
 		}
-		target := filepath.Join(outputDir, path)
-		if err := writeGeneratedFile(target, task.Content); err != nil {
-			return nil, err
+		if err := os.WriteFile(pt.target, pt.body, 0o644); err != nil {
+			return nil, fmt.Errorf("writing %s: %w", pt.target, err)
 		}
-		written = append(written, target)
+		written = append(written, pt.target)
 	}
 
 	for i, fixture := range s.Fixtures {
@@ -272,6 +382,9 @@ func (s *Suggestion) WriteToDir(outputDir string) ([]string, error) {
 			return nil, err
 		}
 		target := filepath.Join(outputDir, path)
+		if _, err := os.Stat(target); err == nil && !opts.Force {
+			return nil, fmt.Errorf("refusing to overwrite existing fixture file %s (use --force to override)", target)
+		}
 		if err := writeGeneratedFile(target, fixture.Content); err != nil {
 			return nil, err
 		}
@@ -279,6 +392,51 @@ func (s *Suggestion) WriteToDir(outputDir string) ([]string, error) {
 	}
 
 	return written, nil
+}
+
+// collectExistingTaskIDs scans outputDir/tasks/*.yaml and returns a map of
+// task id -> file path for collision detection. Missing directories are
+// treated as empty.
+func collectExistingTaskIDs(outputDir string) (map[string]string, error) {
+	ids := make(map[string]string)
+	tasksDir := filepath.Join(outputDir, "tasks")
+	entries, err := os.ReadDir(tasksDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ids, nil
+		}
+		return nil, fmt.Errorf("scanning tasks dir: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		full := filepath.Join(tasksDir, name)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		id := extractTaskID(data)
+		if id != "" {
+			ids[id] = full
+		}
+	}
+	return ids, nil
+}
+
+// extractTaskID pulls the top-level `id:` field from task YAML.
+func extractTaskID(data []byte) string {
+	var tc struct {
+		ID string `yaml:"id"`
+	}
+	if err := yaml.Unmarshal(data, &tc); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(tc.ID)
 }
 
 func loadSkill(skillFile string) (string, *skill.Skill, error) {

--- a/internal/suggest/suggest_apply_test.go
+++ b/internal/suggest/suggest_apply_test.go
@@ -1,0 +1,204 @@
+package suggest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Focus category tests ---
+
+func TestValidateFocusAcceptsKnown(t *testing.T) {
+	for _, f := range AvailableFocusCategories() {
+		require.NoError(t, ValidateFocus(f), "expected %s to be accepted", f)
+	}
+	require.NoError(t, ValidateFocus(""), "empty focus should be allowed")
+}
+
+func TestValidateFocusRejectsUnknown(t *testing.T) {
+	err := ValidateFocus("not-a-real-category")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not-a-real-category")
+}
+
+func TestRenderImplementationPromptIncludesFocusDirective(t *testing.T) {
+	cases := map[FocusCategory]string{
+		FocusTriggers:         "positive trigger phrases",
+		FocusNegativeTriggers: "should NOT",
+		FocusEdgeFixtures:     "edge cases",
+		FocusDoNotUseFor:      "DO NOT USE FOR",
+		FocusParameters:       "vary the parameters",
+	}
+	for focus, marker := range cases {
+		t.Run(string(focus), func(t *testing.T) {
+			prompt := renderImplementationPrompt(promptData{
+				SkillName: "sample-skill",
+				Focus:     string(focus),
+			}, "")
+			require.Contains(t, prompt, marker, "directive marker missing for %s", focus)
+		})
+	}
+}
+
+func TestRenderImplementationPromptHonorsCount(t *testing.T) {
+	prompt := renderImplementationPrompt(promptData{
+		SkillName: "sample-skill",
+		Count:     5,
+	}, "")
+	require.Contains(t, prompt, "EXACTLY 5 tasks")
+}
+
+func TestRenderImplementationPromptDefaultGuidance(t *testing.T) {
+	prompt := renderImplementationPrompt(promptData{SkillName: "sample-skill"}, "")
+	require.Contains(t, prompt, "at least 3 diverse tasks")
+}
+
+func TestRenderImplementationPromptRequiresConfidenceAndRationale(t *testing.T) {
+	prompt := renderImplementationPrompt(promptData{SkillName: "sample-skill"}, "")
+	require.Contains(t, prompt, "confidence")
+	require.Contains(t, prompt, "rationale")
+}
+
+// --- Overwrite-safety tests ---
+
+func minimalSuggestion() *Suggestion {
+	return &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Tasks: []GeneratedFile{
+			{
+				Path:    "tasks/task-01.yaml",
+				Content: "id: task-01\nname: Task One\ninputs:\n  prompt: hi\n",
+			},
+		},
+		Fixtures: []GeneratedFile{
+			{Path: "fixtures/sample.txt", Content: "data"},
+		},
+	}
+}
+
+func TestWriteToDirSkipsExistingEvalYAML(t *testing.T) {
+	dir := t.TempDir()
+	existing := "name: curated\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "eval.yaml"), []byte(existing), 0o644))
+
+	s := minimalSuggestion()
+	written, err := s.WriteToDir(dir, WriteOptions{})
+	require.NoError(t, err)
+
+	// eval.yaml should not be in written (skipped because it exists),
+	// but the new task + fixture should be written.
+	for _, p := range written {
+		assert.NotEqual(t, "eval.yaml", filepath.Base(p), "should not have rewritten eval.yaml")
+	}
+	require.Len(t, written, 2)
+
+	// eval.yaml content untouched
+	raw, err := os.ReadFile(filepath.Join(dir, "eval.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, existing, string(raw))
+}
+
+func TestWriteToDirRefusesOverwriteWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "tasks"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "tasks", "task-01.yaml"),
+		[]byte("id: other\nname: Other\ninputs:\n  prompt: x\n"),
+		0o644,
+	))
+
+	s := minimalSuggestion()
+	_, err := s.WriteToDir(dir, WriteOptions{})
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "refusing to overwrite")
+}
+
+func TestWriteToDirAllowsOverwriteWithForce(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "tasks"), 0o755))
+	existingTask := filepath.Join(dir, "tasks", "task-01.yaml")
+	require.NoError(t, os.WriteFile(existingTask, []byte("id: stale\nname: Stale\ninputs:\n  prompt: x\n"), 0o644))
+
+	s := minimalSuggestion()
+	written, err := s.WriteToDir(dir, WriteOptions{Force: true})
+	require.NoError(t, err)
+	require.NotEmpty(t, written)
+
+	raw, err := os.ReadFile(existingTask)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "id: task-01")
+}
+
+func TestWriteToDirDetectsDuplicateTaskIDAgainstExisting(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "tasks"), 0o755))
+	// Existing task with id "task-01" at a *different* file path —
+	// path doesn't collide, but the id does.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "tasks", "previous.yaml"),
+		[]byte("id: task-01\nname: Previous\ninputs:\n  prompt: x\n"),
+		0o644,
+	))
+
+	s := minimalSuggestion()
+	_, err := s.WriteToDir(dir, WriteOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "task-01")
+	require.Contains(t, strings.ToLower(err.Error()), "id")
+}
+
+func TestWriteToDirRejectsDuplicateIDsWithinBatch(t *testing.T) {
+	s := &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Tasks: []GeneratedFile{
+			{Path: "tasks/a.yaml", Content: "id: dup\nname: A\ninputs:\n  prompt: hi\n"},
+			{Path: "tasks/b.yaml", Content: "id: dup\nname: B\ninputs:\n  prompt: hi\n"},
+		},
+	}
+	_, err := s.WriteToDir(t.TempDir(), WriteOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate id")
+}
+
+// --- Schema validation tests ---
+
+func TestWriteToDirRejectsTaskMissingID(t *testing.T) {
+	s := &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Tasks: []GeneratedFile{
+			// no id field
+			{Path: "tasks/bad.yaml", Content: "name: Bad\ninputs:\n  prompt: hi\n"},
+		},
+	}
+	_, err := s.WriteToDir(t.TempDir(), WriteOptions{})
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "schema")
+}
+
+func TestWriteToDirRejectsTaskMissingInputs(t *testing.T) {
+	s := &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Tasks: []GeneratedFile{
+			{Path: "tasks/bad.yaml", Content: "id: missing-inputs\nname: Bad\n"},
+		},
+	}
+	_, err := s.WriteToDir(t.TempDir(), WriteOptions{})
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "schema")
+}
+
+func TestWriteToDirRejectsTaskWithUnknownField(t *testing.T) {
+	// task.schema.json has additionalProperties: false
+	s := &Suggestion{
+		EvalYAML: validEvalYAML(),
+		Tasks: []GeneratedFile{
+			{Path: "tasks/bad.yaml", Content: "id: x\nname: X\ninputs:\n  prompt: hi\nconfidence: 0.9\n"},
+		},
+	}
+	_, err := s.WriteToDir(t.TempDir(), WriteOptions{})
+	require.Error(t, err)
+}

--- a/internal/suggest/suggest_test.go
+++ b/internal/suggest/suggest_test.go
@@ -369,7 +369,7 @@ tasks:
 	}
 
 	outDir := t.TempDir()
-	written, err := s.WriteToDir(outDir)
+	written, err := s.WriteToDir(outDir, WriteOptions{})
 	require.NoError(t, err)
 	require.Len(t, written, 3)
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -461,8 +461,19 @@ waza suggest <skill-path>
 | `--model` | Model to use for suggestions (default: project default model) |
 | `--dry-run` | Print suggestions to stdout (default) |
 | `--apply` | Write suggested files to disk |
+| `--force` | Allow `--apply` to overwrite existing eval/task/fixture files (requires `--apply`) |
+| `--count` | Generate exactly N tasks (default: at least 3 diverse + 1 negative) |
+| `--focus` | Steer generation toward one of `triggers`, `negative-triggers`, `edge-fixtures`, `do-not-use-for`, `parameters` |
 | `--output-dir` | Output directory (default: `<skill-path>/evals`) |
 | `--format` | Output format: `yaml` (default), `json` |
+
+Each suggested task entry carries a `confidence` value in `[0, 1]` and a `rationale` string citing the SKILL.md span it was derived from. Both appear in dry-run / JSON output, but are not written into the task YAML (the task schema rejects unknown fields).
+
+`--apply` is merge-safe by default:
+
+- An existing `eval.yaml` is preserved — new task files are picked up by its existing `tasks:` glob pattern.
+- New task files refuse to overwrite existing task files (by path or by `id`) and new fixtures refuse to overwrite existing fixtures.
+- Pass `--force` to overwrite existing eval / task / fixture files.
 
 ### Examples
 
@@ -470,8 +481,14 @@ waza suggest <skill-path>
 # Preview suggestions
 waza suggest skills/code-explainer --dry-run
 
+# Generate exactly 5 negative-trigger tasks and merge them into the existing suite
+waza suggest skills/code-explainer --focus negative-triggers --count 5 --apply
+
 # Write eval/task/fixture files
 waza suggest skills/code-explainer --apply
+
+# Overwrite a previously generated suite
+waza suggest skills/code-explainer --apply --force
 
 # JSON output
 waza suggest skills/code-explainer --format json


### PR DESCRIPTION
Closes #357

Extends `waza suggest` with steerable generation and merge-safe apply behavior.

## New flags

| Flag | Purpose |
|------|---------|
| `--count <n>` | Generate exactly N tasks (default: at least 3 diverse + 1 negative) |
| `--focus <category>` | Steer generation toward one of `triggers`, `negative-triggers`, `edge-fixtures`, `do-not-use-for`, `parameters` |
| `--force` | Allow `--apply` to overwrite existing eval/task/fixture files (requires `--apply`) |

## Per-case `confidence` and `rationale`

Every generated task entry now carries:

- `confidence`: float in `[0, 1]`
- `rationale`: short sentence pointing back to the SKILL.md span the case came from

These appear in dry-run / JSON output but are kept on the outer suggestion envelope — they are deliberately **not** placed inside the task YAML, since `schemas/task.schema.json` is `additionalProperties: false`.

## Merge-safe `--apply`

Without `--force`:

- An existing `eval.yaml` is preserved (new task files are picked up automatically by its existing `tasks:` glob).
- New task files refuse to overwrite existing task files (same path).
- New tasks refuse to collide with existing task `id`s under `outputDir/tasks/`.
- Duplicate `id`s within the generated batch are rejected.
- New fixtures refuse to overwrite existing fixtures.

`--force` overrides all of the above.

## Schema validation before write

Every generated task is run through `internal/validation.ValidateTaskBytes` before any file is created. Missing `id`, missing `inputs`, or unknown fields produce a clear error and abort the apply.

## Acceptance criteria

- [x] `--count`, `--focus`, `--dry-run`, `--apply`, `--force` flags
- [x] Per-case `confidence` and `rationale`
- [x] Apply is merge-safe (no overwrite without `--force`)
- [x] Generated tasks validated against existing schema before write
- [x] Tests for focus categories (5 categories × directive presence)
- [x] Tests for overwrite safety (refused without `--force`, allowed with `--force`, eval.yaml preservation, duplicate `id` detection in batch + against existing tasks)
- [x] Tests for schema validation (missing `id`, missing `inputs`, unknown field)
- [x] README and site `cli.mdx` updated with new flags + worked example
- [x] `make build`, `go test ./...`, and `golangci-lint run` all pass locally

## Files touched

- `cmd/waza/cmd_suggest.go` — CLI surface for the new flags
- `internal/suggest/suggest.go` — `Options.Count`/`Focus`, `WriteOptions{Force}`, `GeneratedFile.Confidence`/`Rationale`, merge-safe + schema-validated `WriteToDir`, task id collision detection
- `internal/suggest/prompt.go` — `focusDirective`, count handling, confidence/rationale instructions
- `internal/suggest/suggest_apply_test.go` *(new)* — focus / overwrite / schema tests
- `internal/suggest/{suggest,resolve}_test.go` — updated to new `WriteToDir(dir, WriteOptions{})` signature
- `README.md`, `site/src/content/docs/reference/cli.mdx` — flag table + examples