### PR TITLE
feat: add regression gate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ waza grade eval.yaml --results results.json
 # Compare results across models
 waza compare results-gpt4.json results-sonnet.json
 
+# Gate current results against a baseline in CI
+waza gate --baseline baseline.json --current results.json --max-regression-pct 5 --golden-must-pass
+
 # Generate eval coverage grid
 waza coverage --format markdown
 
@@ -399,6 +402,33 @@ Compare results from multiple evaluation runs side by side — per-task score de
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--format <fmt>` | `-f` | Output format: `table` or `json` (default: `table`) |
+
+### `waza gate --baseline <file> --current <file>`
+
+Gate current evaluation results against a baseline for CI. The command fails when aggregate pass rate regresses beyond the allowed threshold, when golden tasks fail, or when added/removed task policies are violated.
+
+| Flag | Description |
+|------|-------------|
+| `--baseline <file>` | Baseline `waza run --output` JSON |
+| `--current <file>` | Current `waza run --output` JSON |
+| `--max-regression-pct <n>` | Maximum allowed aggregate pass-rate drop in percentage points (default: `0`) |
+| `--golden-must-pass` | Fail with exit code `2` when any current task marked `golden: true` fails |
+| `--on-new-tasks <policy>` | Behavior for current-only tasks: `allow`, `warn`, or `fail` (default: `allow`) |
+| `--on-removed-tasks <policy>` | Behavior for baseline-only tasks: `allow`, `warn`, or `fail` (default: `warn`) |
+| `--format <fmt>` | Output format: `human`, `json`, `markdown`, or `github-actions` (default: `human`) |
+
+Stable exit codes: `0` pass, `1` gate failure/regression, `2` golden task failure, `3` gate configuration error.
+
+```bash
+waza gate \
+  --baseline baseline.json \
+  --current results.json \
+  --max-regression-pct 5 \
+  --golden-must-pass \
+  --on-new-tasks allow \
+  --on-removed-tasks warn \
+  --format github-actions
+```
 
 ### `waza coverage [root]`
 

--- a/cmd/waza/cmd_gate.go
+++ b/cmd/waza/cmd_gate.go
@@ -1,0 +1,511 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/spf13/cobra"
+)
+
+const (
+	ExitGateRegression    = 1
+	ExitGateGoldenFailure = 2
+	ExitGateConfigError   = 3
+)
+
+type gateExitError struct {
+	code    int
+	message string
+}
+
+func (e *gateExitError) Error() string {
+	return e.message
+}
+
+func (e *gateExitError) ExitCode() int {
+	return e.code
+}
+
+type gateTaskDeltaPolicy string
+
+const (
+	gateTaskDeltaAllow gateTaskDeltaPolicy = "allow"
+	gateTaskDeltaWarn  gateTaskDeltaPolicy = "warn"
+	gateTaskDeltaFail  gateTaskDeltaPolicy = "fail"
+)
+
+type gateOutputFormat string
+
+const (
+	gateFormatHuman         gateOutputFormat = "human"
+	gateFormatJSON          gateOutputFormat = "json"
+	gateFormatMarkdown      gateOutputFormat = "markdown"
+	gateFormatGitHubActions gateOutputFormat = "github-actions"
+)
+
+type gateOptions struct {
+	baselinePath     string
+	currentPath      string
+	maxRegressionPct float64
+	goldenMustPass   bool
+	onNewTasks       string
+	onRemovedTasks   string
+	format           string
+}
+
+type gateReport struct {
+	Passed                 bool             `json:"passed"`
+	ExitCode               int              `json:"exit_code"`
+	Verdict                string           `json:"verdict"`
+	BaselineFile           string           `json:"baseline_file"`
+	CurrentFile            string           `json:"current_file"`
+	BaselineSuccessRate    float64          `json:"baseline_success_rate"`
+	CurrentSuccessRate     float64          `json:"current_success_rate"`
+	RegressionPct          float64          `json:"regression_pct"`
+	MaxRegressionPct       float64          `json:"max_regression_pct"`
+	GoldenMustPass         bool             `json:"golden_must_pass"`
+	GoldenFailures         []gateTaskResult `json:"golden_failures,omitempty"`
+	NewTasks               []gateTaskResult `json:"new_tasks,omitempty"`
+	RemovedTasks           []gateTaskResult `json:"removed_tasks,omitempty"`
+	Warnings               []gateIssue      `json:"warnings,omitempty"`
+	Failures               []gateIssue      `json:"failures,omitempty"`
+	BaselineTaskCount      int              `json:"baseline_task_count"`
+	CurrentTaskCount       int              `json:"current_task_count"`
+	NewTaskPolicy          string           `json:"new_task_policy"`
+	RemovedTaskPolicy      string           `json:"removed_task_policy"`
+	BaselineModel          string           `json:"baseline_model,omitempty"`
+	CurrentModel           string           `json:"current_model,omitempty"`
+	BaselineRunsPerTest    int              `json:"baseline_runs_per_test,omitempty"`
+	CurrentRunsPerTest     int              `json:"current_runs_per_test,omitempty"`
+	BaselineAggregateScore float64          `json:"baseline_aggregate_score"`
+	CurrentAggregateScore  float64          `json:"current_aggregate_score"`
+}
+
+type gateTaskResult struct {
+	TaskID      string        `json:"task_id"`
+	DisplayName string        `json:"display_name"`
+	Golden      bool          `json:"golden,omitempty"`
+	Status      models.Status `json:"status"`
+	PassRate    float64       `json:"pass_rate"`
+}
+
+type gateIssue struct {
+	Kind     string `json:"kind"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+	TaskID   string `json:"task_id,omitempty"`
+	TaskName string `json:"task_name,omitempty"`
+}
+
+func newGateCommand() *cobra.Command {
+	opts := gateOptions{
+		onNewTasks:     string(gateTaskDeltaAllow),
+		onRemovedTasks: string(gateTaskDeltaWarn),
+		format:         string(gateFormatHuman),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "gate --baseline baseline.json --current results.json",
+		Short: "Gate current evaluation results against a baseline",
+		Long: `Gate current evaluation results against a baseline for CI.
+
+The gate fails when aggregate pass rate regresses beyond the configured
+threshold, when golden tasks fail with --golden-must-pass, or when task set
+changes violate the selected added/removed task policies.`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return gateConfigError(fmt.Errorf("unexpected positional arguments: %s", strings.Join(args, ", ")))
+			}
+			return gateCommandE(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.baselinePath, "baseline", "", "Baseline results JSON file")
+	cmd.Flags().StringVar(&opts.currentPath, "current", "", "Current results JSON file")
+	cmd.Flags().Float64Var(&opts.maxRegressionPct, "max-regression-pct", 0, "Maximum allowed aggregate pass-rate regression in percentage points")
+	cmd.Flags().BoolVar(&opts.goldenMustPass, "golden-must-pass", false, "Fail with exit code 2 if any current golden task fails")
+	cmd.Flags().StringVar(&opts.onNewTasks, "on-new-tasks", opts.onNewTasks, "Behavior for tasks present only in current results: allow, warn, or fail")
+	cmd.Flags().StringVar(&opts.onRemovedTasks, "on-removed-tasks", opts.onRemovedTasks, "Behavior for tasks present only in baseline results: allow, warn, or fail")
+	cmd.Flags().StringVarP(&opts.format, "format", "f", opts.format, "Output format: human, json, markdown, or github-actions")
+
+	return cmd
+}
+
+func gateCommandE(cmd *cobra.Command, opts gateOptions) error {
+	normalized, err := normalizeGateOptions(opts)
+	if err != nil {
+		return gateConfigError(err)
+	}
+
+	baseline, err := loadOutcomeFile(normalized.baselinePath)
+	if err != nil {
+		return gateConfigError(fmt.Errorf("failed to load baseline %s: %w", normalized.baselinePath, err))
+	}
+	current, err := loadOutcomeFile(normalized.currentPath)
+	if err != nil {
+		return gateConfigError(fmt.Errorf("failed to load current %s: %w", normalized.currentPath, err))
+	}
+
+	report := buildGateReport(normalized, baseline, current)
+	if err := printGateReport(cmd.OutOrStdout(), normalized, report); err != nil {
+		return gateConfigError(err)
+	}
+	if report.Passed {
+		return nil
+	}
+	return &gateExitError{code: report.ExitCode, message: gateFailureMessage(report)}
+}
+
+func gateConfigError(err error) error {
+	return &gateExitError{code: ExitGateConfigError, message: err.Error()}
+}
+
+func normalizeGateOptions(opts gateOptions) (gateOptions, error) {
+	opts.baselinePath = strings.TrimSpace(opts.baselinePath)
+	opts.currentPath = strings.TrimSpace(opts.currentPath)
+	opts.onNewTasks = strings.ToLower(strings.TrimSpace(opts.onNewTasks))
+	opts.onRemovedTasks = strings.ToLower(strings.TrimSpace(opts.onRemovedTasks))
+	opts.format = strings.ToLower(strings.TrimSpace(opts.format))
+
+	if opts.baselinePath == "" {
+		return opts, fmt.Errorf("--baseline is required")
+	}
+	if opts.currentPath == "" {
+		return opts, fmt.Errorf("--current is required")
+	}
+	if opts.maxRegressionPct < 0 {
+		return opts, fmt.Errorf("--max-regression-pct must be >= 0")
+	}
+	if _, err := parseGateTaskPolicy(opts.onNewTasks); err != nil {
+		return opts, fmt.Errorf("--on-new-tasks: %w", err)
+	}
+	if _, err := parseGateTaskPolicy(opts.onRemovedTasks); err != nil {
+		return opts, fmt.Errorf("--on-removed-tasks: %w", err)
+	}
+	if _, err := parseGateFormat(opts.format); err != nil {
+		return opts, err
+	}
+	return opts, nil
+}
+
+func parseGateTaskPolicy(value string) (gateTaskDeltaPolicy, error) {
+	switch gateTaskDeltaPolicy(value) {
+	case gateTaskDeltaAllow, gateTaskDeltaWarn, gateTaskDeltaFail:
+		return gateTaskDeltaPolicy(value), nil
+	default:
+		return "", fmt.Errorf("unsupported policy %q: must be allow, warn, or fail", value)
+	}
+}
+
+func parseGateFormat(value string) (gateOutputFormat, error) {
+	switch gateOutputFormat(value) {
+	case gateFormatHuman, gateFormatJSON, gateFormatMarkdown, gateFormatGitHubActions:
+		return gateOutputFormat(value), nil
+	default:
+		return "", fmt.Errorf("unsupported format %q: must be human, json, markdown, or github-actions", value)
+	}
+}
+
+func buildGateReport(opts gateOptions, baseline, current *models.EvaluationOutcome) *gateReport {
+	newPolicy, _ := parseGateTaskPolicy(opts.onNewTasks)
+	removedPolicy, _ := parseGateTaskPolicy(opts.onRemovedTasks)
+
+	report := &gateReport{
+		Passed:                 true,
+		ExitCode:               ExitSuccess,
+		Verdict:                "pass",
+		BaselineFile:           opts.baselinePath,
+		CurrentFile:            opts.currentPath,
+		BaselineSuccessRate:    baseline.Digest.SuccessRate,
+		CurrentSuccessRate:     current.Digest.SuccessRate,
+		MaxRegressionPct:       opts.maxRegressionPct,
+		GoldenMustPass:         opts.goldenMustPass,
+		BaselineTaskCount:      len(baseline.TestOutcomes),
+		CurrentTaskCount:       len(current.TestOutcomes),
+		NewTaskPolicy:          string(newPolicy),
+		RemovedTaskPolicy:      string(removedPolicy),
+		BaselineModel:          baseline.Setup.ModelID,
+		CurrentModel:           current.Setup.ModelID,
+		BaselineRunsPerTest:    baseline.Setup.RunsPerTest,
+		CurrentRunsPerTest:     current.Setup.RunsPerTest,
+		BaselineAggregateScore: baseline.Digest.AggregateScore,
+		CurrentAggregateScore:  current.Digest.AggregateScore,
+	}
+
+	drop := (baseline.Digest.SuccessRate - current.Digest.SuccessRate) * 100
+	if drop > 0 {
+		report.RegressionPct = drop
+	}
+	if report.RegressionPct > opts.maxRegressionPct {
+		report.Failures = append(report.Failures, gateIssue{
+			Kind:     "regression",
+			Severity: "error",
+			Message:  fmt.Sprintf("aggregate pass rate regressed by %.2f percentage points, exceeding %.2f", report.RegressionPct, opts.maxRegressionPct),
+		})
+	}
+
+	baselineTasks := indexGateTasks(baseline.TestOutcomes)
+	currentTasks := indexGateTasks(current.TestOutcomes)
+
+	for _, id := range sortedTaskIDs(currentTasks) {
+		currentTask := currentTasks[id]
+		if _, ok := baselineTasks[id]; !ok {
+			task := gateTaskFromOutcome(currentTask)
+			report.NewTasks = append(report.NewTasks, task)
+			applyGateTaskPolicy(&report.Warnings, &report.Failures, newPolicy, "new_task", task)
+		}
+		if opts.goldenMustPass && currentTask.Golden && currentTask.Status != models.StatusPassed {
+			task := gateTaskFromOutcome(currentTask)
+			report.GoldenFailures = append(report.GoldenFailures, task)
+		}
+	}
+
+	for _, id := range sortedTaskIDs(baselineTasks) {
+		if _, ok := currentTasks[id]; ok {
+			continue
+		}
+		task := gateTaskFromOutcome(baselineTasks[id])
+		report.RemovedTasks = append(report.RemovedTasks, task)
+		applyGateTaskPolicy(&report.Warnings, &report.Failures, removedPolicy, "removed_task", task)
+	}
+
+	if len(report.GoldenFailures) > 0 {
+		report.Passed = false
+		report.ExitCode = ExitGateGoldenFailure
+		report.Verdict = "golden-failure"
+		report.Failures = appendGoldenFailures(report.Failures, report.GoldenFailures)
+		return report
+	}
+
+	if len(report.Failures) > 0 {
+		report.Passed = false
+		report.ExitCode = ExitGateRegression
+		report.Verdict = "fail"
+	}
+
+	return report
+}
+
+func indexGateTasks(outcomes []models.TestOutcome) map[string]models.TestOutcome {
+	result := make(map[string]models.TestOutcome, len(outcomes))
+	for _, outcome := range outcomes {
+		result[outcome.TestID] = outcome
+	}
+	return result
+}
+
+func sortedTaskIDs(tasks map[string]models.TestOutcome) []string {
+	ids := make([]string, 0, len(tasks))
+	for id := range tasks {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func gateTaskFromOutcome(outcome models.TestOutcome) gateTaskResult {
+	passRate := 0.0
+	if outcome.Stats != nil {
+		passRate = outcome.Stats.PassRate
+	}
+	return gateTaskResult{
+		TaskID:      outcome.TestID,
+		DisplayName: outcome.DisplayName,
+		Golden:      outcome.Golden,
+		Status:      outcome.Status,
+		PassRate:    passRate,
+	}
+}
+
+func applyGateTaskPolicy(warnings, failures *[]gateIssue, policy gateTaskDeltaPolicy, kind string, task gateTaskResult) {
+	if policy == gateTaskDeltaAllow {
+		return
+	}
+	severity := "warning"
+	target := warnings
+	if policy == gateTaskDeltaFail {
+		severity = "error"
+		target = failures
+	}
+	*target = append(*target, gateIssue{
+		Kind:     kind,
+		Severity: severity,
+		Message:  gateTaskPolicyMessage(kind, task, policy),
+		TaskID:   task.TaskID,
+		TaskName: task.DisplayName,
+	})
+}
+
+func gateTaskPolicyMessage(kind string, task gateTaskResult, policy gateTaskDeltaPolicy) string {
+	action := "is present only in current results"
+	if kind == "removed_task" {
+		action = "is present only in baseline results"
+	}
+	return fmt.Sprintf("task %q (%s) %s and policy is %s", task.DisplayName, task.TaskID, action, policy)
+}
+
+func appendGoldenFailures(failures []gateIssue, goldenFailures []gateTaskResult) []gateIssue {
+	for _, task := range goldenFailures {
+		failures = append(failures, gateIssue{
+			Kind:     "golden_failure",
+			Severity: "error",
+			Message:  fmt.Sprintf("golden task %q (%s) did not pass; status=%s", task.DisplayName, task.TaskID, task.Status),
+			TaskID:   task.TaskID,
+			TaskName: task.DisplayName,
+		})
+	}
+	return failures
+}
+
+func gateFailureMessage(report *gateReport) string {
+	switch report.ExitCode {
+	case ExitGateGoldenFailure:
+		return fmt.Sprintf("gate failed: %d golden task(s) failed", len(report.GoldenFailures))
+	case ExitGateRegression:
+		return fmt.Sprintf("gate failed: %d failure(s)", len(report.Failures))
+	default:
+		return "gate failed"
+	}
+}
+
+func printGateReport(w io.Writer, opts gateOptions, report *gateReport) error {
+	format, err := parseGateFormat(opts.format)
+	if err != nil {
+		return err
+	}
+	switch format {
+	case gateFormatJSON:
+		return printGateJSON(w, report)
+	case gateFormatMarkdown:
+		_, err := fmt.Fprint(w, gateMarkdown(report))
+		return err
+	case gateFormatGitHubActions:
+		return printGateGitHubActions(w, report)
+	default:
+		return printGateHuman(w, report)
+	}
+}
+
+func printGateJSON(w io.Writer, report *gateReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal gate report: %w", err)
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}
+
+func printGateHuman(w io.Writer, report *gateReport) error {
+	status := strings.ToUpper(report.Verdict)
+	if report.Passed {
+		status = "PASS"
+	}
+	_, err := fmt.Fprintf(w, "Waza gate: %s\n\n", status)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(w, "Baseline: %.1f%% pass rate (%d tasks, model: %s)\n", report.BaselineSuccessRate*100, report.BaselineTaskCount, emptyAsNA(report.BaselineModel))
+	_, _ = fmt.Fprintf(w, "Current:  %.1f%% pass rate (%d tasks, model: %s)\n", report.CurrentSuccessRate*100, report.CurrentTaskCount, emptyAsNA(report.CurrentModel))
+	_, _ = fmt.Fprintf(w, "Regression: %.2f percentage points (max allowed %.2f)\n", report.RegressionPct, report.MaxRegressionPct)
+	if report.GoldenMustPass {
+		_, _ = fmt.Fprintf(w, "Golden tasks: %d failure(s)\n", len(report.GoldenFailures))
+	}
+	_, _ = fmt.Fprintf(w, "Task changes: %d new, %d removed\n", len(report.NewTasks), len(report.RemovedTasks))
+
+	printGateIssues(w, "Failures", report.Failures)
+	printGateIssues(w, "Warnings", report.Warnings)
+	return nil
+}
+
+func printGateIssues(w io.Writer, title string, issues []gateIssue) {
+	if len(issues) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\n%s:\n", title)
+	for _, issue := range issues {
+		_, _ = fmt.Fprintf(w, "- %s\n", issue.Message)
+	}
+}
+
+func gateMarkdown(report *gateReport) string {
+	var b strings.Builder
+	status := "PASS"
+	if !report.Passed {
+		status = "FAIL"
+	}
+	_, _ = fmt.Fprintf(&b, "## Waza gate: %s\n\n", status)
+	_, _ = fmt.Fprintf(&b, "| Metric | Baseline | Current |\n")
+	_, _ = fmt.Fprintf(&b, "|---|---:|---:|\n")
+	_, _ = fmt.Fprintf(&b, "| Pass rate | %.1f%% | %.1f%% |\n", report.BaselineSuccessRate*100, report.CurrentSuccessRate*100)
+	_, _ = fmt.Fprintf(&b, "| Aggregate score | %.4f | %.4f |\n", report.BaselineAggregateScore, report.CurrentAggregateScore)
+	_, _ = fmt.Fprintf(&b, "| Tasks | %d | %d |\n\n", report.BaselineTaskCount, report.CurrentTaskCount)
+	_, _ = fmt.Fprintf(&b, "- Regression: %.2f percentage points (max allowed %.2f)\n", report.RegressionPct, report.MaxRegressionPct)
+	_, _ = fmt.Fprintf(&b, "- New tasks: %d (`%s`)\n", len(report.NewTasks), report.NewTaskPolicy)
+	_, _ = fmt.Fprintf(&b, "- Removed tasks: %d (`%s`)\n", len(report.RemovedTasks), report.RemovedTaskPolicy)
+	if report.GoldenMustPass {
+		_, _ = fmt.Fprintf(&b, "- Golden failures: %d\n", len(report.GoldenFailures))
+	}
+	appendGateIssueMarkdown(&b, "Failures", report.Failures)
+	appendGateIssueMarkdown(&b, "Warnings", report.Warnings)
+	return b.String()
+}
+
+func appendGateIssueMarkdown(b *strings.Builder, title string, issues []gateIssue) {
+	if len(issues) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(b, "\n### %s\n\n", title)
+	for _, issue := range issues {
+		_, _ = fmt.Fprintf(b, "- %s\n", issue.Message)
+	}
+}
+
+func printGateGitHubActions(w io.Writer, report *gateReport) error {
+	for _, issue := range report.Warnings {
+		_, _ = fmt.Fprintf(w, "::warning title=Waza gate::%s\n", escapeGitHubActions(issue.Message))
+	}
+	for _, issue := range report.Failures {
+		_, _ = fmt.Fprintf(w, "::error title=Waza gate::%s\n", escapeGitHubActions(issue.Message))
+	}
+	summary := gateMarkdown(report)
+	if summaryPath := os.Getenv("GITHUB_STEP_SUMMARY"); summaryPath != "" {
+		f, err := os.OpenFile(summaryPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return fmt.Errorf("writing GITHUB_STEP_SUMMARY: %w", err)
+		}
+		if _, err := f.WriteString(summary + "\n"); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("writing GITHUB_STEP_SUMMARY: %w", err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("closing GITHUB_STEP_SUMMARY: %w", err)
+		}
+		return nil
+	}
+	_, err := fmt.Fprint(w, summary)
+	return err
+}
+
+func escapeGitHubActions(value string) string {
+	replacer := strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+		":", "%3A",
+		",", "%2C",
+	)
+	return replacer.Replace(value)
+}
+
+func emptyAsNA(value string) string {
+	if value == "" {
+		return "n/a"
+	}
+	return value
+}

--- a/cmd/waza/cmd_gate_test.go
+++ b/cmd/waza/cmd_gate_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func executeGateCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newGateCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func requireExitCode(t *testing.T, err error, want int) {
+	t.Helper()
+	require.Error(t, err)
+	var exitErr exitCoder
+	require.True(t, errors.As(err, &exitErr), "expected exitCoder, got %T", err)
+	assert.Equal(t, want, exitErr.ExitCode())
+}
+
+func TestGateCommand_RegressionThresholdExitCode(t *testing.T) {
+	dir := t.TempDir()
+	baseline := createResultFile(t, dir, "baseline.json", sampleOutcome("gpt-4o", 1.0, 1.0, 1.0))
+	current := createResultFile(t, dir, "current.json", sampleOutcome("gpt-4o", 0.9, 0.9, 0.9))
+
+	out, err := executeGateCommand(t,
+		"--baseline", baseline,
+		"--current", current,
+		"--max-regression-pct", "5",
+	)
+
+	requireExitCode(t, err, ExitGateRegression)
+	assert.Contains(t, out, "Waza gate: FAIL")
+	assert.Contains(t, out, "10.00 percentage points")
+}
+
+func TestGateCommand_GoldenFailureExitCode(t *testing.T) {
+	dir := t.TempDir()
+	baselineOutcome := sampleOutcome("gpt-4o", 1.0, 1.0, 1.0)
+	currentOutcome := sampleOutcome("gpt-4o", 1.0, 1.0, 1.0)
+	currentOutcome.TestOutcomes[0].Golden = true
+	currentOutcome.TestOutcomes[0].Status = models.StatusFailed
+	currentOutcome.TestOutcomes[0].Stats.PassRate = 0
+
+	baseline := createResultFile(t, dir, "baseline.json", baselineOutcome)
+	current := createResultFile(t, dir, "current.json", currentOutcome)
+
+	out, err := executeGateCommand(t,
+		"--baseline", baseline,
+		"--current", current,
+		"--golden-must-pass",
+	)
+
+	requireExitCode(t, err, ExitGateGoldenFailure)
+	assert.Contains(t, out, "Waza gate: GOLDEN-FAILURE")
+	assert.Contains(t, out, "golden task")
+}
+
+func TestGateCommand_TaskSetPolicies(t *testing.T) {
+	baseline := sampleOutcome("gpt-4o", 1.0, 1.0, 1.0)
+	current := sampleOutcome("gpt-4o", 1.0, 1.0, 1.0)
+	current.TestOutcomes = append(current.TestOutcomes, models.TestOutcome{
+		TestID:      "task-new",
+		DisplayName: "New Task",
+		Status:      models.StatusPassed,
+		Stats:       &models.TestStats{PassRate: 1, AvgScore: 1},
+	})
+
+	report := buildGateReport(gateOptions{
+		maxRegressionPct: 0,
+		onNewTasks:       string(gateTaskDeltaFail),
+		onRemovedTasks:   string(gateTaskDeltaAllow),
+	}, baseline, current)
+
+	require.False(t, report.Passed)
+	assert.Equal(t, ExitGateRegression, report.ExitCode)
+	require.Len(t, report.NewTasks, 1)
+	require.Len(t, report.Failures, 1)
+	assert.Equal(t, "new_task", report.Failures[0].Kind)
+}
+
+func TestGateCommand_RemovedTaskWarnDoesNotFail(t *testing.T) {
+	baseline := sampleOutcome("gpt-4o", 1.0, 1.0, 1.0)
+	baseline.TestOutcomes = append(baseline.TestOutcomes, models.TestOutcome{
+		TestID:      "task-removed",
+		DisplayName: "Removed Task",
+		Status:      models.StatusPassed,
+		Stats:       &models.TestStats{PassRate: 1, AvgScore: 1},
+	})
+	current := sampleOutcome("gpt-4o", 1.0, 1.0, 1.0)
+
+	report := buildGateReport(gateOptions{
+		maxRegressionPct: 0,
+		onNewTasks:       string(gateTaskDeltaAllow),
+		onRemovedTasks:   string(gateTaskDeltaWarn),
+	}, baseline, current)
+
+	require.True(t, report.Passed)
+	require.Len(t, report.RemovedTasks, 1)
+	require.Len(t, report.Warnings, 1)
+	assert.Equal(t, "removed_task", report.Warnings[0].Kind)
+}
+
+func TestGateCommand_JSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	baseline := createResultFile(t, dir, "baseline.json", sampleOutcome("gpt-4o", 1.0, 1.0, 1.0))
+	current := createResultFile(t, dir, "current.json", sampleOutcome("gpt-4o", 1.0, 1.0, 1.0))
+
+	out, err := executeGateCommand(t,
+		"--baseline", baseline,
+		"--current", current,
+		"--format", "json",
+	)
+
+	require.NoError(t, err)
+	var report gateReport
+	require.NoError(t, json.Unmarshal([]byte(out), &report))
+	assert.True(t, report.Passed)
+	assert.Equal(t, ExitSuccess, report.ExitCode)
+}
+
+func TestGateCommand_GitHubActionsWritesAnnotationsAndSummary(t *testing.T) {
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	baseline := createResultFile(t, dir, "baseline.json", sampleOutcome("gpt-4o", 1.0, 1.0, 1.0))
+	current := createResultFile(t, dir, "current.json", sampleOutcome("gpt-4o", 0.8, 0.8, 0.8))
+
+	out, err := executeGateCommand(t,
+		"--baseline", baseline,
+		"--current", current,
+		"--max-regression-pct", "5",
+		"--format", "github-actions",
+	)
+
+	requireExitCode(t, err, ExitGateRegression)
+	assert.Contains(t, out, "::error title=Waza gate::")
+	summary, readErr := os.ReadFile(summaryPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(summary), "## Waza gate: FAIL")
+}
+
+func TestGateCommand_ConfigErrorsUseExitCode3(t *testing.T) {
+	_, err := executeGateCommand(t,
+		"--baseline", "baseline.json",
+		"--current", "current.json",
+		"--on-new-tasks", "block",
+	)
+
+	requireExitCode(t, err, ExitGateConfigError)
+}
+
+func TestRootCommand_HasGateSubcommand(t *testing.T) {
+	root := newRootCommand()
+	found := false
+	for _, c := range root.Commands() {
+		if c.Name() == "gate" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "root command should have 'gate' subcommand")
+}

--- a/cmd/waza/main.go
+++ b/cmd/waza/main.go
@@ -13,6 +13,10 @@ const (
 	ExitError      = 2 // Configuration or runtime error
 )
 
+type exitCoder interface {
+	ExitCode() int
+}
+
 // TestFailureError indicates that the benchmark ran successfully,
 // but one or more test cases failed validation.
 type TestFailureError struct {
@@ -28,6 +32,11 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 
 		// Check error type to determine exit code
+		var exitCodeErr exitCoder
+		if errors.As(err, &exitCodeErr) {
+			os.Exit(exitCodeErr.ExitCode())
+		}
+
 		var testFailureErr *TestFailureError
 		if errors.As(err, &testFailureErr) {
 			os.Exit(ExitTestFailed)

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -54,6 +54,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newInitCommand())
 	cmd.AddCommand(tokens.NewCommand())
 	cmd.AddCommand(newCompareCommand())
+	cmd.AddCommand(newGateCommand())
 	cmd.AddCommand(newCoverageCommand())
 	cmd.AddCommand(dev.NewCommand())
 	cmd.AddCommand(newGradeCommand())

--- a/docs/CI-CD-GUIDE.md
+++ b/docs/CI-CD-GUIDE.md
@@ -172,6 +172,33 @@ jobs:
         run: waza compare results-baseline.json results-current.json
 ```
 
+### Regression Gate
+
+Use `waza gate` when CI should fail on a pass-rate regression, a must-pass golden task failure, or unexpected task-set changes. The command uses stable exit codes: `0` pass, `1` regression or task-set gate failure, `2` golden task failure, and `3` gate configuration error.
+
+```yaml
+      - name: Gate results
+        run: |
+          waza gate \
+            --baseline results-baseline.json \
+            --current results-current.json \
+            --max-regression-pct 5 \
+            --golden-must-pass \
+            --on-new-tasks allow \
+            --on-removed-tasks warn \
+            --format github-actions
+```
+
+Mark critical task files with `golden: true` so any current failure exits `2` when `--golden-must-pass` is enabled:
+
+```yaml
+id: smoke-install
+name: Smoke install path
+golden: true
+inputs:
+  prompt: Verify the install path still works.
+```
+
 ## Azure DevOps Pipelines
 
 ### Basic Evaluation Pipeline
@@ -213,6 +240,17 @@ steps:
         exit 1
       fi
     displayName: Check results
+
+  - script: |
+      waza gate \
+        --baseline results-baseline.json \
+        --current results.json \
+        --max-regression-pct 5 \
+        --golden-must-pass \
+        --on-new-tasks allow \
+        --on-removed-tasks warn \
+        --format markdown
+    displayName: Gate eval results
 
   - task: PublishTestResults@2
     inputs:

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -139,6 +139,7 @@ type MeasureResult struct {
 type TestOutcome struct {
 	TestID      string             `json:"test_id"`
 	DisplayName string             `json:"display_name"`
+	Golden      bool               `json:"golden,omitempty"`
 	Group       string             `json:"group,omitempty"`
 	Status      Status             `json:"status"`
 	Runs        []RunResult        `json:"runs"`

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -16,6 +16,7 @@ type TestCase struct {
 	ContextRoot      string          `yaml:"context_dir,omitempty" json:"context_root,omitempty"`
 	DisplayName      string          `yaml:"name" json:"display_name"`
 	Expectation      TaskExpectation `yaml:"expected,omitempty" json:"expectation,omitempty"`
+	Golden           bool            `yaml:"golden,omitempty" json:"golden,omitempty"`
 	InstructionFiles []string        `yaml:"instruction_files,omitempty" json:"instruction_files,omitempty"`
 	SkillPaths       []string        `yaml:"skill_directories,omitempty" json:"skill_paths,omitempty"`
 	Stimulus         TaskStimulus    `yaml:"inputs" json:"stimulus"`

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -105,6 +105,22 @@ expected:
 	}
 }
 
+func TestLoadTestCase_GoldenField(t *testing.T) {
+	yamlData := `id: tc-golden
+name: golden task
+golden: true
+inputs:
+  prompt: do something important
+`
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tc.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(yamlData), 0o644))
+
+	tc, err := LoadTestCase(p)
+	require.NoError(t, err)
+	require.True(t, tc.Golden)
+}
+
 func TestLoadTestCase_InvalidTimeoutRejected(t *testing.T) {
 	yamlData := `id: tc-invalid-timeout
 name: invalid timeout

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -745,6 +745,7 @@ func (r *EvalRunner) runSequential(ctx context.Context, testCases []*models.Test
 				outcomes = append(outcomes, models.TestOutcome{
 					TestID:      tc.TestID,
 					DisplayName: tc.DisplayName,
+					Golden:      tc.Golden,
 					Status:      models.StatusFailed,
 					Runs:        []models.RunResult{},
 				})
@@ -832,6 +833,7 @@ func (r *EvalRunner) runConcurrent(ctx context.Context, testCases []*models.Test
 					resultChan <- result{index: idx, outcome: models.TestOutcome{
 						TestID:      test.TestID,
 						DisplayName: test.DisplayName,
+						Golden:      test.Golden,
 						Status:      models.StatusFailed,
 						Runs:        []models.RunResult{},
 					}}
@@ -910,7 +912,9 @@ func (r *EvalRunner) runTest(ctx context.Context, tc *models.TestCase, testNum, 
 		if err == nil {
 			if cachedOutcome, found := r.cache.Get(cacheKey); found {
 				// Return cached outcome with cached flag
-				return *cachedOutcome, true
+				outcome := *cachedOutcome
+				outcome.Golden = tc.Golden
+				return outcome, true
 			}
 			// Run the test and cache the result
 			outcome := r.runTestUncached(ctx, tc, testNum, totalTests)
@@ -1004,6 +1008,7 @@ func (r *EvalRunner) runTestUncached(ctx context.Context, tc *models.TestCase, t
 	return models.TestOutcome{
 		TestID:      tc.TestID,
 		DisplayName: tc.DisplayName,
+		Golden:      tc.Golden,
 		Group:       r.resolveGroup(),
 		Status:      status,
 		Runs:        runs,

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -112,6 +112,37 @@ func TestBuildExecutionRequest_SkillPaths(t *testing.T) {
 	}
 }
 
+func TestRunTestUncached_PreservesGoldenFlag(t *testing.T) {
+	spec := &models.EvalSpec{
+		SpecIdentity: models.SpecIdentity{Name: "test-benchmark"},
+		SkillName:    "test-skill",
+		Config: models.Config{
+			TrialsPerTask: 1,
+			TimeoutSec:    60,
+			EngineType:    "mock",
+			ModelID:       "gpt-4o",
+		},
+	}
+	cfg := config.NewEvalConfig(spec)
+	engine := execution.NewMockEngine("gpt-4o")
+	require.NoError(t, engine.Initialize(context.Background()))
+	t.Cleanup(func() {
+		require.NoError(t, engine.Shutdown(context.Background()))
+	})
+
+	runner := NewEvalRunner(cfg, engine)
+	outcome := runner.runTestUncached(context.Background(), &models.TestCase{
+		TestID:      "golden-task",
+		DisplayName: "Golden Task",
+		Golden:      true,
+		Stimulus: models.TaskStimulus{
+			Message: "test prompt",
+		},
+	}, 1, 1)
+
+	require.True(t, outcome.Golden)
+}
+
 func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 	// Create a spec
 	spec := &models.EvalSpec{

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -29,6 +29,11 @@
       "type": "boolean",
       "description": "Whether this task is active. Defaults to true when omitted."
     },
+    "golden": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether this task is a golden task that must pass when waza gate --golden-must-pass is used."
+    },
     "context_dir": {
       "type": "string",
       "description": "Override the context/fixtures directory for this task."

--- a/site/src/content/docs/guides/ci-cd.mdx
+++ b/site/src/content/docs/guides/ci-cd.mdx
@@ -139,6 +139,36 @@ To run it manually:
 gh workflow run weekly-regression-loop.yml --repo microsoft/waza
 ```
 
+### CI Regression Gate
+
+Use `waza gate` after producing a current results file and downloading or generating a baseline results file. The `github-actions` format emits workflow annotations and appends a Markdown summary to `$GITHUB_STEP_SUMMARY`.
+
+```yaml
+- name: Run evaluation
+  run: waza run evals/my-skill/eval.yaml --output results.json
+
+- name: Gate eval results
+  run: |
+    waza gate \
+      --baseline baseline.json \
+      --current results.json \
+      --max-regression-pct 5 \
+      --golden-must-pass \
+      --on-new-tasks allow \
+      --on-removed-tasks warn \
+      --format github-actions
+```
+
+Mark critical task files with `golden: true` to make any failure a hard gate failure:
+
+```yaml
+id: install-smoke
+name: Install smoke test
+golden: true
+inputs:
+  prompt: Verify the install path still works.
+```
+
 ### Token Budget Checks
 
 Use `waza tokens compare` to track token usage across PRs and fail if budgets are exceeded:
@@ -267,6 +297,23 @@ jobs:
       --format table \
       --strict
   displayName: 'Check token budget'
+```
+
+### Regression Gate in Azure DevOps
+
+Use `--format markdown` for a readable log summary, or `--format json` if later steps parse the gate report.
+
+```yaml
+- script: |
+    waza gate \
+      --baseline results-baseline.json \
+      --current results-current.json \
+      --max-regression-pct 5 \
+      --golden-must-pass \
+      --on-new-tasks allow \
+      --on-removed-tasks warn \
+      --format markdown
+  displayName: 'Gate eval results'
 ```
 
 ## GitLab CI

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -311,6 +311,7 @@ Individual task files (e.g., `tasks/basic-usage.yaml`):
 id: basic-usage-001
 name: Basic Usage - Python Function
 description: Test that the skill explains a simple Python function correctly.
+golden: true
 
 tags:
   - basic
@@ -339,6 +340,7 @@ expected:
 | `id`          | string | Unique task identifier                              |
 | `name`        | string | Human-readable task name                            |
 | `description` | string | What the task tests                                 |
+| `golden`      | bool   | Mark as a must-pass task for `waza gate --golden-must-pass` |
 | `tags`        | array  | Tags for filtering (e.g., `["basic", "edge-case"]`) |
 | `inputs`      | object | Test inputs (prompt, files)                         |
 | `expected`    | object | Validation rules and expected behavior              |

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -408,6 +408,50 @@ waza compare gpt4.json sonnet.json opus.json
 waza compare results-*.json --format json
 ```
 
+## waza gate
+
+Gate current evaluation results against a baseline in CI.
+
+```bash
+waza gate --baseline baseline.json --current results.json
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--baseline` | string | | Baseline `waza run --output` JSON file |
+| `--current` | string | | Current `waza run --output` JSON file |
+| `--max-regression-pct` | number | `0` | Maximum allowed aggregate pass-rate drop in percentage points |
+| `--golden-must-pass` | bool | `false` | Fail with exit code `2` if any current task marked `golden: true` fails |
+| `--on-new-tasks` | enum | `allow` | Behavior for current-only tasks: `allow`, `warn`, or `fail` |
+| `--on-removed-tasks` | enum | `warn` | Behavior for baseline-only tasks: `allow`, `warn`, or `fail` |
+| `--format` | enum | `human` | Output format: `human`, `json`, `markdown`, or `github-actions` |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passed |
+| `1` | Regression or task-set policy failure |
+| `2` | Golden task failure |
+| `3` | Gate configuration error |
+
+### Examples
+
+```bash
+waza gate \
+  --baseline baseline.json \
+  --current results.json \
+  --max-regression-pct 5 \
+  --golden-must-pass \
+  --on-new-tasks allow \
+  --on-removed-tasks warn
+
+waza gate --baseline baseline.json --current results.json --format json
+waza gate --baseline baseline.json --current results.json --format github-actions
+```
+
 ## waza coverage
 
 Generate an eval coverage grid for discovered skills and custom agents.


### PR DESCRIPTION
## Summary
- Add `waza gate` for baseline/current result gating with regression thresholds, golden task enforcement, task-set policies, and human/json/markdown/github-actions formats.
- Add `golden: true` task metadata parsing and preserve it in result JSON for CI gating.
- Document CI usage snippets and update CLI/task schema references.

## Validation
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run`
- `cd site && npm run build`

Closes #364

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.