### PR TITLE
feat: Enhance suggest case generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ waza new task from-prompt "Explain this code and suggest fixes" evals/code-expla
 waza check skills/my-skill
 
 # Suggest an eval suite from SKILL.md
-waza suggest skills/my-skill --dry-run
+waza suggest skills/my-skill --count 5 --focus edge-fixtures --dry-run
 waza suggest skills/my-skill --apply
 
 # Note: 'generate' is available as an alias for 'new' (see below for new command)
@@ -564,22 +564,30 @@ Use an LLM to analyze `SKILL.md` and generate suggested evaluation artifacts.
 | Flag | Description |
 |------|-------------|
 | `--model <model>` | Model to use for suggestions (default: project default model) |
+| `--count <n>` | Number of task cases to propose (default: `3`) |
+| `--focus <category>` | Focus category: `triggers`, `negative-triggers`, `edge-fixtures`, `do-not-use-for`, or `parameters` |
 | `--dry-run` | Print suggested output to stdout (default) |
 | `--apply` | Write files to disk |
+| `--force` | Overwrite conflicting generated files or task IDs when applying |
 | `--output-dir <dir>` | Output directory (default: `<skill-path>/evals`) |
 | `--format yaml\|json` | Output format (default: `yaml`) |
 
 **Examples:**
 ```bash
 # Preview generated eval/task/fixture files as YAML
-waza suggest skills/code-explainer --dry-run
+waza suggest skills/code-explainer --count 5 --focus negative-triggers --dry-run
 
 # Write generated files to disk
 waza suggest skills/code-explainer --apply
 
+# Replace conflicting generated task files after review
+waza suggest skills/code-explainer --apply --force
+
 # Print JSON-formatted suggestion payload
 waza suggest skills/code-explainer --format json
 ```
+
+Dry-run output includes per-task `confidence` and `rationale` fields so authors can review why each case was proposed. Apply mode validates generated eval and task YAML against the built-in schemas before writing, merges task references into an existing `eval.yaml`, and refuses to overwrite an existing fixture, task file, or task `id` unless `--force` is set.
 
 ### `waza tokens count [paths...]`
 

--- a/cmd/waza/cmd_suggest.go
+++ b/cmd/waza/cmd_suggest.go
@@ -25,8 +25,11 @@ type suggestFlags struct {
 	model     string
 	dryRun    bool
 	apply     bool
+	force     bool
 	outputDir string
 	format    string
+	count     int
+	focus     string
 }
 
 func newSuggestCommand() *cobra.Command {
@@ -35,6 +38,7 @@ func newSuggestCommand() *cobra.Command {
 		model:  defaultModel,
 		dryRun: true,
 		format: "yaml",
+		count:  suggestpkg.DefaultCaseCount,
 	}
 
 	cmd := &cobra.Command{
@@ -55,8 +59,11 @@ reviewed by a human before applying. By default, suggestions are printed to stdo
 	cmd.Flags().StringVar(&flags.model, "model", flags.model, "Model to use for suggestions")
 	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", true, "Print suggestions to stdout without writing files")
 	cmd.Flags().BoolVar(&flags.apply, "apply", false, "Write suggested files to disk")
+	cmd.Flags().BoolVar(&flags.force, "force", false, "Overwrite conflicting generated files and task ids when applying")
 	cmd.Flags().StringVar(&flags.outputDir, "output-dir", "", "Directory for output (default: <skill-path>/evals)")
 	cmd.Flags().StringVar(&flags.format, "format", "yaml", "Output format: yaml|json")
+	cmd.Flags().IntVar(&flags.count, "count", suggestpkg.DefaultCaseCount, "Number of task cases to propose")
+	cmd.Flags().StringVar(&flags.focus, "focus", "", fmt.Sprintf("Focus category: %s", strings.Join(suggestFocusValues(), "|")))
 
 	return cmd
 }
@@ -64,6 +71,13 @@ reviewed by a human before applying. By default, suggestions are printed to stdo
 func runSuggestCommand(cmd *cobra.Command, skillPath string, flags *suggestFlags) error {
 	if flags.format != "yaml" && flags.format != "json" {
 		return fmt.Errorf("invalid format %q: must be yaml or json", flags.format)
+	}
+	if flags.count < 1 {
+		return fmt.Errorf("invalid count %d: must be at least 1", flags.count)
+	}
+	focus, err := suggestpkg.ParseFocusCategory(flags.focus)
+	if err != nil {
+		return err
 	}
 	if flags.apply {
 		flags.dryRun = false
@@ -93,6 +107,8 @@ func runSuggestCommand(cmd *cobra.Command, skillPath string, flags *suggestFlags
 	suggestion, err := suggestpkg.Generate(cmd.Context(), engine, suggestpkg.Options{
 		SkillPath:  skillPath,
 		GraderDocs: waza.GraderDocsFS,
+		Count:      flags.count,
+		Focus:      focus,
 	})
 	if err != nil {
 		return err
@@ -110,7 +126,7 @@ func runSuggestCommand(cmd *cobra.Command, skillPath string, flags *suggestFlags
 		return nil
 	}
 
-	written, err := suggestion.WriteToDir(outputDir)
+	written, err := suggestion.WriteToDirWithOptions(outputDir, suggestpkg.WriteOptions{Force: flags.force})
 	if err != nil {
 		return err
 	}
@@ -132,6 +148,15 @@ func runSuggestCommand(cmd *cobra.Command, skillPath string, flags *suggestFlags
 		_, _ = cmd.OutOrStdout().Write([]byte("\n"))
 	}
 	return nil
+}
+
+func suggestFocusValues() []string {
+	categories := suggestpkg.AllFocusCategories()
+	values := make([]string, 0, len(categories))
+	for _, category := range categories {
+		values = append(values, string(category))
+	}
+	return values
 }
 
 func defaultSuggestOutputDir(skillPath string) string {

--- a/cmd/waza/cmd_suggest_test.go
+++ b/cmd/waza/cmd_suggest_test.go
@@ -18,6 +18,7 @@ type suggestTestEngine struct {
 	err        error
 	callIdx    int
 	initCalled bool
+	requests   []string
 }
 
 func (e *suggestTestEngine) Initialize(context.Context) error {
@@ -25,13 +26,16 @@ func (e *suggestTestEngine) Initialize(context.Context) error {
 	return nil
 }
 
-func (e *suggestTestEngine) Execute(_ context.Context, _ *execution.ExecutionRequest) (*execution.ExecutionResponse, error) {
+func (e *suggestTestEngine) Execute(_ context.Context, req *execution.ExecutionRequest) (*execution.ExecutionResponse, error) {
 	if !e.initCalled {
 		return nil, fmt.Errorf("initialize was not called before Execute!")
 	}
 
 	if e.err != nil {
 		return nil, e.err
+	}
+	if req != nil {
+		e.requests = append(e.requests, req.Message)
 	}
 	idx := e.callIdx
 	e.callIdx++
@@ -90,6 +94,8 @@ func TestSuggestCommand_DryRunYAML(t *testing.T) {
     - "tasks/*.yaml"
 tasks:
   - path: tasks/basic.yaml
+    confidence: 0.9
+    rationale: "SKILL.md overview"
     content: |
       id: basic-001
       name: Basic
@@ -115,6 +121,65 @@ tasks:
 	require.Contains(t, out.String(), "eval_yaml:")
 	require.Contains(t, out.String(), "tasks:")
 	require.NoFileExists(t, filepath.Join(skillDir, "evals", "eval.yaml"))
+}
+
+func TestSuggestCommand_CountFocusAndCaseMetadata(t *testing.T) {
+	skillDir := writeSuggestSkill(t)
+	engineOutput := `eval_yaml: |
+  name: generated-eval
+  description: generated
+  skill: suggest-skill
+  version: "1.0"
+  config:
+    trials_per_task: 1
+    timeout_seconds: 120
+    parallel: false
+    executor: mock
+    model: test
+  graders:
+    - type: text
+      name: has_text
+      config:
+        contains:
+          - hello
+  metrics:
+    - name: completion
+      weight: 1.0
+      threshold: 0.8
+  tasks:
+    - "tasks/*.yaml"
+tasks:
+  - path: tasks/params.yaml
+    confidence: 0.77
+    rationale: "SKILL.md parameters section"
+    content: |
+      id: params-001
+      name: Parameters
+      inputs:
+        prompt: "hello"
+`
+
+	selectionOutput := "graders:\n  - text\n"
+	engine := &suggestTestEngine{outputs: []string{selectionOutput, engineOutput}}
+
+	orig := newSuggestEngine
+	newSuggestEngine = func(string) execution.AgentEngine {
+		return engine
+	}
+	t.Cleanup(func() { newSuggestEngine = orig })
+
+	cmd := newSuggestCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{skillDir, "--count", "1", "--focus", "parameters"})
+
+	require.NoError(t, cmd.Execute())
+	require.Contains(t, out.String(), "confidence: 0.77")
+	require.Contains(t, out.String(), "rationale: SKILL.md parameters section")
+	require.Len(t, engine.requests, 2)
+	require.Contains(t, engine.requests[1], "Generate exactly 1 task case(s).")
+	require.Contains(t, engine.requests[1], "parameter extraction")
 }
 
 func TestSuggestCommand_ApplyWritesFiles(t *testing.T) {
@@ -144,6 +209,8 @@ func TestSuggestCommand_ApplyWritesFiles(t *testing.T) {
     - "tasks/*.yaml"
 tasks:
   - path: tasks/basic.yaml
+    confidence: 0.9
+    rationale: "SKILL.md overview"
     content: |
       id: basic-001
       name: Basic

--- a/internal/suggest/prompt.go
+++ b/internal/suggest/prompt.go
@@ -68,12 +68,16 @@ type promptData struct {
 	ContentSummary string
 	GraderTypes    string
 	SkillContent   string
+	Count          int
+	Focus          string
 }
 
 // renderSelectionPrompt builds the pass-1 prompt that asks the LLM
 // to choose appropriate grader types for the skill.
 func renderSelectionPrompt(data promptData) string {
 	var b strings.Builder
+	count := effectivePromptCount(data.Count)
+	focus := effectivePromptFocus(data.Focus)
 	b.WriteString("You are selecting grader types for a waza evaluation suite.\n")
 	b.WriteString("Given the skill description below, choose which grader types are most appropriate.\n\n")
 	b.WriteString("Return ONLY a YAML list of grader type names, one per line, like:\n")
@@ -86,6 +90,8 @@ func renderSelectionPrompt(data promptData) string {
 	fmt.Fprintf(&b, "- Triggers (USE FOR): %s\n", data.Triggers)
 	fmt.Fprintf(&b, "- Anti-triggers (DO NOT USE FOR): %s\n", data.AntiTriggers)
 	fmt.Fprintf(&b, "- Content summary: %s\n\n", data.ContentSummary)
+	fmt.Fprintf(&b, "Requested case count: %d\n", count)
+	fmt.Fprintf(&b, "Requested focus: %s\n\n", focus)
 	b.WriteString("Available grader types:\n")
 	b.WriteString(GraderSummaries())
 	b.WriteString("\n")
@@ -96,12 +102,16 @@ func renderSelectionPrompt(data promptData) string {
 // the full eval YAML, with detailed docs for the selected grader types.
 func renderImplementationPrompt(data promptData, graderDocs string) string {
 	var b strings.Builder
+	count := effectivePromptCount(data.Count)
+	focus := effectivePromptFocus(data.Focus)
 	b.WriteString("You are generating a waza evaluation suite for a skill.\n")
 	b.WriteString("Return ONLY YAML in this exact schema:\n\n")
 	b.WriteString("eval_yaml: |\n")
 	b.WriteString("  <full eval.yaml content>\n")
 	b.WriteString("tasks:\n")
 	b.WriteString("  - path: tasks/<task-file>.yaml\n")
+	b.WriteString("    confidence: <0.0-1.0>\n")
+	b.WriteString("    rationale: <SKILL.md span or phrase that supports this case>\n")
 	b.WriteString("    content: |\n")
 	b.WriteString("      <task yaml>\n")
 	b.WriteString("fixtures:\n")
@@ -113,7 +123,10 @@ func renderImplementationPrompt(data promptData, graderDocs string) string {
 	b.WriteString("- Each grader entry MUST be an object with at least 'type' and 'name' fields. NEVER use bare strings like '- grader_name'. Always use '- name: grader_name' with a 'type' field.\n")
 	b.WriteString("- Include required config fields for each grader type (see grader documentation below).\n")
 	b.WriteString("- For skill_invocation graders, use required_skills + mode (exact_match, in_order, any_order) for positive checks, forbidden_skills for negative checks, or both together.\n")
-	b.WriteString("- Include at least 3 diverse tasks and at least 1 negative/anti-trigger task.\n")
+	b.WriteString("- Make the task set diverse when count allows; include negative/anti-trigger coverage when it fits the requested focus.\n")
+	fmt.Fprintf(&b, "- Generate exactly %d task case(s).\n", count)
+	fmt.Fprintf(&b, "- Focus guidance: %s\n", focus)
+	b.WriteString("- For every task case, include confidence as a number from 0.0 to 1.0 and rationale referencing the SKILL.md heading, phrase, or span that supports the case.\n")
 	b.WriteString("- Use grader types from the allowed list only.\n")
 	b.WriteString("- Keep task IDs deterministic and kebab-case.\n")
 	b.WriteString("- Task YAML must use inputs: { prompt: ... } (do not use a top-level prompt field).\n")
@@ -135,10 +148,25 @@ func renderImplementationPrompt(data promptData, graderDocs string) string {
 		b.WriteString(graderDocs)
 		b.WriteString("\n\n")
 	}
+
 	b.WriteString("Skill content (SKILL.md):\n")
 	b.WriteString(data.SkillContent)
 	b.WriteString("\n")
 	return b.String()
+}
+
+func effectivePromptCount(count int) int {
+	if count <= 0 {
+		return DefaultCaseCount
+	}
+	return count
+}
+
+func effectivePromptFocus(focus string) string {
+	if strings.TrimSpace(focus) == "" {
+		return focusInstruction("")
+	}
+	return focus
 }
 
 // renderPrompt builds a single-pass prompt (used when no grader docs FS is available).

--- a/internal/suggest/prompt_test.go
+++ b/internal/suggest/prompt_test.go
@@ -73,8 +73,9 @@ func TestRenderImplementationPrompt_ContainsRequirements(t *testing.T) {
 	assert.Contains(t, prompt, "NEVER use bare strings")
 	assert.Contains(t, prompt, "required_skills")
 	assert.Contains(t, prompt, "Task YAML must use inputs")
-	assert.Contains(t, prompt, "at least 3 diverse tasks")
-	assert.Contains(t, prompt, "at least 1 negative/anti-trigger task")
+	assert.Contains(t, prompt, "Generate exactly 3 task case(s)")
+	assert.Contains(t, prompt, "confidence")
+	assert.Contains(t, prompt, "rationale")
 }
 
 func TestRenderPrompt_IsSinglePassFallback(t *testing.T) {

--- a/internal/suggest/resolve_test.go
+++ b/internal/suggest/resolve_test.go
@@ -112,7 +112,7 @@ func TestBuildPromptData_ExtractsFields(t *testing.T) {
 	rawContent, sk, err := loadSkill(skillPath)
 	require.NoError(t, err)
 
-	data := buildPromptData(sk, rawContent)
+	data := buildPromptData(sk, rawContent, DefaultCaseCount, "")
 	assert.Equal(t, "build-prompt-skill", data.SkillName)
 	assert.NotEmpty(t, data.Description)
 	assert.Contains(t, data.Triggers, "summarize")
@@ -133,7 +133,7 @@ func TestBuildPromptData_FallbackSkillName(t *testing.T) {
 	rawContent, sk, err := loadSkill(skillPath)
 	require.NoError(t, err)
 
-	data := buildPromptData(sk, rawContent)
+	data := buildPromptData(sk, rawContent, DefaultCaseCount, "")
 	// Name not set in frontmatter, should fall back to parent dir name
 	assert.Equal(t, "my-cool-skill", data.SkillName)
 }
@@ -147,7 +147,7 @@ func TestBuildPromptData_NoTriggers(t *testing.T) {
 	rawContent, sk, err := loadSkill(skillPath)
 	require.NoError(t, err)
 
-	data := buildPromptData(sk, rawContent)
+	data := buildPromptData(sk, rawContent, DefaultCaseCount, "")
 	assert.Equal(t, "none", data.Triggers)
 	assert.Equal(t, "none", data.AntiTriggers)
 }
@@ -158,7 +158,7 @@ func TestWriteToDir_EmptyTaskPath(t *testing.T) {
 	s := &Suggestion{
 		EvalYAML: validEvalYAML(),
 		Tasks: []GeneratedFile{
-			{Path: "", Content: "id: auto\nname: Auto\ninputs:\n  prompt: hi"},
+			{Path: "", Confidence: testConfidence(0.8), Rationale: "SKILL.md overview", Content: "id: auto\nname: Auto\ninputs:\n  prompt: hi"},
 		},
 	}
 
@@ -190,7 +190,7 @@ func TestWriteToDir_AbsolutePathRejected(t *testing.T) {
 	s := &Suggestion{
 		EvalYAML: validEvalYAML(),
 		Tasks: []GeneratedFile{
-			{Path: absPath, Content: "id: x\nname: X\ninputs:\n  prompt: hi"},
+			{Path: absPath, Confidence: testConfidence(0.8), Rationale: "SKILL.md overview", Content: "id: x\nname: X\ninputs:\n  prompt: hi"},
 		},
 	}
 

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -1,6 +1,7 @@
 package suggest
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,22 +15,64 @@ import (
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/scaffold"
 	"github.com/microsoft/waza/internal/skill"
+	"github.com/microsoft/waza/internal/validation"
 	"gopkg.in/yaml.v3"
 )
 
 const defaultTimeoutSec = 120
+const DefaultCaseCount = 3
+
+// FocusCategory identifies the behavior area that generated test cases should target.
+type FocusCategory string
+
+const (
+	FocusTriggers         FocusCategory = "triggers"
+	FocusNegativeTriggers FocusCategory = "negative-triggers"
+	FocusEdgeFixtures     FocusCategory = "edge-fixtures"
+	FocusDoNotUseFor      FocusCategory = "do-not-use-for"
+	FocusParameters       FocusCategory = "parameters"
+)
+
+// AllFocusCategories returns the supported focus category values.
+func AllFocusCategories() []FocusCategory {
+	return []FocusCategory{
+		FocusTriggers,
+		FocusNegativeTriggers,
+		FocusEdgeFixtures,
+		FocusDoNotUseFor,
+		FocusParameters,
+	}
+}
+
+// ParseFocusCategory validates a focus category. Empty focus means balanced generation.
+func ParseFocusCategory(value string) (FocusCategory, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	for _, category := range AllFocusCategories() {
+		if value == string(category) {
+			return category, nil
+		}
+	}
+	return "", fmt.Errorf("invalid focus %q: must be one of %s", value, focusCategoryList())
+}
 
 // Options configures suggestion generation.
 type Options struct {
 	SkillPath  string
 	TimeoutSec int
 	GraderDocs fs.FS // embedded grader documentation (optional)
+	Count      int
+	Focus      FocusCategory
 }
 
 // GeneratedFile is a single generated artifact.
 type GeneratedFile struct {
-	Path    string `yaml:"path" json:"path"`
-	Content string `yaml:"content" json:"content"`
+	Path       string   `yaml:"path" json:"path"`
+	Content    string   `yaml:"content" json:"content"`
+	Confidence *float64 `yaml:"confidence,omitempty" json:"confidence,omitempty"`
+	Rationale  string   `yaml:"rationale,omitempty" json:"rationale,omitempty"`
 }
 
 // Suggestion is the structured output returned by the LLM.
@@ -51,6 +94,15 @@ func Generate(ctx context.Context, engine execution.AgentEngine, opts Options) (
 	if err != nil {
 		return nil, err
 	}
+	if opts.Count < 0 {
+		return nil, fmt.Errorf("count must be at least 1, got %d", opts.Count)
+	}
+	if opts.Count == 0 {
+		opts.Count = DefaultCaseCount
+	}
+	if _, err := ParseFocusCategory(string(opts.Focus)); err != nil {
+		return nil, err
+	}
 
 	skillContent, sk, err := loadSkill(skillFile)
 	if err != nil {
@@ -62,7 +114,7 @@ func Generate(ctx context.Context, engine execution.AgentEngine, opts Options) (
 		timeoutSec = defaultTimeoutSec
 	}
 
-	data := buildPromptData(sk, skillContent)
+	data := buildPromptData(sk, skillContent, opts.Count, opts.Focus)
 
 	// Determine grader docs for the implementation prompt.
 	var graderDocs string
@@ -111,6 +163,9 @@ func Generate(ctx context.Context, engine execution.AgentEngine, opts Options) (
 	if err != nil {
 		return nil, fmt.Errorf("parsing suggest response: %w", err)
 	}
+	if opts.Count > 0 && len(suggestion.Tasks) > opts.Count {
+		suggestion.Tasks = suggestion.Tasks[:opts.Count]
+	}
 	return suggestion, nil
 }
 
@@ -125,8 +180,11 @@ func engineResponseError(resp *execution.ExecutionResponse) error {
 }
 
 // buildPromptData assembles the prompt data from a parsed skill.
-func buildPromptData(sk *skill.Skill, skillContent string) promptData {
+func buildPromptData(sk *skill.Skill, skillContent string, count int, focus FocusCategory) promptData {
 	useFor, doNotUseFor := scaffold.ParseTriggerPhrases(sk.Frontmatter.Description)
+	if count <= 0 {
+		count = DefaultCaseCount
+	}
 	return promptData{
 		SkillName:      orDefault(sk.Frontmatter.Name, filepath.Base(filepath.Dir(sk.Path))),
 		Description:    strings.TrimSpace(sk.Frontmatter.Description),
@@ -135,13 +193,15 @@ func buildPromptData(sk *skill.Skill, skillContent string) promptData {
 		ContentSummary: summarizeBody(sk.Body),
 		GraderTypes:    "- " + strings.Join(AvailableGraderTypes(), "\n- "),
 		SkillContent:   skillContent,
+		Count:          count,
+		Focus:          focusInstruction(focus),
 	}
 }
 
 // BuildPrompt builds a single-pass LLM prompt (no grader docs).
 // Retained for backward compatibility and tests.
 func BuildPrompt(sk *skill.Skill, skillContent string) string {
-	data := buildPromptData(sk, skillContent)
+	data := buildPromptData(sk, skillContent, DefaultCaseCount, "")
 	return renderPrompt(data)
 }
 
@@ -224,7 +284,7 @@ func ParseResponse(raw string) (*Suggestion, error) {
 	decoder := yaml.NewDecoder(strings.NewReader(normalized))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&s); err == nil && strings.TrimSpace(s.EvalYAML) != "" {
-		if err := validateEvalYAML(s.EvalYAML); err != nil {
+		if err := s.Validate(); err != nil {
 			return nil, err
 		}
 		return &s, nil
@@ -237,9 +297,66 @@ func ParseResponse(raw string) (*Suggestion, error) {
 	return nil, errors.New("response is not valid suggestion YAML")
 }
 
+// WriteOptions configures how suggestions are applied to disk.
+type WriteOptions struct {
+	Force bool
+}
+
+// Validate checks generated eval and task YAML before any files are written.
+func (s *Suggestion) Validate() error {
+	if s == nil {
+		return errors.New("suggestion is nil")
+	}
+	if err := validateEvalYAML(s.EvalYAML); err != nil {
+		return err
+	}
+	seenPaths := map[string]bool{"eval.yaml": true}
+	seenTaskIDs := make(map[string]string)
+	for i, task := range s.Tasks {
+		path, err := normalizeTaskPath(task.Path, fmt.Sprintf("tasks/task-%02d.yaml", i+1))
+		if err != nil {
+			return err
+		}
+		if seenPaths[path] {
+			return fmt.Errorf("duplicate generated path: %s", path)
+		}
+		seenPaths[path] = true
+		if err := validateGeneratedTask(task); err != nil {
+			return fmt.Errorf("invalid generated task %d (%s): %w", i+1, orDefault(task.Path, "unnamed"), err)
+		}
+		id, err := generatedTaskID(task)
+		if err != nil {
+			return fmt.Errorf("invalid generated task %d (%s): %w", i+1, orDefault(task.Path, "unnamed"), err)
+		}
+		if previousPath, ok := seenTaskIDs[id]; ok {
+			return fmt.Errorf("duplicate generated task id %q in %s and %s", id, previousPath, path)
+		}
+		seenTaskIDs[id] = path
+	}
+	for i, fixture := range s.Fixtures {
+		path, err := normalizeFixturePath(fixture.Path, fmt.Sprintf("fixtures/fixture-%02d.txt", i+1))
+		if err != nil {
+			return err
+		}
+		if seenPaths[path] {
+			return fmt.Errorf("duplicate generated path: %s", path)
+		}
+		seenPaths[path] = true
+	}
+	return nil
+}
+
 // WriteToDir writes suggested files to outputDir and returns written paths.
 func (s *Suggestion) WriteToDir(outputDir string) ([]string, error) {
-	if err := validateEvalYAML(s.EvalYAML); err != nil {
+	return s.WriteToDirWithOptions(outputDir, WriteOptions{})
+}
+
+// WriteToDirWithOptions writes suggested files to outputDir and returns written paths.
+func (s *Suggestion) WriteToDirWithOptions(outputDir string, opts WriteOptions) ([]string, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	if err := s.validateNoConflicts(outputDir, opts); err != nil {
 		return nil, err
 	}
 
@@ -249,36 +366,295 @@ func (s *Suggestion) WriteToDir(outputDir string) ([]string, error) {
 
 	var written []string
 	evalPath := filepath.Join(outputDir, "eval.yaml")
-	if err := os.WriteFile(evalPath, []byte(strings.TrimSpace(s.EvalYAML)+"\n"), 0o644); err != nil {
-		return nil, fmt.Errorf("writing eval.yaml: %w", err)
+	evalYAML, writeEval, err := s.evalYAMLForApply(evalPath)
+	if err != nil {
+		return nil, err
 	}
-	written = append(written, evalPath)
+	if err := s.validateWritableTargets(outputDir, writeEval); err != nil {
+		return nil, err
+	}
+	if opts.Force {
+		if err := s.removeExistingTaskIDConflicts(outputDir); err != nil {
+			return nil, err
+		}
+	}
+	if writeEval {
+		if err := writeGeneratedFile(outputDir, evalPath, string(evalYAML)); err != nil {
+			return nil, fmt.Errorf("writing eval.yaml: %w", err)
+		}
+		written = append(written, evalPath)
+	}
 
 	for i, task := range s.Tasks {
-		path, err := normalizeGeneratedPath(task.Path, fmt.Sprintf("tasks/task-%02d.yaml", i+1))
+		path, err := normalizeTaskPath(task.Path, fmt.Sprintf("tasks/task-%02d.yaml", i+1))
 		if err != nil {
 			return nil, err
 		}
 		target := filepath.Join(outputDir, path)
-		if err := writeGeneratedFile(target, task.Content); err != nil {
+		if err := writeGeneratedFile(outputDir, target, task.Content); err != nil {
 			return nil, err
 		}
 		written = append(written, target)
 	}
 
 	for i, fixture := range s.Fixtures {
-		path, err := normalizeGeneratedPath(fixture.Path, fmt.Sprintf("fixtures/fixture-%02d.txt", i+1))
+		path, err := normalizeFixturePath(fixture.Path, fmt.Sprintf("fixtures/fixture-%02d.txt", i+1))
 		if err != nil {
 			return nil, err
 		}
 		target := filepath.Join(outputDir, path)
-		if err := writeGeneratedFile(target, fixture.Content); err != nil {
+		if err := writeGeneratedFile(outputDir, target, fixture.Content); err != nil {
 			return nil, err
 		}
 		written = append(written, target)
 	}
 
 	return written, nil
+}
+
+func (s *Suggestion) validateWritableTargets(outputDir string, writeEval bool) error {
+	if writeEval {
+		if err := ensureSafeGeneratedTarget(outputDir, filepath.Join(outputDir, "eval.yaml")); err != nil {
+			return err
+		}
+	}
+	for i, task := range s.Tasks {
+		path, err := normalizeTaskPath(task.Path, fmt.Sprintf("tasks/task-%02d.yaml", i+1))
+		if err != nil {
+			return err
+		}
+		if err := ensureSafeGeneratedTarget(outputDir, filepath.Join(outputDir, path)); err != nil {
+			return err
+		}
+	}
+	for i, fixture := range s.Fixtures {
+		path, err := normalizeFixturePath(fixture.Path, fmt.Sprintf("fixtures/fixture-%02d.txt", i+1))
+		if err != nil {
+			return err
+		}
+		if err := ensureSafeGeneratedTarget(outputDir, filepath.Join(outputDir, path)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Suggestion) evalYAMLForApply(evalPath string) ([]byte, bool, error) {
+	info, statErr := os.Lstat(evalPath)
+	if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, false, errors.New("existing eval.yaml is a symlink; refusing to follow it")
+	}
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return nil, false, fmt.Errorf("checking existing eval.yaml: %w", statErr)
+	}
+	existing, err := os.ReadFile(evalPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []byte(strings.TrimSpace(s.EvalYAML) + "\n"), true, nil
+		}
+		return nil, false, fmt.Errorf("reading existing eval.yaml: %w", err)
+	}
+
+	merged, changed, err := mergeEvalTasks(existing, []byte(s.EvalYAML))
+	if err != nil {
+		return nil, false, fmt.Errorf("merging eval.yaml: %w", err)
+	}
+	return merged, changed, nil
+}
+
+func mergeEvalTasks(existingYAML []byte, generatedYAML []byte) ([]byte, bool, error) {
+	if err := validateEvalYAML(string(existingYAML)); err != nil {
+		return nil, false, err
+	}
+	if err := validateEvalYAML(string(generatedYAML)); err != nil {
+		return nil, false, err
+	}
+
+	generatedTasks, err := evalTaskRefs(generatedYAML)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(generatedTasks) == 0 {
+		return existingYAML, false, nil
+	}
+
+	var doc yaml.Node
+	if err := yaml.NewDecoder(bytes.NewReader(existingYAML)).Decode(&doc); err != nil {
+		return nil, false, fmt.Errorf("parsing existing eval.yaml: %w", err)
+	}
+	root := mappingRoot(&doc)
+	if root == nil {
+		return nil, false, errors.New("existing eval.yaml must be a mapping")
+	}
+
+	tasksNode := mappingValue(root, "tasks")
+	if tasksNode == nil {
+		tasksNode = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "tasks"},
+			tasksNode,
+		)
+	}
+	if tasksNode.Kind != yaml.SequenceNode {
+		return nil, false, errors.New("existing eval.yaml tasks must be a list")
+	}
+
+	existing := make(map[string]bool, len(tasksNode.Content))
+	for _, item := range tasksNode.Content {
+		if item.Kind == yaml.ScalarNode {
+			existing[item.Value] = true
+		}
+	}
+
+	changed := false
+	for _, taskRef := range generatedTasks {
+		if existing[taskRef] {
+			continue
+		}
+		tasksNode.Content = append(tasksNode.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: taskRef})
+		existing[taskRef] = true
+		changed = true
+	}
+	if !changed {
+		return existingYAML, false, nil
+	}
+
+	var out bytes.Buffer
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&doc); err != nil {
+		_ = encoder.Close()
+		return nil, false, fmt.Errorf("encoding merged eval.yaml: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, false, fmt.Errorf("encoding merged eval.yaml: %w", err)
+	}
+	if err := validateEvalYAML(out.String()); err != nil {
+		return nil, false, err
+	}
+	return out.Bytes(), true, nil
+}
+
+func evalTaskRefs(raw []byte) ([]string, error) {
+	var spec struct {
+		Tasks []string `yaml:"tasks"`
+	}
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		return nil, fmt.Errorf("parsing eval tasks: %w", err)
+	}
+	return spec.Tasks, nil
+}
+
+func mappingRoot(doc *yaml.Node) *yaml.Node {
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		return doc.Content[0]
+	}
+	if doc.Kind == yaml.MappingNode {
+		return doc
+	}
+	return nil
+}
+
+func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Kind == yaml.ScalarNode && mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func (s *Suggestion) validateNoConflicts(outputDir string, opts WriteOptions) error {
+	if opts.Force {
+		return nil
+	}
+
+	existingTaskIDs, err := loadExistingTaskIDs(filepath.Join(outputDir, "tasks"))
+	if err != nil {
+		return err
+	}
+
+	var conflicts []string
+	seenGeneratedIDs := make(map[string]string)
+	seenGeneratedPaths := make(map[string]bool)
+	for i, task := range s.Tasks {
+		path, err := normalizeTaskPath(task.Path, fmt.Sprintf("tasks/task-%02d.yaml", i+1))
+		if err != nil {
+			return err
+		}
+		if seenGeneratedPaths[path] {
+			return fmt.Errorf("duplicate generated path: %s", path)
+		}
+		seenGeneratedPaths[path] = true
+		target := filepath.Join(outputDir, path)
+		if _, err := os.Lstat(target); err == nil {
+			conflicts = append(conflicts, fmt.Sprintf("- existing: %s\n+ generated: %s", path, path))
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("checking %s: %w", path, err)
+		}
+		id, err := generatedTaskID(task)
+		if err != nil {
+			return err
+		}
+		if previousPath, ok := seenGeneratedIDs[id]; ok {
+			return fmt.Errorf("duplicate generated task id %q in %s and %s", id, previousPath, path)
+		}
+		seenGeneratedIDs[id] = path
+		if existingPath, ok := existingTaskIDs[id]; ok {
+			conflicts = append(conflicts, fmt.Sprintf("- existing task id %q: %s\n+ generated task id %q: %s", id, existingPath, id, path))
+		}
+	}
+
+	for i, fixture := range s.Fixtures {
+		path, err := normalizeFixturePath(fixture.Path, fmt.Sprintf("fixtures/fixture-%02d.txt", i+1))
+		if err != nil {
+			return err
+		}
+		if seenGeneratedPaths[path] {
+			return fmt.Errorf("duplicate generated path: %s", path)
+		}
+		seenGeneratedPaths[path] = true
+		target := filepath.Join(outputDir, path)
+		if _, err := os.Lstat(target); err == nil {
+			conflicts = append(conflicts, fmt.Sprintf("- existing: %s\n+ generated: %s", path, path))
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("checking %s: %w", path, err)
+		}
+	}
+
+	if len(conflicts) > 0 {
+		return fmt.Errorf("refusing to overwrite existing suggest output without --force:\n%s\nUse --force to overwrite conflicting files or task ids", strings.Join(conflicts, "\n"))
+	}
+	return nil
+}
+
+func (s *Suggestion) removeExistingTaskIDConflicts(outputDir string) error {
+	existingTaskIDs, err := loadExistingTaskIDs(filepath.Join(outputDir, "tasks"))
+	if err != nil {
+		return err
+	}
+	for i, task := range s.Tasks {
+		path, err := normalizeTaskPath(task.Path, fmt.Sprintf("tasks/task-%02d.yaml", i+1))
+		if err != nil {
+			return err
+		}
+		id, err := generatedTaskID(task)
+		if err != nil {
+			return err
+		}
+		existingPath, ok := existingTaskIDs[id]
+		if !ok || existingPath == path {
+			continue
+		}
+		target := filepath.Join(outputDir, existingPath)
+		if err := ensureSafeGeneratedTarget(outputDir, target); err != nil {
+			return err
+		}
+		if err := os.Remove(target); err != nil {
+			return fmt.Errorf("removing existing task id %q at %s: %w", id, existingPath, err)
+		}
+	}
+	return nil
 }
 
 func loadSkill(skillFile string) (string, *skill.Skill, error) {
@@ -354,6 +730,9 @@ func extractYAML(raw string) string {
 }
 
 func validateEvalYAML(raw string) error {
+	if errs := validation.ValidateEvalBytes([]byte(raw)); len(errs) > 0 {
+		return fmt.Errorf("invalid eval_yaml: %s", strings.Join(errs, "; "))
+	}
 	var spec models.EvalSpec
 	decoder := yaml.NewDecoder(strings.NewReader(raw))
 	decoder.KnownFields(true) // Strict parsing to catch unknown fields
@@ -362,6 +741,11 @@ func validateEvalYAML(raw string) error {
 	}
 	if err := spec.Validate(); err != nil {
 		return fmt.Errorf("invalid eval_yaml: %w", err)
+	}
+	for _, taskRef := range spec.Tasks {
+		if err := validateEvalTaskRef(taskRef); err != nil {
+			return fmt.Errorf("invalid eval_yaml: tasks entry %q: %w", taskRef, err)
+		}
 	}
 	for i, g := range spec.Graders {
 		if g.Identifier == "" {
@@ -372,6 +756,89 @@ func validateEvalYAML(raw string) error {
 		}
 	}
 	return nil
+}
+
+func validateEvalTaskRef(ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return errors.New("must not be empty")
+	}
+	if filepath.IsAbs(ref) || strings.HasPrefix(ref, "/") || strings.HasPrefix(ref, `\`) {
+		return errors.New("must be a relative path or glob")
+	}
+	if containsTraversalSegment(ref) {
+		return errors.New("must not contain '..' segments")
+	}
+	return nil
+}
+
+func validateGeneratedTask(task GeneratedFile) error {
+	if task.Confidence == nil {
+		return errors.New("confidence is required")
+	}
+	if *task.Confidence < 0 || *task.Confidence > 1 {
+		return fmt.Errorf("confidence must be between 0 and 1, got %g", *task.Confidence)
+	}
+	if strings.TrimSpace(task.Rationale) == "" {
+		return errors.New("rationale is required")
+	}
+	if _, err := generatedTaskID(task); err != nil {
+		return err
+	}
+	return nil
+}
+
+func generatedTaskID(task GeneratedFile) (string, error) {
+	if strings.TrimSpace(task.Content) == "" {
+		return "", errors.New("task content is required")
+	}
+	if errs := validation.ValidateTaskBytes([]byte(task.Content)); len(errs) > 0 {
+		return "", fmt.Errorf("task schema validation failed: %s", strings.Join(errs, "; "))
+	}
+	var tc models.TestCase
+	decoder := yaml.NewDecoder(bytes.NewReader([]byte(task.Content)))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&tc); err != nil {
+		return "", fmt.Errorf("parsing task YAML: %w", err)
+	}
+	if err := tc.Validate(); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(tc.TestID) == "" {
+		return "", errors.New("task id is required")
+	}
+	return tc.TestID, nil
+}
+
+func loadExistingTaskIDs(tasksDir string) (map[string]string, error) {
+	ids := make(map[string]string)
+	matches, err := filepath.Glob(filepath.Join(tasksDir, "*.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("scanning existing tasks: %w", err)
+	}
+	for _, match := range matches {
+		info, err := os.Lstat(match)
+		if err != nil {
+			return nil, fmt.Errorf("checking existing task %s: %w", match, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("existing task %s is a symlink; refusing to follow it", match)
+		}
+		data, err := os.ReadFile(match)
+		if err != nil {
+			return nil, fmt.Errorf("reading existing task %s: %w", match, err)
+		}
+		id, err := generatedTaskID(GeneratedFile{Path: match, Content: string(data)})
+		if err != nil {
+			return nil, fmt.Errorf("existing task %s is invalid: %w", match, err)
+		}
+		rel, err := filepath.Rel(filepath.Dir(tasksDir), match)
+		if err != nil {
+			rel = match
+		}
+		ids[id] = rel
+	}
+	return ids, nil
 }
 
 func phrasesToText(phrases []scaffold.TriggerPhrase) string {
@@ -420,6 +887,9 @@ func normalizeGeneratedPath(path, fallback string) (string, error) {
 	if clean == "" {
 		clean = fallback
 	}
+	if containsTraversalSegment(clean) {
+		return "", fmt.Errorf("invalid generated path: %s", path)
+	}
 	clean = filepath.Clean(clean)
 	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") || strings.HasPrefix(path, "/") {
 		return "", fmt.Errorf("invalid generated path: %s", path)
@@ -427,12 +897,91 @@ func normalizeGeneratedPath(path, fallback string) (string, error) {
 	return clean, nil
 }
 
-func writeGeneratedFile(path string, content string) error {
+func normalizeTaskPath(path, fallback string) (string, error) {
+	clean, err := normalizeGeneratedPath(path, fallback)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(filepath.ToSlash(clean), "tasks/") {
+		return "", fmt.Errorf("invalid generated task path %q: must be under tasks/", path)
+	}
+	return clean, nil
+}
+
+func normalizeFixturePath(path, fallback string) (string, error) {
+	clean, err := normalizeGeneratedPath(path, fallback)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(filepath.ToSlash(clean), "fixtures/") {
+		return "", fmt.Errorf("invalid generated fixture path %q: must be under fixtures/", path)
+	}
+	return clean, nil
+}
+
+func containsTraversalSegment(p string) bool {
+	for _, seg := range strings.FieldsFunc(p, func(r rune) bool {
+		return r == '/' || r == '\\' || r == filepath.Separator
+	}) {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func writeGeneratedFile(outputDir, path string, content string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("creating directory for %s: %w", path, err)
 	}
+	if err := ensureSafeGeneratedTarget(outputDir, path); err != nil {
+		return err
+	}
 	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o644); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+func ensureSafeGeneratedTarget(outputDir, target string) error {
+	rel, err := filepath.Rel(outputDir, target)
+	if err != nil {
+		return fmt.Errorf("checking generated path %s: %w", target, err)
+	}
+	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+		return fmt.Errorf("generated path escapes output directory: %s", target)
+	}
+
+	current := outputDir
+	dir := filepath.Dir(rel)
+	if dir != "." {
+		for _, part := range strings.Split(dir, string(filepath.Separator)) {
+			if part == "" || part == "." {
+				continue
+			}
+			current = filepath.Join(current, part)
+			info, err := os.Lstat(current)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				return fmt.Errorf("checking generated directory %s: %w", current, err)
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("generated directory %s is a symlink; refusing to write through it", current)
+			}
+		}
+	}
+
+	info, err := os.Lstat(target)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("checking generated file %s: %w", target, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("generated file %s is a symlink; refusing to overwrite it", target)
 	}
 	return nil
 }
@@ -442,4 +991,29 @@ func orDefault(value, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func focusInstruction(focus FocusCategory) string {
+	switch focus {
+	case FocusTriggers:
+		return "triggers: Focus all cases on positive trigger behavior from USE FOR phrases."
+	case FocusNegativeTriggers:
+		return "negative-triggers: Focus all cases on negative trigger boundaries where the skill should not activate."
+	case FocusEdgeFixtures:
+		return "edge-fixtures: Focus all cases on edge fixture inputs, unusual file contents, and boundary examples."
+	case FocusDoNotUseFor:
+		return "do-not-use-for: Focus all cases on explicit DO NOT USE FOR exclusions and refusal behavior."
+	case FocusParameters:
+		return "parameters: Focus all cases on parameter extraction, defaults, validation, and ambiguity."
+	default:
+		return "Balance cases across triggers, negative triggers, edge fixtures, DO NOT USE FOR exclusions, and parameters."
+	}
+}
+
+func focusCategoryList() string {
+	values := make([]string, 0, len(AllFocusCategories()))
+	for _, category := range AllFocusCategories() {
+		values = append(values, string(category))
+	}
+	return strings.Join(values, "|")
 }

--- a/internal/suggest/suggest_test.go
+++ b/internal/suggest/suggest_test.go
@@ -3,8 +3,10 @@ package suggest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -92,7 +94,7 @@ description: "A test skill."
 	require.NoError(t, sk.UnmarshalText([]byte(raw)))
 	sk.Path = filepath.Join(t.TempDir(), "SKILL.md")
 
-	data := buildPromptData(&sk, raw)
+	data := buildPromptData(&sk, raw, DefaultCaseCount, "")
 	prompt := renderSelectionPrompt(data)
 	require.Contains(t, prompt, "selecting grader types")
 	require.Contains(t, prompt, "Name: test-skill")
@@ -112,7 +114,7 @@ description: "A test skill."
 	require.NoError(t, sk.UnmarshalText([]byte(raw)))
 	sk.Path = filepath.Join(t.TempDir(), "SKILL.md")
 
-	data := buildPromptData(&sk, raw)
+	data := buildPromptData(&sk, raw, DefaultCaseCount, "")
 	graderDocs := "### `code` - Assertion-Based Grader\nSome docs here."
 	prompt := renderImplementationPrompt(data, graderDocs)
 	require.Contains(t, prompt, "Grader documentation for the types you should use")
@@ -200,7 +202,7 @@ func TestGenerateSurfacesImplementationEngineError(t *testing.T) {
 }
 
 func TestParseResponseStructuredYAML(t *testing.T) {
-	resp := "```yaml\neval_yaml: |\n  name: generated-eval\n  description: generated\n  skill: sample\n  version: \"1.0\"\n  config:\n    trials_per_task: 1\n    timeout_seconds: 120\n    parallel: false\n    executor: mock\n    model: test\n  graders:\n    - type: code\n      name: has_output\n      config:\n        assertions:\n          - \\\"len(output) > 0\\\"\n  metrics:\n    - name: completion\n      weight: 1.0\n      threshold: 0.8\n  tasks:\n    - \"tasks/*.yaml\"\ntasks:\n  - path: tasks/basic.yaml\n    content: |\n      id: basic-001\n      name: Basic\n      inputs:\n        prompt: \"hello\"\nfixtures:\n  - path: fixtures/sample.txt\n    content: |\n      sample\n```"
+	resp := "```yaml\neval_yaml: |\n  name: generated-eval\n  description: generated\n  skill: sample\n  version: \"1.0\"\n  config:\n    trials_per_task: 1\n    timeout_seconds: 120\n    parallel: false\n    executor: mock\n    model: test\n  graders:\n    - type: code\n      name: has_output\n      config:\n        assertions:\n          - \\\"len(output) > 0\\\"\n  metrics:\n    - name: completion\n      weight: 1.0\n      threshold: 0.8\n  tasks:\n    - \"tasks/*.yaml\"\ntasks:\n  - path: tasks/basic.yaml\n    confidence: 0.9\n    rationale: \"SKILL.md overview\"\n    content: |\n      id: basic-001\n      name: Basic\n      inputs:\n        prompt: \"hello\"\nfixtures:\n  - path: fixtures/sample.txt\n    content: |\n      sample\n```"
 
 	s, err := ParseResponse(resp)
 	require.NoError(t, err)
@@ -209,9 +211,89 @@ func TestParseResponseStructuredYAML(t *testing.T) {
 	require.Equal(t, 1, len(s.Fixtures))
 }
 
+func TestParseResponseIncludesCaseMetadata(t *testing.T) {
+	resp := `eval_yaml: |
+  name: generated-eval
+  description: generated
+  skill: sample
+  version: "1.0"
+  config:
+    trials_per_task: 1
+    timeout_seconds: 120
+    parallel: false
+    executor: mock
+    model: test
+  graders:
+    - type: text
+      name: has_keywords
+      config:
+        contains:
+          - hello
+  metrics:
+    - name: completion
+      weight: 1.0
+      threshold: 0.8
+  tasks:
+    - "tasks/*.yaml"
+tasks:
+  - path: tasks/basic.yaml
+    confidence: 0.82
+    rationale: "SKILL.md description USE FOR: summarize"
+    content: |
+      id: basic-001
+      name: Basic
+      inputs:
+        prompt: "hello"
+`
+
+	s, err := ParseResponse(resp)
+	require.NoError(t, err)
+	require.Len(t, s.Tasks, 1)
+	require.NotNil(t, s.Tasks[0].Confidence)
+	require.Equal(t, 0.82, *s.Tasks[0].Confidence)
+	require.Equal(t, "SKILL.md description USE FOR: summarize", s.Tasks[0].Rationale)
+}
+
 func TestParseResponseInvalid(t *testing.T) {
 	_, err := ParseResponse("not valid yaml")
 	require.Error(t, err)
+}
+
+func TestParseResponseRequiresCaseMetadata(t *testing.T) {
+	resp := `eval_yaml: |
+  name: generated-eval
+  description: generated
+  skill: sample
+  version: "1.0"
+  config:
+    trials_per_task: 1
+    timeout_seconds: 120
+    parallel: false
+    executor: mock
+    model: test
+  graders:
+    - type: text
+      name: has_keywords
+      config:
+        contains:
+          - hello
+  metrics:
+    - name: completion
+      weight: 1.0
+      threshold: 0.8
+  tasks:
+    - "tasks/*.yaml"
+tasks:
+  - path: tasks/basic.yaml
+    content: |
+      id: basic-001
+      name: Basic
+      inputs:
+        prompt: "hello"
+`
+
+	_, err := ParseResponse(resp)
+	require.ErrorContains(t, err, "confidence is required")
 }
 
 func TestParseResponseEmpty(t *testing.T) {
@@ -309,7 +391,7 @@ tasks:
 `
 	err := validateEvalYAML(evalYAML)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing required 'name'")
+	require.Contains(t, err.Error(), "missing property 'name'")
 }
 
 func TestValidateEvalYAMLRejectsGraderMissingType(t *testing.T) {
@@ -333,7 +415,7 @@ tasks:
 `
 	err := validateEvalYAML(evalYAML)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing required 'type'")
+	require.Contains(t, err.Error(), "missing property 'type'")
 }
 
 func TestWriteToDirWritesFiles(t *testing.T) {
@@ -361,7 +443,7 @@ metrics:
 tasks:
   - "tasks/*.yaml"`,
 		Tasks: []GeneratedFile{
-			{Path: "tasks/basic.yaml", Content: "id: basic-001\nname: Basic\ninputs:\n  prompt: \"hello\""},
+			{Path: "tasks/basic.yaml", Confidence: testConfidence(0.9), Rationale: "SKILL.md overview", Content: "id: basic-001\nname: Basic\ninputs:\n  prompt: \"hello\""},
 		},
 		Fixtures: []GeneratedFile{
 			{Path: "fixtures/sample.txt", Content: "sample"},
@@ -380,6 +462,220 @@ tasks:
 	taskData, err := os.ReadFile(filepath.Join(outDir, "tasks", "basic.yaml"))
 	require.NoError(t, err)
 	require.True(t, strings.Contains(string(taskData), "id: basic-001"))
+}
+
+func TestWriteToDirMergesExistingEvalYAML(t *testing.T) {
+	s := validSuggestionForWrite()
+	outDir := t.TempDir()
+	existingEval := `name: curated-eval
+description: curated
+skill: sample
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 120
+  parallel: false
+  executor: mock
+  model: test
+graders:
+  - type: text
+    name: has_text
+    config:
+      contains:
+        - hello
+metrics:
+  - name: completion
+    weight: 1.0
+    threshold: 0.8
+tasks:
+  - "custom/*.yaml"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outDir, "eval.yaml"), []byte(existingEval), 0o644))
+
+	written, err := s.WriteToDirWithOptions(outDir, WriteOptions{})
+	require.NoError(t, err)
+	require.Contains(t, written, filepath.Join(outDir, "eval.yaml"))
+
+	evalData, err := os.ReadFile(filepath.Join(outDir, "eval.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(evalData), "name: curated-eval")
+	require.Contains(t, string(evalData), "custom/*.yaml")
+	require.Contains(t, string(evalData), "tasks/*.yaml")
+	require.NotContains(t, string(evalData), "generated-eval")
+}
+
+func TestFocusCategoriesAreAcceptedInPrompt(t *testing.T) {
+	raw := `---
+name: focus-skill
+description: "Useful skill. USE FOR: summarize. DO NOT USE FOR: deploy."
+---
+# Focus Skill
+`
+	var sk skill.Skill
+	require.NoError(t, sk.UnmarshalText([]byte(raw)))
+	sk.Path = filepath.Join(t.TempDir(), "SKILL.md")
+
+	for _, category := range AllFocusCategories() {
+		parsed, err := ParseFocusCategory(string(category))
+		require.NoError(t, err)
+
+		data := buildPromptData(&sk, raw, 2, parsed)
+		prompt := renderImplementationPrompt(data, "")
+
+		require.Contains(t, prompt, fmt.Sprintf("Generate exactly %d task case(s).", 2))
+		require.Contains(t, prompt, string(category))
+	}
+}
+
+func TestParseFocusCategoryRejectsInvalid(t *testing.T) {
+	_, err := ParseFocusCategory("not-a-focus")
+	require.ErrorContains(t, err, "invalid focus")
+}
+
+func TestWriteToDirRefusesExistingTaskIDWithoutForce(t *testing.T) {
+	s := validSuggestionForWrite()
+	outDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(outDir, "tasks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outDir, "tasks", "existing.yaml"), []byte(`id: basic-001
+name: Existing
+inputs:
+  prompt: "existing"
+`), 0o644))
+
+	_, err := s.WriteToDirWithOptions(outDir, WriteOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `existing task id "basic-001"`)
+	require.Contains(t, err.Error(), "--force")
+}
+
+func TestWriteToDirForceOverwritesExistingTaskID(t *testing.T) {
+	s := validSuggestionForWrite()
+	outDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(outDir, "tasks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outDir, "tasks", "basic.yaml"), []byte(`id: basic-001
+name: Existing
+inputs:
+  prompt: "existing"
+`), 0o644))
+
+	written, err := s.WriteToDirWithOptions(outDir, WriteOptions{Force: true})
+	require.NoError(t, err)
+	require.Len(t, written, 3)
+
+	taskData, err := os.ReadFile(filepath.Join(outDir, "tasks", "basic.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(taskData), `prompt: "hello"`)
+}
+
+func TestWriteToDirForceRemovesExistingTaskIDAtDifferentPath(t *testing.T) {
+	s := validSuggestionForWrite()
+	outDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(outDir, "tasks"), 0o755))
+	existingPath := filepath.Join(outDir, "tasks", "existing.yaml")
+	require.NoError(t, os.WriteFile(existingPath, []byte(`id: basic-001
+name: Existing
+inputs:
+  prompt: "existing"
+`), 0o644))
+
+	_, err := s.WriteToDirWithOptions(outDir, WriteOptions{Force: true})
+	require.NoError(t, err)
+	require.NoFileExists(t, existingPath)
+	require.FileExists(t, filepath.Join(outDir, "tasks", "basic.yaml"))
+}
+
+func TestWriteToDirValidatesGeneratedTaskSchemaBeforeWrite(t *testing.T) {
+	s := validSuggestionForWrite()
+	s.Tasks[0].Content = `id: basic-001
+name: Basic
+prompt: "unknown top-level field"
+`
+
+	outDir := t.TempDir()
+	_, err := s.WriteToDirWithOptions(outDir, WriteOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "task schema validation failed")
+	require.Contains(t, err.Error(), "prompt")
+	require.NoFileExists(t, filepath.Join(outDir, "eval.yaml"))
+}
+
+func TestWriteToDirRejectsSymlinkEvalYAML(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on some Windows environments")
+	}
+	s := validSuggestionForWrite()
+	outDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(outDir, "tasks"), 0o755))
+	existingTask := filepath.Join(outDir, "tasks", "existing.yaml")
+	require.NoError(t, os.WriteFile(existingTask, []byte(`id: basic-001
+name: Existing
+inputs:
+  prompt: "existing"
+`), 0o644))
+	target := filepath.Join(t.TempDir(), "outside-eval.yaml")
+	require.NoError(t, os.WriteFile(target, []byte(validEvalYAML()), 0o644))
+	require.NoError(t, os.Symlink(target, filepath.Join(outDir, "eval.yaml")))
+
+	_, err := s.WriteToDirWithOptions(outDir, WriteOptions{Force: true})
+	require.ErrorContains(t, err, "eval.yaml is a symlink")
+	require.FileExists(t, existingTask)
+}
+
+func TestWriteToDirRejectsSymlinkFixtureTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on some Windows environments")
+	}
+	s := validSuggestionForWrite()
+	outDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(outDir, "fixtures"), 0o755))
+	target := filepath.Join(t.TempDir(), "outside-fixture.txt")
+	require.NoError(t, os.WriteFile(target, []byte("outside"), 0o644))
+	require.NoError(t, os.Symlink(target, filepath.Join(outDir, "fixtures", "sample.txt")))
+
+	_, err := s.WriteToDirWithOptions(outDir, WriteOptions{Force: true})
+	require.ErrorContains(t, err, "symlink")
+}
+
+func TestWriteToDirRejectsTaskPathOutsideTasks(t *testing.T) {
+	s := validSuggestionForWrite()
+	s.Tasks[0].Path = "eval.yaml"
+
+	_, err := s.WriteToDirWithOptions(t.TempDir(), WriteOptions{Force: true})
+	require.ErrorContains(t, err, "must be under tasks/")
+}
+
+func TestWriteToDirRejectsUnsafeGeneratedEvalTaskRef(t *testing.T) {
+	s := validSuggestionForWrite()
+	s.EvalYAML = strings.Replace(s.EvalYAML, `tasks/*.yaml`, `../outside/*.yaml`, 1)
+
+	_, err := s.WriteToDirWithOptions(t.TempDir(), WriteOptions{Force: true})
+	require.ErrorContains(t, err, "must not contain '..' segments")
+}
+
+func TestWriteToDirRejectsDuplicateGeneratedPath(t *testing.T) {
+	s := validSuggestionForWrite()
+	s.Tasks = append(s.Tasks, GeneratedFile{
+		Path:       "tasks/basic.yaml",
+		Confidence: testConfidence(0.8),
+		Rationale:  "SKILL.md second span",
+		Content:    "id: basic-002\nname: Basic Two\ninputs:\n  prompt: \"hello again\"",
+	})
+
+	_, err := s.WriteToDirWithOptions(t.TempDir(), WriteOptions{Force: true})
+	require.ErrorContains(t, err, "duplicate generated path: tasks/basic.yaml")
+}
+
+func TestWriteToDirRejectsDuplicateGeneratedTaskIDWithForce(t *testing.T) {
+	s := validSuggestionForWrite()
+	s.Tasks = append(s.Tasks, GeneratedFile{
+		Path:       "tasks/other.yaml",
+		Confidence: testConfidence(0.8),
+		Rationale:  "SKILL.md second span",
+		Content:    "id: basic-001\nname: Other\ninputs:\n  prompt: \"hello again\"",
+	})
+
+	_, err := s.WriteToDirWithOptions(t.TempDir(), WriteOptions{Force: true})
+	require.ErrorContains(t, err, `duplicate generated task id "basic-001"`)
 }
 
 func TestValidateInvalidConfigFields(t *testing.T) {
@@ -414,4 +710,46 @@ config:
 	err := validateEvalYAML(invalidEvalYAML)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown_field")
+}
+
+func validSuggestionForWrite() *Suggestion {
+	return &Suggestion{
+		EvalYAML: `name: generated-eval
+description: generated
+skill: sample
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 120
+  parallel: false
+  executor: mock
+  model: test
+graders:
+  - type: code
+    name: has_output
+    config:
+      assertions:
+        - "len(output) > 0"
+metrics:
+  - name: completion
+    weight: 1.0
+    threshold: 0.8
+tasks:
+  - "tasks/*.yaml"`,
+		Tasks: []GeneratedFile{
+			{
+				Path:       "tasks/basic.yaml",
+				Confidence: testConfidence(0.9),
+				Rationale:  "SKILL.md overview",
+				Content:    "id: basic-001\nname: Basic\ninputs:\n  prompt: \"hello\"",
+			},
+		},
+		Fixtures: []GeneratedFile{
+			{Path: "fixtures/sample.txt", Content: "sample"},
+		},
+	}
+}
+
+func testConfidence(value float64) *float64 {
+	return &value
 }

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -459,23 +459,45 @@ waza suggest <skill-path>
 | Flag | Description |
 |------|-------------|
 | `--model` | Model to use for suggestions (default: project default model) |
+| `--count` | Number of task cases to propose (default: `3`) |
+| `--focus` | Focus category: `triggers`, `negative-triggers`, `edge-fixtures`, `do-not-use-for`, or `parameters` |
 | `--dry-run` | Print suggestions to stdout (default) |
 | `--apply` | Write suggested files to disk |
+| `--force` | Overwrite conflicting generated files or task IDs when applying |
 | `--output-dir` | Output directory (default: `<skill-path>/evals`) |
 | `--format` | Output format: `yaml` (default), `json` |
 
 ### Examples
 
 ```bash
-# Preview suggestions
-waza suggest skills/code-explainer --dry-run
+# Preview five edge-fixture cases with triage metadata
+waza suggest skills/code-explainer --count 5 --focus edge-fixtures --dry-run
 
 # Write eval/task/fixture files
 waza suggest skills/code-explainer --apply
 
+# Replace conflicting generated output after review
+waza suggest skills/code-explainer --apply --force
+
 # JSON output
 waza suggest skills/code-explainer --format json
 ```
+
+Dry-run output includes `confidence` and `rationale` for each proposed task case. The rationale should point back to the `SKILL.md` heading, phrase, or span that supports the case:
+
+```yaml
+tasks:
+  - path: tasks/negative-trigger-deploy.yaml
+    confidence: 0.84
+    rationale: "SKILL.md description: DO NOT USE FOR deployment"
+    content: |
+      id: negative-trigger-deploy
+      name: Refuses deployment work
+      inputs:
+        prompt: "Deploy this service to production."
+```
+
+When applying, waza validates generated eval and task YAML against the built-in schemas before writing. If `eval.yaml` already exists, waza preserves it and merges any new generated task references into its `tasks` list. It refuses to overwrite an existing task file, fixture file, or task `id` unless `--force` is provided, and prints the conflicting existing and generated paths so you can review the change first.
 
 ## waza tokens
 


### PR DESCRIPTION
Closes #357

## Summary
- Adds `waza suggest --count`, `--focus`, and `--force` while preserving existing `--dry-run`/`--apply` behavior.
- Requires generated task cases to include `confidence` and `rationale`, and validates generated eval/task YAML with built-in schemas before writing.
- Makes apply merge-safe by preserving existing `eval.yaml` task references, rejecting unsafe paths/symlinks, and preventing task file or task ID overwrites unless `--force` is used.
- Updates README and site CLI docs with focused-generation examples.

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Validation
- `go test ./...`
- `cd site && npm run build -- --silent`