### PR TITLE
feat: Add waza gate command for CI regression gates (#364)

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,43 @@ Compare results from multiple evaluation runs side by side — per-task score de
 |------|-------|-------------|
 | `--format <fmt>` | `-f` | Output format: `table` or `json` (default: `table`) |
 
+### `waza gate`
+
+CI-grade regression gate: compare a baseline results JSON against the current run and fail with stable exit codes when quality drops, golden tasks fail, or the task set diverges.
+
+| Flag | Description |
+|------|-------------|
+| `--baseline <path>` | Baseline results JSON (required) |
+| `--current <path>` | Current results JSON (required) |
+| `--max-regression-pct <N>` | Fail if aggregate pass rate drops by more than _N_ percentage points (default `0`) |
+| `--golden-must-pass` | Hard-fail (exit 2) if any task with `golden: true` fails (default `true`) |
+| `--on-new-tasks <p>` | `allow` / `warn` / `fail` for tasks present in current but missing from baseline (default `allow`) |
+| `--on-removed-tasks <p>` | `allow` / `warn` / `fail` for tasks missing from current (default `warn`) |
+| `--format <fmt>` | `human` / `json` / `markdown` / `github-actions` (default `human`) |
+| `--summary-file <path>` | Write the markdown report to this path (auto-set to `$GITHUB_STEP_SUMMARY` with `github-actions`) |
+
+**Exit codes:** `0` pass · `1` regression · `2` golden failure · `3` configuration error.
+
+**Example:**
+```bash
+waza gate \
+  --baseline results-baseline.json \
+  --current results.json \
+  --max-regression-pct 2 \
+  --golden-must-pass \
+  --format github-actions
+```
+
+Mark tasks as golden in your eval YAML:
+```yaml
+tasks:
+  - id: smoke-test
+    name: Must always work
+    golden: true
+    inputs:
+      prompt: "..."
+```
+
 ### `waza coverage [root]`
 
 Generate a skill-to-eval coverage grid showing which skills are fully covered, partially covered, or missing evals.

--- a/cmd/waza/cmd_gate.go
+++ b/cmd/waza/cmd_gate.go
@@ -1,0 +1,655 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/spf13/cobra"
+)
+
+// Gate-specific exit codes. These are stable and documented; CI pipelines
+// can rely on them to distinguish gate outcomes. They are scoped to the
+// `waza gate` command and intentionally do NOT alias the global
+// run/compare exit codes (which are 0/1/2 for success/test-failure/config
+// error). When `waza gate` exits, the value below overrides the default
+// CLI error mapping in main.go via gateExitError.
+const (
+	GateExitPass    = 0 // All checks passed
+	GateExitRegress = 1 // Aggregate regression exceeded threshold, or task-set delta policy fired
+	GateExitGolden  = 2 // One or more golden tasks failed in the current results
+	GateExitConfErr = 3 // Gate configuration error (bad flags, unreadable input, etc.)
+)
+
+// gatePolicy describes how the gate should treat new or removed tasks
+// between baseline and current results.
+type gatePolicy string
+
+const (
+	gatePolicyAllow gatePolicy = "allow"
+	gatePolicyWarn  gatePolicy = "warn"
+	gatePolicyFail  gatePolicy = "fail"
+)
+
+// gateFormat enumerates supported output formats.
+type gateFormat string
+
+const (
+	gateFormatHuman         gateFormat = "human"
+	gateFormatJSON          gateFormat = "json"
+	gateFormatMarkdown      gateFormat = "markdown"
+	gateFormatGithubActions gateFormat = "github-actions"
+)
+
+// gateExitError carries a gate-specific exit code through the standard
+// cobra/main error path so we can return rich messages without losing the
+// nuanced status code CI expects.
+type gateExitError struct {
+	code int
+	msg  string
+}
+
+func (e *gateExitError) Error() string { return e.msg }
+
+// gateOpts holds parsed gate command flags.
+type gateOpts struct {
+	baselinePath     string
+	currentPath      string
+	maxRegressionPct float64
+	goldenMustPass   bool
+	onNewTasks       gatePolicy
+	onRemovedTasks   gatePolicy
+	format           gateFormat
+	// summaryFile, when set, receives the markdown summary in addition to
+	// stdout. GitHub Actions sets GITHUB_STEP_SUMMARY automatically.
+	summaryFile string
+}
+
+// gateTaskRow is one row in the gate report — a single task's baseline vs
+// current state.
+type gateTaskRow struct {
+	TestID         string  `json:"test_id"`
+	DisplayName    string  `json:"display_name"`
+	Golden         bool    `json:"golden,omitempty"`
+	InBaseline     bool    `json:"in_baseline"`
+	InCurrent      bool    `json:"in_current"`
+	BaselineStatus string  `json:"baseline_status,omitempty"`
+	CurrentStatus  string  `json:"current_status,omitempty"`
+	BaselinePass   float64 `json:"baseline_pass_rate"`
+	CurrentPass    float64 `json:"current_pass_rate"`
+	PassRateDelta  float64 `json:"pass_rate_delta"`
+	BaselineScore  float64 `json:"baseline_score"`
+	CurrentScore   float64 `json:"current_score"`
+	ScoreDelta     float64 `json:"score_delta"`
+	// Classification: "passed", "regressed", "improved", "golden-fail",
+	// "new", "removed".
+	Classification string `json:"classification"`
+	// Note is a free-form short reason populated when a row is flagged.
+	Note string `json:"note,omitempty"`
+}
+
+// gateReport is the full machine-readable summary of a gate run.
+type gateReport struct {
+	BaselineFile     string        `json:"baseline_file"`
+	CurrentFile      string        `json:"current_file"`
+	BaselineModel    string        `json:"baseline_model,omitempty"`
+	CurrentModel     string        `json:"current_model,omitempty"`
+	BaselinePassRate float64       `json:"baseline_pass_rate"`
+	CurrentPassRate  float64       `json:"current_pass_rate"`
+	PassRateDelta    float64       `json:"pass_rate_delta_pct"`
+	MaxRegressionPct float64       `json:"max_regression_pct"`
+	GoldenMustPass   bool          `json:"golden_must_pass"`
+	OnNewTasks       string        `json:"on_new_tasks"`
+	OnRemovedTasks   string        `json:"on_removed_tasks"`
+	NewTasks         []string      `json:"new_tasks,omitempty"`
+	RemovedTasks     []string      `json:"removed_tasks,omitempty"`
+	GoldenFailures   []string      `json:"golden_failures,omitempty"`
+	Regressions      []string      `json:"regressions,omitempty"`
+	Improvements     []string      `json:"improvements,omitempty"`
+	Warnings         []string      `json:"warnings,omitempty"`
+	Tasks            []gateTaskRow `json:"tasks"`
+	// Overall outcome: "pass", "regression", "golden-fail".
+	Outcome  string `json:"outcome"`
+	ExitCode int    `json:"exit_code"`
+}
+
+func newGateCommand() *cobra.Command {
+	opts := &gateOpts{
+		maxRegressionPct: 0,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyWarn,
+		format:           gateFormatHuman,
+	}
+
+	var (
+		onNew     string
+		onRemoved string
+		format    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "gate",
+		Short: "Gate a CI run by comparing current results to a baseline",
+		Long: `Gate compares two waza result JSON files (a stable baseline and the
+current run) and decides whether CI should pass or fail based on:
+
+- aggregate pass-rate regression threshold (--max-regression-pct)
+- per-task hard failures on tasks marked golden: true (--golden-must-pass)
+- the appearance or disappearance of tasks between baseline and current
+  (--on-new-tasks, --on-removed-tasks)
+
+Exit codes are stable and machine-readable:
+
+  0  pass — no regressions
+  1  regression — aggregate pass-rate dropped beyond the threshold, or a
+     task-set delta policy was set to "fail"
+  2  golden-failure — a task with golden: true failed in the current run
+  3  config-error — bad flags, missing or unreadable input files
+
+The --format flag selects the output renderer: human, json, markdown, or
+github-actions (which also emits ::error::/::warning:: annotations and a
+GITHUB_STEP_SUMMARY entry when $GITHUB_STEP_SUMMARY is set).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Re-parse enums into typed values so we get a clear error before doing IO.
+			p, err := parseGatePolicy(onNew, "--on-new-tasks")
+			if err != nil {
+				return &gateExitError{code: GateExitConfErr, msg: err.Error()}
+			}
+			opts.onNewTasks = p
+			p, err = parseGatePolicy(onRemoved, "--on-removed-tasks")
+			if err != nil {
+				return &gateExitError{code: GateExitConfErr, msg: err.Error()}
+			}
+			opts.onRemovedTasks = p
+			f, err := parseGateFormat(format)
+			if err != nil {
+				return &gateExitError{code: GateExitConfErr, msg: err.Error()}
+			}
+			opts.format = f
+
+			if opts.maxRegressionPct < 0 || opts.maxRegressionPct > 100 {
+				return &gateExitError{code: GateExitConfErr, msg: fmt.Sprintf("--max-regression-pct must be in [0,100], got %g", opts.maxRegressionPct)}
+			}
+			if opts.baselinePath == "" || opts.currentPath == "" {
+				return &gateExitError{code: GateExitConfErr, msg: "--baseline and --current are required"}
+			}
+
+			return runGate(cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.baselinePath, "baseline", "", "Path to baseline results.json (required)")
+	cmd.Flags().StringVar(&opts.currentPath, "current", "", "Path to current results.json (required)")
+	cmd.Flags().Float64Var(&opts.maxRegressionPct, "max-regression-pct", 0, "Fail when current pass rate drops more than N percentage points below the baseline (0 = any drop fails)")
+	cmd.Flags().BoolVar(&opts.goldenMustPass, "golden-must-pass", true, "Fail with exit code 2 when any task marked golden: true did not pass in the current run")
+	cmd.Flags().StringVar(&onNew, "on-new-tasks", "allow", "Policy for tasks present in current but not baseline: allow|warn|fail")
+	cmd.Flags().StringVar(&onRemoved, "on-removed-tasks", "warn", "Policy for tasks present in baseline but not current: allow|warn|fail")
+	cmd.Flags().StringVarP(&format, "format", "f", "human", "Output format: human|json|markdown|github-actions")
+	cmd.Flags().StringVar(&opts.summaryFile, "summary-file", "", "Optional path to write a markdown summary (defaults to $GITHUB_STEP_SUMMARY for --format=github-actions)")
+
+	return cmd
+}
+
+func parseGatePolicy(value, flagName string) (gatePolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "allow":
+		return gatePolicyAllow, nil
+	case "warn":
+		return gatePolicyWarn, nil
+	case "fail":
+		return gatePolicyFail, nil
+	default:
+		return "", fmt.Errorf("%s: must be one of allow|warn|fail, got %q", flagName, value)
+	}
+}
+
+func parseGateFormat(value string) (gateFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "human", "":
+		return gateFormatHuman, nil
+	case "json":
+		return gateFormatJSON, nil
+	case "markdown", "md":
+		return gateFormatMarkdown, nil
+	case "github-actions", "gha":
+		return gateFormatGithubActions, nil
+	default:
+		return "", fmt.Errorf("--format: must be one of human|json|markdown|github-actions, got %q", value)
+	}
+}
+
+// runGate is the testable core of the gate command. It loads files, builds
+// the report, renders the chosen format, and returns either nil (pass) or
+// a *gateExitError carrying the documented exit code.
+func runGate(stdout, stderr io.Writer, opts *gateOpts) error {
+	baseline, err := loadOutcomeFile(opts.baselinePath)
+	if err != nil {
+		return &gateExitError{code: GateExitConfErr, msg: fmt.Sprintf("failed to load baseline %s: %v", opts.baselinePath, err)}
+	}
+	current, err := loadOutcomeFile(opts.currentPath)
+	if err != nil {
+		return &gateExitError{code: GateExitConfErr, msg: fmt.Sprintf("failed to load current %s: %v", opts.currentPath, err)}
+	}
+
+	report := buildGateReport(baseline, current, opts)
+
+	switch opts.format {
+	case gateFormatJSON:
+		if err := renderGateJSON(stdout, report); err != nil {
+			return &gateExitError{code: GateExitConfErr, msg: err.Error()}
+		}
+	case gateFormatMarkdown:
+		renderGateMarkdown(stdout, report)
+	case gateFormatGithubActions:
+		renderGateGitHubActions(stdout, stderr, report)
+		// Optionally write a job summary to $GITHUB_STEP_SUMMARY or
+		// the explicit --summary-file path.
+		if err := writeGateSummary(opts, report); err != nil {
+			_, _ = fmt.Fprintf(stderr, "warning: failed to write job summary: %v\n", err)
+		}
+	default:
+		renderGateHuman(stdout, report)
+	}
+
+	if report.ExitCode == GateExitPass {
+		return nil
+	}
+	return &gateExitError{code: report.ExitCode, msg: gateExitMessage(report)}
+}
+
+func gateExitMessage(r *gateReport) string {
+	switch r.Outcome {
+	case "golden-fail":
+		return fmt.Sprintf("gate failed: %d golden task(s) failed: %s", len(r.GoldenFailures), strings.Join(r.GoldenFailures, ", "))
+	case "regression":
+		return fmt.Sprintf("gate failed: pass-rate regression %.2fpp exceeds threshold %.2fpp", -r.PassRateDelta, r.MaxRegressionPct)
+	default:
+		return "gate failed"
+	}
+}
+
+// buildGateReport applies the gate policies to baseline/current and
+// returns a populated report. It is the single source of truth for which
+// exit code to use: callers in CI can re-derive the verdict from the JSON
+// payload without re-running the gate logic.
+func buildGateReport(baseline, current *models.EvaluationOutcome, opts *gateOpts) *gateReport {
+	r := &gateReport{
+		BaselineFile:     opts.baselinePath,
+		CurrentFile:      opts.currentPath,
+		BaselineModel:    baseline.Setup.ModelID,
+		CurrentModel:     current.Setup.ModelID,
+		BaselinePassRate: baseline.Digest.SuccessRate,
+		CurrentPassRate:  current.Digest.SuccessRate,
+		MaxRegressionPct: opts.maxRegressionPct,
+		GoldenMustPass:   opts.goldenMustPass,
+		OnNewTasks:       string(opts.onNewTasks),
+		OnRemovedTasks:   string(opts.onRemovedTasks),
+	}
+	// pass-rate delta as percentage points (e.g. -5.0 means 5pp drop).
+	r.PassRateDelta = (current.Digest.SuccessRate - baseline.Digest.SuccessRate) * 100.0
+
+	// Index both result sets by TestID and collect the union of task IDs
+	// in a stable order (baseline first, then current-only).
+	baseIdx := indexByTestID(baseline.TestOutcomes)
+	currIdx := indexByTestID(current.TestOutcomes)
+
+	ordered := make([]string, 0, len(baseIdx)+len(currIdx))
+	seen := make(map[string]bool, len(baseIdx)+len(currIdx))
+	for _, t := range baseline.TestOutcomes {
+		if !seen[t.TestID] {
+			seen[t.TestID] = true
+			ordered = append(ordered, t.TestID)
+		}
+	}
+	for _, t := range current.TestOutcomes {
+		if !seen[t.TestID] {
+			seen[t.TestID] = true
+			ordered = append(ordered, t.TestID)
+		}
+	}
+
+	for _, id := range ordered {
+		b, hasBase := baseIdx[id]
+		c, hasCurr := currIdx[id]
+
+		row := gateTaskRow{
+			TestID:     id,
+			InBaseline: hasBase,
+			InCurrent:  hasCurr,
+		}
+		switch {
+		case hasCurr:
+			row.DisplayName = c.DisplayName
+			row.Golden = c.Golden
+			row.CurrentStatus = string(c.Status)
+			row.CurrentPass = passRateOf(c)
+			row.CurrentScore = avgScoreOf(c)
+		case hasBase:
+			row.DisplayName = b.DisplayName
+			row.Golden = b.Golden
+		}
+		if hasBase {
+			if row.DisplayName == "" {
+				row.DisplayName = b.DisplayName
+			}
+			row.BaselineStatus = string(b.Status)
+			row.BaselinePass = passRateOf(b)
+			row.BaselineScore = avgScoreOf(b)
+			// Golden flag propagates from either side; baseline wins if
+			// current omitted it.
+			if !row.Golden {
+				row.Golden = b.Golden
+			}
+		}
+
+		switch {
+		case hasBase && !hasCurr:
+			row.Classification = "removed"
+			r.RemovedTasks = append(r.RemovedTasks, id)
+		case !hasBase && hasCurr:
+			row.Classification = "new"
+			r.NewTasks = append(r.NewTasks, id)
+		default:
+			row.PassRateDelta = row.CurrentPass - row.BaselinePass
+			row.ScoreDelta = row.CurrentScore - row.BaselineScore
+			switch {
+			case row.Golden && c.Status != models.StatusPassed:
+				row.Classification = "golden-fail"
+				row.Note = "golden task did not pass"
+			case row.PassRateDelta < 0:
+				row.Classification = "regressed"
+			case row.PassRateDelta > 0:
+				row.Classification = "improved"
+				r.Improvements = append(r.Improvements, id)
+			default:
+				row.Classification = "passed"
+			}
+			if row.Classification == "regressed" {
+				r.Regressions = append(r.Regressions, id)
+			}
+		}
+
+		// Golden hard-fail check is independent of pass-rate delta and
+		// applies to any task that is present in the current run.
+		if hasCurr && row.Golden && c.Status != models.StatusPassed && opts.goldenMustPass {
+			if row.Classification != "golden-fail" {
+				row.Classification = "golden-fail"
+			}
+			if row.Note == "" {
+				row.Note = "golden task did not pass"
+			}
+			if !containsString(r.GoldenFailures, id) {
+				r.GoldenFailures = append(r.GoldenFailures, id)
+			}
+		}
+
+		r.Tasks = append(r.Tasks, row)
+	}
+
+	sort.Strings(r.NewTasks)
+	sort.Strings(r.RemovedTasks)
+	sort.Strings(r.GoldenFailures)
+	sort.Strings(r.Regressions)
+	sort.Strings(r.Improvements)
+
+	// Decide overall outcome and exit code. Order matters: golden failure
+	// dominates over aggregate regression, so CI knows the task list itself
+	// is broken even if the headline pass rate looks fine.
+	r.Outcome = "pass"
+	r.ExitCode = GateExitPass
+
+	if len(r.GoldenFailures) > 0 && opts.goldenMustPass {
+		r.Outcome = "golden-fail"
+		r.ExitCode = GateExitGolden
+	}
+
+	// Aggregate regression check: only when --max-regression-pct is set
+	// (>= 0). The drop is expressed in percentage points of pass rate.
+	regressionDrop := -r.PassRateDelta // positive when current < baseline
+	if regressionDrop > opts.maxRegressionPct {
+		if r.ExitCode == GateExitPass {
+			r.Outcome = "regression"
+			r.ExitCode = GateExitRegress
+		}
+	}
+
+	// Task-set delta policies. Warnings always surface; "fail" promotes
+	// the exit code if nothing more severe has fired yet.
+	applyTaskSetPolicy(r, "new", r.NewTasks, opts.onNewTasks)
+	applyTaskSetPolicy(r, "removed", r.RemovedTasks, opts.onRemovedTasks)
+
+	return r
+}
+
+func applyTaskSetPolicy(r *gateReport, label string, ids []string, policy gatePolicy) {
+	if len(ids) == 0 {
+		return
+	}
+	switch policy {
+	case gatePolicyAllow:
+		// silent
+	case gatePolicyWarn:
+		r.Warnings = append(r.Warnings, fmt.Sprintf("%d %s task(s): %s", len(ids), label, strings.Join(ids, ", ")))
+	case gatePolicyFail:
+		r.Warnings = append(r.Warnings, fmt.Sprintf("%d %s task(s) (policy=fail): %s", len(ids), label, strings.Join(ids, ", ")))
+		if r.ExitCode == GateExitPass {
+			r.Outcome = "regression"
+			r.ExitCode = GateExitRegress
+		}
+	}
+}
+
+func indexByTestID(outcomes []models.TestOutcome) map[string]models.TestOutcome {
+	m := make(map[string]models.TestOutcome, len(outcomes))
+	for _, o := range outcomes {
+		m[o.TestID] = o
+	}
+	return m
+}
+
+func passRateOf(o models.TestOutcome) float64 {
+	if o.Stats != nil {
+		return o.Stats.PassRate
+	}
+	if o.Status == models.StatusPassed {
+		return 1.0
+	}
+	return 0.0
+}
+
+func avgScoreOf(o models.TestOutcome) float64 {
+	if o.Stats != nil {
+		return o.Stats.AvgScore
+	}
+	return 0.0
+}
+
+func containsString(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// --- renderers -------------------------------------------------------------
+
+func renderGateJSON(w io.Writer, r *gateReport) error {
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal gate report: %w", err)
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}
+
+func renderGateHuman(w io.Writer, r *gateReport) {
+	_, _ = fmt.Fprintln(w, strings.Repeat("=", 70))
+	_, _ = fmt.Fprintln(w, " WAZA GATE")
+	_, _ = fmt.Fprintln(w, strings.Repeat("=", 70))
+	_, _ = fmt.Fprintf(w, "  baseline: %s (model=%s)\n", r.BaselineFile, r.BaselineModel)
+	_, _ = fmt.Fprintf(w, "  current:  %s (model=%s)\n", r.CurrentFile, r.CurrentModel)
+	_, _ = fmt.Fprintf(w, "  pass rate: %.1f%% → %.1f%%  (Δ %+.2fpp, threshold -%.2fpp)\n",
+		r.BaselinePassRate*100, r.CurrentPassRate*100, r.PassRateDelta, r.MaxRegressionPct)
+	_, _ = fmt.Fprintln(w)
+
+	if len(r.GoldenFailures) > 0 {
+		_, _ = fmt.Fprintln(w, "  ✗ GOLDEN FAILURES:")
+		for _, id := range r.GoldenFailures {
+			_, _ = fmt.Fprintf(w, "    - %s\n", id)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+	if len(r.Regressions) > 0 {
+		_, _ = fmt.Fprintln(w, "  ↓ Regressed tasks:")
+		for _, id := range r.Regressions {
+			_, _ = fmt.Fprintf(w, "    - %s\n", id)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+	if len(r.NewTasks) > 0 {
+		_, _ = fmt.Fprintf(w, "  + New tasks (policy=%s): %s\n", r.OnNewTasks, strings.Join(r.NewTasks, ", "))
+	}
+	if len(r.RemovedTasks) > 0 {
+		_, _ = fmt.Fprintf(w, "  - Removed tasks (policy=%s): %s\n", r.OnRemovedTasks, strings.Join(r.RemovedTasks, ", "))
+	}
+	if len(r.Warnings) > 0 {
+		_, _ = fmt.Fprintln(w)
+		for _, msg := range r.Warnings {
+			_, _ = fmt.Fprintf(w, "  warning: %s\n", msg)
+		}
+	}
+
+	_, _ = fmt.Fprintln(w)
+	switch r.Outcome {
+	case "pass":
+		_, _ = fmt.Fprintln(w, "  RESULT: ✓ PASS")
+	case "regression":
+		_, _ = fmt.Fprintln(w, "  RESULT: ✗ REGRESSION")
+	case "golden-fail":
+		_, _ = fmt.Fprintln(w, "  RESULT: ✗ GOLDEN FAILURE")
+	}
+	_, _ = fmt.Fprintf(w, "  exit code: %d\n", r.ExitCode)
+}
+
+func renderGateMarkdown(w io.Writer, r *gateReport) {
+	_, _ = fmt.Fprintln(w, "# Waza Gate Report")
+	_, _ = fmt.Fprintln(w)
+	icon := "✅"
+	switch r.Outcome {
+	case "regression":
+		icon = "❌"
+	case "golden-fail":
+		icon = "🛑"
+	}
+	_, _ = fmt.Fprintf(w, "**%s Result:** `%s` (exit %d)\n\n", icon, r.Outcome, r.ExitCode)
+	_, _ = fmt.Fprintln(w, "| Metric | Baseline | Current | Δ |")
+	_, _ = fmt.Fprintln(w, "|---|---|---|---|")
+	_, _ = fmt.Fprintf(w, "| Pass rate | %.1f%% | %.1f%% | %+.2fpp |\n",
+		r.BaselinePassRate*100, r.CurrentPassRate*100, r.PassRateDelta)
+	_, _ = fmt.Fprintf(w, "| Threshold | | | -%.2fpp |\n", r.MaxRegressionPct)
+	_, _ = fmt.Fprintln(w)
+
+	if len(r.GoldenFailures) > 0 {
+		_, _ = fmt.Fprintln(w, "## 🛑 Golden Failures")
+		_, _ = fmt.Fprintln(w)
+		for _, id := range r.GoldenFailures {
+			_, _ = fmt.Fprintf(w, "- `%s`\n", id)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+	if len(r.Regressions) > 0 {
+		_, _ = fmt.Fprintln(w, "## ⬇️ Regressed Tasks")
+		_, _ = fmt.Fprintln(w)
+		for _, id := range r.Regressions {
+			_, _ = fmt.Fprintf(w, "- `%s`\n", id)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+	if len(r.NewTasks) > 0 {
+		_, _ = fmt.Fprintf(w, "## ➕ New Tasks (policy: `%s`)\n\n", r.OnNewTasks)
+		for _, id := range r.NewTasks {
+			_, _ = fmt.Fprintf(w, "- `%s`\n", id)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+	if len(r.RemovedTasks) > 0 {
+		_, _ = fmt.Fprintf(w, "## ➖ Removed Tasks (policy: `%s`)\n\n", r.OnRemovedTasks)
+		for _, id := range r.RemovedTasks {
+			_, _ = fmt.Fprintf(w, "- `%s`\n", id)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	_, _ = fmt.Fprintln(w, "## Tasks")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "| Task | Golden | Baseline | Current | Δ pass | Status |")
+	_, _ = fmt.Fprintln(w, "|---|---|---|---|---|---|")
+	for _, t := range r.Tasks {
+		golden := ""
+		if t.Golden {
+			golden = "⭐"
+		}
+		_, _ = fmt.Fprintf(w, "| `%s` | %s | %s | %s | %+.2fpp | %s |\n",
+			t.TestID, golden,
+			renderStatus(t.BaselineStatus, t.InBaseline),
+			renderStatus(t.CurrentStatus, t.InCurrent),
+			t.PassRateDelta*100, t.Classification)
+	}
+}
+
+func renderStatus(s string, present bool) string {
+	if !present {
+		return "—"
+	}
+	if s == "" {
+		return "?"
+	}
+	return s
+}
+
+// renderGateGitHubActions emits human output plus inline ::error::/::warning::
+// annotations consumed by GitHub Actions. Stderr is used for the workflow
+// commands so they remain visible even if stdout is redirected.
+func renderGateGitHubActions(stdout, stderr io.Writer, r *gateReport) {
+	renderGateHuman(stdout, r)
+
+	for _, id := range r.GoldenFailures {
+		_, _ = fmt.Fprintf(stderr, "::error title=Golden task failed::%s did not pass in current results\n", id)
+	}
+	for _, id := range r.Regressions {
+		_, _ = fmt.Fprintf(stderr, "::error title=Task regressed::%s pass rate dropped\n", id)
+	}
+	for _, msg := range r.Warnings {
+		_, _ = fmt.Fprintf(stderr, "::warning title=Gate warning::%s\n", msg)
+	}
+	if r.Outcome != "pass" && len(r.GoldenFailures) == 0 && len(r.Regressions) == 0 {
+		_, _ = fmt.Fprintf(stderr, "::error title=Waza gate failed::%s\n", r.Outcome)
+	}
+}
+
+// writeGateSummary writes the markdown rendering of the report to either
+// the explicit --summary-file or, when GITHUB_STEP_SUMMARY is set and the
+// format is github-actions, that file. Safe to call even when neither is
+// configured: it becomes a no-op.
+func writeGateSummary(opts *gateOpts, r *gateReport) error {
+	target := opts.summaryFile
+	if target == "" && opts.format == gateFormatGithubActions {
+		target = os.Getenv("GITHUB_STEP_SUMMARY")
+	}
+	if target == "" {
+		return nil
+	}
+	f, err := os.OpenFile(target, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	renderGateMarkdown(f, r)
+	return nil
+}

--- a/cmd/waza/cmd_gate_test.go
+++ b/cmd/waza/cmd_gate_test.go
@@ -1,0 +1,463 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTaskOutcome builds a minimal TestOutcome for gate tests. Passing
+// score=1.0 + status=Passed reflects a healthy task; score=0 + status=Failed
+// reflects an outright failure.
+func makeTaskOutcome(id, name string, golden bool, status models.Status, passRate, score float64) models.TestOutcome {
+	return models.TestOutcome{
+		TestID:      id,
+		DisplayName: name,
+		Golden:      golden,
+		Status:      status,
+		Stats: &models.TestStats{
+			PassRate: passRate,
+			AvgScore: score,
+		},
+	}
+}
+
+// makeOutcome builds a minimal EvaluationOutcome with the given tasks
+// and an aggregate success rate.
+func makeOutcome(t *testing.T, modelID string, successRate float64, tasks ...models.TestOutcome) *models.EvaluationOutcome {
+	t.Helper()
+	return &models.EvaluationOutcome{
+		RunID:     "eval-gate",
+		BenchName: "gate-test",
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Setup: models.OutcomeSetup{
+			ModelID:     modelID,
+			RunsPerTest: 1,
+			EngineType:  "mock",
+		},
+		Digest: models.OutcomeDigest{
+			TotalTests:  len(tasks),
+			SuccessRate: successRate,
+		},
+		TestOutcomes: tasks,
+	}
+}
+
+// writeOutcome serializes an outcome to a temp file and returns the path.
+func writeOutcome(t *testing.T, dir, name string, o *models.EvaluationOutcome) string {
+	t.Helper()
+	data, err := json.MarshalIndent(o, "", "  ")
+	require.NoError(t, err)
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, data, 0o644))
+	return p
+}
+
+func TestGate_Pass_NoRegression(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+	)
+	curr := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 5,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyWarn,
+		format:           gateFormatHuman,
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, stdout.String(), "PASS")
+}
+
+func TestGate_RegressionExceedsThreshold(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+		makeTaskOutcome("task-2", "Task 2", false, models.StatusPassed, 1.0, 1.0),
+	)
+	// Drop 50pp (one of two tasks failed)
+	curr := makeOutcome(t, "gpt-4o", 0.5,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+		makeTaskOutcome("task-2", "Task 2", false, models.StatusFailed, 0.0, 0.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 5,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyAllow,
+		format:           gateFormatHuman,
+	})
+	require.Error(t, err)
+	var ge *gateExitError
+	require.True(t, errors.As(err, &ge))
+	assert.Equal(t, GateExitRegress, ge.code, "regression must exit 1")
+}
+
+func TestGate_RegressionUnderThreshold_Passes(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.00,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+	)
+	// Tiny drop (1pp) — should pass when threshold is 5pp
+	curr := makeOutcome(t, "gpt-4o", 0.99,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 0.99, 0.99),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 5,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyAllow,
+		format:           gateFormatHuman,
+	})
+	assert.NoError(t, err, "1pp drop with 5pp threshold should pass")
+}
+
+func TestGate_GoldenFailure_HardFails(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-golden", "Golden Task", true, models.StatusPassed, 1.0, 1.0),
+		makeTaskOutcome("task-2", "Task 2", false, models.StatusPassed, 1.0, 1.0),
+	)
+	// Aggregate pass rate still high (no threshold breach) but the golden
+	// task failed — must exit 2.
+	curr := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-golden", "Golden Task", true, models.StatusFailed, 0.0, 0.0),
+		makeTaskOutcome("task-2", "Task 2", false, models.StatusPassed, 1.0, 1.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 50,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyAllow,
+		format:           gateFormatJSON,
+	})
+	require.Error(t, err)
+	var ge *gateExitError
+	require.True(t, errors.As(err, &ge))
+	assert.Equal(t, GateExitGolden, ge.code, "golden failure must exit 2 even when aggregate is healthy")
+
+	// JSON output should expose the golden failures list.
+	var report gateReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	assert.Equal(t, "golden-fail", report.Outcome)
+	assert.Contains(t, report.GoldenFailures, "task-golden")
+}
+
+func TestGate_GoldenFailure_Disabled_FallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-golden", "Golden Task", true, models.StatusPassed, 1.0, 1.0),
+	)
+	curr := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-golden", "Golden Task", true, models.StatusFailed, 0.0, 0.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 100,
+		goldenMustPass:   false,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyAllow,
+		format:           gateFormatJSON,
+	})
+	// With --golden-must-pass=false and a permissive aggregate threshold,
+	// the gate should pass even though a golden task failed.
+	assert.NoError(t, err)
+}
+
+func TestGate_NewTasksFail(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+	)
+	curr := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+		makeTaskOutcome("task-2-new", "Task 2", false, models.StatusPassed, 1.0, 1.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 100,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyFail,
+		onRemovedTasks:   gatePolicyAllow,
+		format:           gateFormatJSON,
+	})
+	require.Error(t, err)
+	var ge *gateExitError
+	require.True(t, errors.As(err, &ge))
+	assert.Equal(t, GateExitRegress, ge.code)
+}
+
+func TestGate_RemovedTasksWarn_StillPasses(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+		makeTaskOutcome("task-2", "Task 2", false, models.StatusPassed, 1.0, 1.0),
+	)
+	// Removed task-2 in current
+	curr := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 100,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyWarn,
+		format:           gateFormatJSON,
+	})
+	assert.NoError(t, err, "warn policy on removed tasks should not fail")
+
+	var report gateReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	assert.Equal(t, "pass", report.Outcome)
+	assert.Contains(t, report.RemovedTasks, "task-2")
+	assert.NotEmpty(t, report.Warnings)
+}
+
+func TestGate_RemovedTasksFail(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+		makeTaskOutcome("task-2", "Task 2", false, models.StatusPassed, 1.0, 1.0),
+	)
+	curr := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 100,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyFail,
+		format:           gateFormatJSON,
+	})
+	require.Error(t, err)
+	var ge *gateExitError
+	require.True(t, errors.As(err, &ge))
+	assert.Equal(t, GateExitRegress, ge.code)
+}
+
+func TestGate_MissingFile_ConfigError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     "/nonexistent/base.json",
+		currentPath:      "/nonexistent/curr.json",
+		maxRegressionPct: 5,
+		format:           gateFormatHuman,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyAllow,
+	})
+	require.Error(t, err)
+	var ge *gateExitError
+	require.True(t, errors.As(err, &ge))
+	assert.Equal(t, GateExitConfErr, ge.code)
+}
+
+func TestGate_GoldenPriorityOverRegression(t *testing.T) {
+	// When both a golden failure and an aggregate regression happen, the
+	// exit code should be 2 (golden) — the more specific signal wins.
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-golden", "Golden", true, models.StatusPassed, 1.0, 1.0),
+		makeTaskOutcome("task-2", "Task 2", false, models.StatusPassed, 1.0, 1.0),
+	)
+	curr := makeOutcome(t, "gpt-4o", 0.0,
+		makeTaskOutcome("task-golden", "Golden", true, models.StatusFailed, 0.0, 0.0),
+		makeTaskOutcome("task-2", "Task 2", false, models.StatusFailed, 0.0, 0.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 5,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyAllow,
+		format:           gateFormatJSON,
+	})
+	require.Error(t, err)
+	var ge *gateExitError
+	require.True(t, errors.As(err, &ge))
+	assert.Equal(t, GateExitGolden, ge.code, "golden failure must dominate over regression")
+}
+
+func TestGate_GithubActionsFormat_AnnotationsOnStderr(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-golden", "Golden", true, models.StatusPassed, 1.0, 1.0),
+	)
+	curr := makeOutcome(t, "gpt-4o", 0.0,
+		makeTaskOutcome("task-golden", "Golden", true, models.StatusFailed, 0.0, 0.0),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	summary := filepath.Join(dir, "summary.md")
+
+	var stdout, stderr bytes.Buffer
+	err := runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 100,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyAllow,
+		format:           gateFormatGithubActions,
+		summaryFile:      summary,
+	})
+	require.Error(t, err)
+	assert.Contains(t, stderr.String(), "::error", "GHA format must emit ::error:: annotations on stderr")
+	data, ferr := os.ReadFile(summary)
+	require.NoError(t, ferr)
+	assert.Contains(t, string(data), "# Waza Gate Report")
+}
+
+func TestGate_PolicyParsing(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    gatePolicy
+		wantErr bool
+	}{
+		{"allow", gatePolicyAllow, false},
+		{"WARN", gatePolicyWarn, false},
+		{"  fail  ", gatePolicyFail, false},
+		{"bogus", "", true},
+	}
+	for _, c := range cases {
+		got, err := parseGatePolicy(c.in, "--flag")
+		if c.wantErr {
+			assert.Error(t, err, "input=%q", c.in)
+		} else {
+			require.NoError(t, err, "input=%q", c.in)
+			assert.Equal(t, c.want, got)
+		}
+	}
+}
+
+func TestGate_FormatParsing(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    gateFormat
+		wantErr bool
+	}{
+		{"human", gateFormatHuman, false},
+		{"", gateFormatHuman, false},
+		{"json", gateFormatJSON, false},
+		{"MARKDOWN", gateFormatMarkdown, false},
+		{"github-actions", gateFormatGithubActions, false},
+		{"yaml", "", true},
+	}
+	for _, c := range cases {
+		got, err := parseGateFormat(c.in)
+		if c.wantErr {
+			assert.Error(t, err, "input=%q", c.in)
+		} else {
+			require.NoError(t, err, "input=%q", c.in)
+			assert.Equal(t, c.want, got)
+		}
+	}
+}
+
+func TestGate_MarkdownContainsKeyHeadings(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(t, "gpt-4o", 1.0,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusPassed, 1.0, 1.0),
+	)
+	curr := makeOutcome(t, "gpt-4o", 0.5,
+		makeTaskOutcome("task-1", "Task 1", false, models.StatusFailed, 0.5, 0.5),
+	)
+	bp := writeOutcome(t, dir, "base.json", base)
+	cp := writeOutcome(t, dir, "curr.json", curr)
+
+	var stdout, stderr bytes.Buffer
+	_ = runGate(&stdout, &stderr, &gateOpts{
+		baselinePath:     bp,
+		currentPath:      cp,
+		maxRegressionPct: 5,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyAllow,
+		format:           gateFormatMarkdown,
+	})
+	out := stdout.String()
+	assert.True(t, strings.Contains(out, "# Waza Gate Report"))
+	assert.True(t, strings.Contains(out, "Regressed Tasks"))
+}
+
+// TestGate_TestCaseGoldenYAML verifies the YAML tag for golden round-trips
+// through the model. Documented for skill authors: `golden: true` in a task
+// must surface on TestCase.Golden.
+func TestGate_TestCaseGoldenYAML(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "task.yaml")
+	yaml := []byte(`id: t1
+name: A
+golden: true
+inputs:
+  prompt: hello
+`)
+	require.NoError(t, os.WriteFile(p, yaml, 0o644))
+
+	tc, err := models.LoadTestCase(p)
+	require.NoError(t, err)
+	assert.True(t, tc.Golden)
+}

--- a/cmd/waza/main.go
+++ b/cmd/waza/main.go
@@ -6,7 +6,12 @@ import (
 	"os"
 )
 
-// Exit codes for different failure modes
+// Exit codes for different failure modes.
+//
+// Existing commands (waza run) historically use 0/1/2 for success /
+// test failure / config error. The `waza gate` command defines its own
+// stable scheme documented in cmd_gate.go: 0=pass, 1=regression,
+// 2=golden failure, 3=config error.
 const (
 	ExitSuccess    = 0 // All tests passed
 	ExitTestFailed = 1 // One or more tests failed
@@ -26,6 +31,13 @@ func (e *TestFailureError) Error() string {
 func main() {
 	if err := execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+
+		// Gate-specific exit codes (0=pass, 1=regression, 2=golden, 3=config).
+		// See cmd_gate.go for the full contract.
+		var gateErr *gateExitError
+		if errors.As(err, &gateErr) {
+			os.Exit(gateErr.code)
+		}
 
 		// Check error type to determine exit code
 		var testFailureErr *TestFailureError

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -54,6 +54,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newInitCommand())
 	cmd.AddCommand(tokens.NewCommand())
 	cmd.AddCommand(newCompareCommand())
+	cmd.AddCommand(newGateCommand())
 	cmd.AddCommand(newCoverageCommand())
 	cmd.AddCommand(dev.NewCommand())
 	cmd.AddCommand(newGradeCommand())

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -140,6 +140,7 @@ type TestOutcome struct {
 	TestID      string             `json:"test_id"`
 	DisplayName string             `json:"display_name"`
 	Group       string             `json:"group,omitempty"`
+	Golden      bool               `json:"golden,omitempty"`
 	Status      Status             `json:"status"`
 	Runs        []RunResult        `json:"runs"`
 	Stats       *TestStats         `json:"stats,omitempty"`

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -22,7 +22,11 @@ type TestCase struct {
 	Summary          string          `yaml:"description,omitempty" json:"summary,omitempty"`
 	Tags             []string        `yaml:"tags,omitempty" json:"labels,omitempty"`
 	TestID           string          `yaml:"id" json:"test_id"`
-	TimeoutSec       *int            `yaml:"timeout_seconds,omitempty" json:"timeout_sec,omitempty"`
+	// Golden marks a test as a "golden" task: when true, any failure of this
+	// task causes `waza gate` to fail with the dedicated golden exit code
+	// regardless of the aggregate regression threshold.
+	Golden     bool `yaml:"golden,omitempty" json:"golden,omitempty"`
+	TimeoutSec *int `yaml:"timeout_seconds,omitempty" json:"timeout_sec,omitempty"`
 	// FirstEventTimeoutSec overrides Config.FirstEventTimeoutSec for this task.
 	// nil inherits the eval-level value; 0 disables the check for this task.
 	FirstEventTimeoutSec *int              `yaml:"first_event_timeout_seconds,omitempty" json:"first_event_timeout_sec,omitempty"`

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -745,6 +745,7 @@ func (r *EvalRunner) runSequential(ctx context.Context, testCases []*models.Test
 				outcomes = append(outcomes, models.TestOutcome{
 					TestID:      tc.TestID,
 					DisplayName: tc.DisplayName,
+					Golden:      tc.Golden,
 					Status:      models.StatusFailed,
 					Runs:        []models.RunResult{},
 				})
@@ -832,6 +833,7 @@ func (r *EvalRunner) runConcurrent(ctx context.Context, testCases []*models.Test
 					resultChan <- result{index: idx, outcome: models.TestOutcome{
 						TestID:      test.TestID,
 						DisplayName: test.DisplayName,
+						Golden:      test.Golden,
 						Status:      models.StatusFailed,
 						Runs:        []models.RunResult{},
 					}}
@@ -1005,6 +1007,7 @@ func (r *EvalRunner) runTestUncached(ctx context.Context, tc *models.TestCase, t
 		TestID:      tc.TestID,
 		DisplayName: tc.DisplayName,
 		Group:       r.resolveGroup(),
+		Golden:      tc.Golden,
 		Status:      status,
 		Runs:        runs,
 		Stats:       stats,

--- a/site/src/content/docs/guides/ci-cd.mdx
+++ b/site/src/content/docs/guides/ci-cd.mdx
@@ -139,6 +139,110 @@ To run it manually:
 gh workflow run weekly-regression-loop.yml --repo microsoft/waza
 ```
 
+### Regression Gates with `waza gate`
+
+For per-PR gating, use the dedicated [`waza gate`](/reference/cli/#waza-gate)
+command. It compares a baseline results JSON against the current run and
+exits with stable codes so CI systems can branch on the failure class:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Pass |
+| `1` | Aggregate regression past `--max-regression-pct` |
+| `2` | A `golden: true` task failed |
+| `3` | Configuration error |
+
+#### GitHub Actions
+
+```yaml
+name: Eval Gate
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "evals/**"
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install waza
+        run: curl -fsSL https://aka.ms/install-waza | bash
+
+      # Download the latest successful run's baseline.
+      - name: Download baseline
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: eval-baseline.yml
+          name: waza-baseline
+          path: baseline
+
+      - name: Run evals
+        run: waza run evals/my-skill.yaml -o results.json
+
+      - name: Gate
+        run: |
+          waza gate \
+            --baseline baseline/results.json \
+            --current results.json \
+            --max-regression-pct 2 \
+            --golden-must-pass \
+            --on-removed-tasks fail \
+            --format github-actions
+
+      - name: Upload current results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: waza-current
+          path: results.json
+```
+
+Because the `github-actions` format writes `::error::` / `::warning::` workflow
+commands and appends a markdown report to `$GITHUB_STEP_SUMMARY`, gate failures
+appear directly in the PR Files Changed view and the workflow summary.
+
+#### Azure DevOps Pipelines
+
+```yaml
+- script: |
+    waza gate \
+      --baseline $(Pipeline.Workspace)/baseline/results.json \
+      --current results.json \
+      --max-regression-pct 2 \
+      --golden-must-pass \
+      --format markdown \
+      --summary-file gate-report.md
+  displayName: "Waza Gate"
+
+- task: PublishBuildArtifacts@1
+  condition: always()
+  inputs:
+    pathToPublish: gate-report.md
+    artifactName: gate-report
+```
+
+#### GitLab CI
+
+```yaml
+gate:
+  stage: test
+  script:
+    - waza gate
+        --baseline baseline/results.json
+        --current results.json
+        --max-regression-pct 2
+        --golden-must-pass
+        --format json
+        > gate.json
+  artifacts:
+    when: always
+    paths: [gate.json]
+```
+
 ### Token Budget Checks
 
 Use `waza tokens compare` to track token usage across PRs and fail if budgets are exceeded:

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -340,6 +340,7 @@ expected:
 | `name`        | string | Human-readable task name                            |
 | `description` | string | What the task tests                                 |
 | `tags`        | array  | Tags for filtering (e.g., `["basic", "edge-case"]`) |
+| `golden`      | bool   | Mark as a golden / smoke task. When the task fails, [`waza gate`](/reference/cli/#waza-gate) exits with code `2`, taking priority over the aggregate regression check. |
 | `inputs`      | object | Test inputs (prompt, files)                         |
 | `expected`    | object | Validation rules and expected behavior              |
 | `skill_directories` | string[] | Skill directories for this task (overrides eval-level) |

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -408,6 +408,76 @@ waza compare gpt4.json sonnet.json opus.json
 waza compare results-*.json --format json
 ```
 
+## waza gate
+
+Compare a current eval results file against a baseline and fail CI when quality
+regresses, golden tasks fail, or the task set diverges in unexpected ways.
+
+```bash
+waza gate \
+  --baseline results-baseline.json \
+  --current results-current.json \
+  --max-regression-pct 2 \
+  --golden-must-pass \
+  --format github-actions
+```
+
+**Flags**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--baseline <path>` | Baseline results JSON to compare against. | _required_ |
+| `--current <path>` | Current results JSON produced by `waza run -o`. | _required_ |
+| `--max-regression-pct <N>` | Fail if aggregate pass rate drops by more than _N_ percentage points. | `0` |
+| `--golden-must-pass` | When set, any failing task with `golden: true` exits **2** regardless of aggregate pass rate. | `true` |
+| `--on-new-tasks <policy>` | Behavior when `current` has tasks missing from `baseline`. One of `allow`, `warn`, `fail`. | `allow` |
+| `--on-removed-tasks <policy>` | Behavior when `baseline` has tasks missing from `current`. One of `allow`, `warn`, `fail`. | `warn` |
+| `--format <format>` | Output format. One of `human`, `json`, `markdown`, `github-actions`. | `human` |
+| `--summary-file <path>` | Write the markdown report to this path. When `--format github-actions` is set, this defaults to `$GITHUB_STEP_SUMMARY`. | _none_ |
+
+**Exit codes**
+
+`waza gate` defines its own stable exit codes so CI systems can branch on the
+exact failure class:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Pass — no regression, no golden failures, task-set policies satisfied. |
+| `1` | Regression — aggregate pass rate dropped past `--max-regression-pct`, or a task-set policy fired with `fail`. |
+| `2` | Golden failure — a task marked `golden: true` failed. Takes priority over `1`. |
+| `3` | Configuration error — bad flags, missing/unreadable files, etc. |
+
+**Marking a task as golden**
+
+```yaml
+# my-eval.yaml
+tasks:
+  - id: must-always-work
+    name: Smoke test
+    golden: true       # <- waza gate will exit 2 if this task fails
+    inputs:
+      prompt: "..."
+```
+
+**Examples**
+
+```bash
+# Strict gate: any drop in aggregate pass rate fails the build.
+waza gate --baseline base.json --current results.json --max-regression-pct 0
+
+# Allow up to a 2pp drop, but never tolerate a golden failure.
+waza gate --baseline base.json --current results.json \
+  --max-regression-pct 2 --golden-must-pass
+
+# GitHub Actions: emit ::error:: annotations + job summary.
+waza gate --baseline base.json --current results.json \
+  --format github-actions
+
+# Treat removed tasks as a hard failure (covers accidental deletions).
+waza gate --baseline base.json --current results.json \
+  --on-removed-tasks fail
+```
+
 ## waza coverage
 
 Generate an eval coverage grid for discovered skills and custom agents.
@@ -949,11 +1019,16 @@ waza models --json
 
 ## Exit Codes
 
+Most commands use the following exit codes:
+
 | Code | Meaning |
 |------|---------|
 | `0` | Success |
 | `1` | One or more tasks failed |
 | `2` | Configuration or runtime error |
+
+`waza gate` defines its own scheme (see the [waza gate](#waza-gate) section):
+`0` pass, `1` regression, `2` golden failure, `3` configuration error.
 
 ## Global Flags
 


### PR DESCRIPTION
Closes #364

## Summary

Adds a new `waza gate` subcommand that compares a baseline `results.json` against the current run and returns **stable exit codes** so CI systems can branch on the exact failure class.

## Exit code contract

| Code | Meaning |
|------|---------|
| `0` | Pass — no regressions, no golden failures, task-set policies satisfied |
| `1` | Aggregate pass rate dropped beyond `--max-regression-pct`, or a task-set policy fired with `fail` |
| `2` | A task with `golden: true` failed (takes priority over `1`) |
| `3` | Configuration error (bad flags, missing or unreadable files) |

## Flags

| Flag | Description | Default |
|------|-------------|---------|
| `--baseline <path>` | Baseline results JSON | _required_ |
| `--current <path>`  | Current results JSON  | _required_ |
| `--max-regression-pct <N>` | Fail if aggregate pass rate drops by more than _N_ pp | `0` |
| `--golden-must-pass` | Hard-fail on any golden task failure | `true` |
| `--on-new-tasks <p>` | `allow` / `warn` / `fail` for tasks in current but not baseline | `allow` |
| `--on-removed-tasks <p>` | `allow` / `warn` / `fail` for tasks in baseline but not current | `warn` |
| `--format <fmt>` | `human` / `json` / `markdown` / `github-actions` | `human` |
| `--summary-file <path>` | Markdown summary path (auto-set to `$GITHUB_STEP_SUMMARY` with `github-actions`) | _none_ |

## Golden tasks

New `golden: true` field on `TestCase`, propagated through `TestOutcome`. Skill authors mark tasks the build must never regress:

```yaml
tasks:
  - id: smoke-test
    name: Must always work
    golden: true
    inputs:
      prompt: "..."
```

## GitHub Actions integration

The `github-actions` format:
- emits `::error::` / `::warning::` workflow commands on **stderr** (so they still surface when stdout is captured),
- appends a markdown report to `$GITHUB_STEP_SUMMARY`,
- so failures appear in the PR Files Changed view and the workflow summary without any extra wiring.

## Files changed

- **New:** `cmd/waza/cmd_gate.go` — command, four renderers, exit-code error type
- **New:** `cmd/waza/cmd_gate_test.go` — 15 tests covering all exit codes, all renderers, golden priority, task-set policies, YAML round-trip
- **Modified:** `internal/models/testcase.go`, `internal/models/outcome.go` — add `Golden bool` field
- **Modified:** `internal/orchestration/runner.go` — propagate `Golden` into three `TestOutcome` construction sites
- **Modified:** `cmd/waza/main.go`, `cmd/waza/root.go` — wire `gateExitError` and register the command
- **Docs:** `README.md`, `site/src/content/docs/reference/cli.mdx`, `site/src/content/docs/guides/ci-cd.mdx`, `site/src/content/docs/guides/eval-yaml.mdx`

## Verification

- `go build ./...` — ✅
- `go test ./...` — ✅ (all packages, 15 new gate tests pass)
- `make lint` — ✅ (no new issues; the 6 remaining `SA5011` warnings in `internal/mcp/coverage_test.go` are pre-existing on `main` and unrelated to this PR)
- `go run ./cmd/waza gate --help` — ✅ renders correctly