### PR TITLE
feat: schema versioning policy (closes #368)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ waza grade eval.yaml --results results.json
 # Compare results across models
 waza compare results-gpt4.json results-sonnet.json
 
+# Check whether a schema artifact needs migration
+waza migrate eval.yaml
+
 # Generate eval coverage grid
 waza coverage --format markdown
 
@@ -408,6 +411,15 @@ Compare results from multiple evaluation runs side by side — per-task score de
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--format <fmt>` | `-f` | Output format: `table` or `json` (default: `table`) |
+
+### `waza migrate <file>`
+
+Check a public schema artifact and migrate it to the current schema version when a future major schema requires it. The current schema is `1.0`, so v1 `eval.yaml` and `results.json` files are already current and no file changes are made.
+
+```bash
+waza migrate eval.yaml
+waza migrate results.json
+```
 
 ### `waza coverage [root]`
 
@@ -931,6 +943,7 @@ skills/                Example skills
 ```yaml
 name: my-eval
 skill: my-skill
+schemaVersion: "1.0"
 version: "1.0"
 
 config:
@@ -1001,6 +1014,8 @@ tasks:
 # tasks_from: ./test-cases.csv
 # range: [1, 10]  # Only include rows 1-10 (0-indexed, skips header)
 ```
+
+`schemaVersion` uses `MAJOR.MINOR` format and defaults to `1.0` when omitted for backward compatibility. Readers allow same-major minor additions with warnings for unknown fields, but reject different majors with a hint to run `waza migrate <file>`.
 
 ### Custom Input Variables
 

--- a/cmd/waza/cmd_compare.go
+++ b/cmd/waza/cmd_compare.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"strings"
 
 	"github.com/microsoft/waza/internal/models"
@@ -79,15 +78,7 @@ func compareCommandE(_ *cobra.Command, args []string) error {
 }
 
 func loadOutcomeFile(path string) (*models.EvaluationOutcome, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var outcome models.EvaluationOutcome
-	if err := json.Unmarshal(data, &outcome); err != nil {
-		return nil, err
-	}
-	return &outcome, nil
+	return models.LoadEvaluationOutcome(path)
 }
 
 func buildComparisonReport(files []string, outcomes []*models.EvaluationOutcome) *comparisonReport {

--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -82,8 +82,8 @@ func runGrade(ctx context.Context, w, errW io.Writer, specPath, taskID, resultsF
 	if readErr != nil {
 		return fmt.Errorf("failed to read results file: %w", readErr)
 	}
-	var outcome models.EvaluationOutcome
-	if jsonErr := json.Unmarshal(data, &outcome); jsonErr != nil {
+	outcome, jsonErr := models.ParseEvaluationOutcome(data, resultsFile)
+	if jsonErr != nil {
 		return fmt.Errorf("failed to parse results JSON: %w", jsonErr)
 	}
 
@@ -181,7 +181,7 @@ func runGrade(ctx context.Context, w, errW io.Writer, specPath, taskID, resultsF
 			}
 		}
 
-		graded := orchestration.RegradeOutcome(&outcome, finalOutcomes, effectiveJudgeModel)
+		graded := orchestration.RegradeOutcome(outcome, finalOutcomes, effectiveJudgeModel)
 		if err := saveOutcome(graded, outputFile); err != nil {
 			return fmt.Errorf("failed to save graded outcome: %w", err)
 		}

--- a/cmd/waza/cmd_migrate.go
+++ b/cmd/waza/cmd_migrate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/microsoft/waza/internal/models"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newMigrateCommand() *cobra.Command {
@@ -28,20 +30,52 @@ migration steps here.`,
 }
 
 func runMigrate(out io.Writer, path string) error {
-	if _, err := os.Stat(path); err != nil {
+	data, err := os.ReadFile(path)
+	if err != nil {
 		return fmt.Errorf("reading %s: %w", path, err)
 	}
 
-	artifact := "artifact"
+	artifact, version, err := readArtifactSchemaVersion(path, data)
+	if err != nil {
+		return err
+	}
+
+	version, err = models.ValidateSchemaVersion(artifact, path, version)
+	if err != nil {
+		return err
+	}
+
+	if version != models.CurrentSchemaVersion {
+		_, err = fmt.Fprintf(out, "%s uses schemaVersion %s, which is compatible with waza schemaVersion %s; no migration needed.\n", artifact, version, models.CurrentSchemaVersion)
+		return err
+	}
+
+	_, err = fmt.Fprintf(out, "%s is already compatible with schemaVersion %s; no migration needed.\n", artifact, models.CurrentSchemaVersion)
+	return err
+}
+
+func readArtifactSchemaVersion(path string, data []byte) (artifact string, version string, err error) {
 	switch filepath.Base(path) {
 	case "eval.yaml", "eval.yml":
 		artifact = "eval.yaml"
+		var header struct {
+			SchemaVersion string `yaml:"schemaVersion"`
+		}
+		if err := yaml.Unmarshal(data, &header); err != nil {
+			return "", "", fmt.Errorf("parsing %s: %w", path, err)
+		}
+		return artifact, header.SchemaVersion, nil
 	default:
 		if filepath.Ext(path) == ".json" {
 			artifact = "results.json"
+			var header struct {
+				SchemaVersion string `json:"schemaVersion"`
+			}
+			if err := json.Unmarshal(data, &header); err != nil {
+				return "", "", fmt.Errorf("parsing %s: %w", path, err)
+			}
+			return artifact, header.SchemaVersion, nil
 		}
 	}
-
-	_, err := fmt.Fprintf(out, "%s is already compatible with schemaVersion %s; no migration needed.\n", artifact, models.CurrentSchemaVersion)
-	return err
+	return "", "", fmt.Errorf("unsupported schema artifact %s: expected eval.yaml, eval.yml, or a JSON results artifact", path)
 }

--- a/cmd/waza/cmd_migrate.go
+++ b/cmd/waza/cmd_migrate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -67,14 +66,14 @@ func readArtifactSchemaVersion(path string, data []byte) (artifact string, versi
 		return artifact, header.SchemaVersion, nil
 	default:
 		if filepath.Ext(path) == ".json" {
-			artifact = "results.json"
-			var header struct {
-				SchemaVersion string `json:"schemaVersion"`
-			}
-			if err := json.Unmarshal(data, &header); err != nil {
+			version, ok, err := models.ProbeEvaluationOutcomeSchemaVersion(data)
+			if err != nil {
 				return "", "", fmt.Errorf("parsing %s: %w", path, err)
 			}
-			return artifact, header.SchemaVersion, nil
+			if !ok {
+				return "", "", fmt.Errorf("unsupported JSON schema artifact %s: expected a results.json object with top-level eval_id, eval_name, summary, or tasks", path)
+			}
+			return "results.json", version, nil
 		}
 	}
 	return "", "", fmt.Errorf("unsupported schema artifact %s: expected eval.yaml, eval.yml, or a JSON results artifact", path)

--- a/cmd/waza/cmd_migrate.go
+++ b/cmd/waza/cmd_migrate.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/spf13/cobra"
+)
+
+func newMigrateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate <file>",
+		Short: "Migrate a waza schema artifact to the current schema version",
+		Long: `Migrate a waza schema artifact to the current schema version.
+
+The current schema version is 1.0, so v1 artifacts are already current and the
+command performs no file changes. Future major schema versions will add explicit
+migration steps here.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMigrate(cmd.OutOrStdout(), args[0])
+		},
+	}
+	return cmd
+}
+
+func runMigrate(out io.Writer, path string) error {
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	artifact := "artifact"
+	switch filepath.Base(path) {
+	case "eval.yaml", "eval.yml":
+		artifact = "eval.yaml"
+	default:
+		if filepath.Ext(path) == ".json" {
+			artifact = "results.json"
+		}
+	}
+
+	_, err := fmt.Fprintf(out, "%s is already compatible with schemaVersion %s; no migration needed.\n", artifact, models.CurrentSchemaVersion)
+	return err
+}

--- a/cmd/waza/cmd_migrate_test.go
+++ b/cmd/waza/cmd_migrate_test.go
@@ -21,6 +21,31 @@ func TestMigrateCommandNoOpForCurrentMajor(t *testing.T) {
 	require.Contains(t, out.String(), "already compatible with schemaVersion 1.0")
 }
 
+func TestMigrateCommandRejectsIncompatibleMajor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":"2.0"}`), 0o644))
+
+	var out bytes.Buffer
+	err := runMigrate(&out, path)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `waza migrate <file>`)
+	require.Empty(t, out.String())
+}
+
+func TestMigrateCommandDefaultsMissingSchemaVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"eval_id":"run-1"}`), 0o644))
+
+	var out bytes.Buffer
+	err := runMigrate(&out, path)
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "already compatible with schemaVersion 1.0")
+}
+
 func TestMigrateCommandMissingFile(t *testing.T) {
 	var out bytes.Buffer
 	err := runMigrate(&out, filepath.Join(t.TempDir(), "missing.json"))

--- a/cmd/waza/cmd_migrate_test.go
+++ b/cmd/waza/cmd_migrate_test.go
@@ -24,7 +24,7 @@ func TestMigrateCommandNoOpForCurrentMajor(t *testing.T) {
 func TestMigrateCommandRejectsIncompatibleMajor(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "results.json")
-	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":"2.0"}`), 0o644))
+	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":"2.0","tasks":[]}`), 0o644))
 
 	var out bytes.Buffer
 	err := runMigrate(&out, path)
@@ -44,6 +44,32 @@ func TestMigrateCommandDefaultsMissingSchemaVersion(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Contains(t, out.String(), "already compatible with schemaVersion 1.0")
+}
+
+func TestMigrateCommandRejectsUnknownJSONShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":"1.0","name":"not-results"}`), 0o644))
+
+	var out bytes.Buffer
+	err := runMigrate(&out, path)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported JSON schema artifact")
+	require.Contains(t, err.Error(), "expected a results.json object")
+	require.Empty(t, out.String())
+}
+
+func TestMigrateCommandDetectsResultsJSONByShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom-name.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":"1.0","tasks":[]}`), 0o644))
+
+	var out bytes.Buffer
+	err := runMigrate(&out, path)
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "results.json is already compatible")
 }
 
 func TestMigrateCommandMissingFile(t *testing.T) {

--- a/cmd/waza/cmd_migrate_test.go
+++ b/cmd/waza/cmd_migrate_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateCommandNoOpForCurrentMajor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("schemaVersion: \"1.0\"\n"), 0o644))
+
+	var out bytes.Buffer
+	err := runMigrate(&out, path)
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "already compatible with schemaVersion 1.0")
+}
+
+func TestMigrateCommandMissingFile(t *testing.T) {
+	var out bytes.Buffer
+	err := runMigrate(&out, filepath.Join(t.TempDir(), "missing.json"))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reading")
+}

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -70,6 +70,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newQualityCommand())
 	cmd.AddCommand(newUpdateCommand())
 	cmd.AddCommand(newSpecCommand())
+	cmd.AddCommand(newMigrateCommand())
 
 	return cmd
 }

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -69,6 +69,7 @@ Port existing Python waza functionality to Go for single-binary distribution.
 | E1-06 | As a developer, I can execute against Copilot SDK | Full integration with streaming responses |
 | E1-07 | As a developer, I can use verbose mode for debugging | Real-time conversation display |
 | E1-08 | As a developer, I can save transcripts for analysis | JSON log output with full conversation |
+| E1-09 | As a developer, public artifacts are schema-versioned | `eval.yaml` and `results.json` include `schemaVersion`; readers warn on same-major drift and reject cross-major versions with a migration hint |
 
 ### Epic 2: Sensei Engine (P0)
 

--- a/examples/code-explainer/eval.yaml
+++ b/examples/code-explainer/eval.yaml
@@ -9,6 +9,7 @@ description: |
   - Code patterns (recursion, async/await, comprehensions, joins)
 
 skill: code-explainer
+schemaVersion: "1.0"
 version: "1.0"
 
 config:

--- a/examples/custom-agent/eval.yaml
+++ b/examples/custom-agent/eval.yaml
@@ -1,6 +1,7 @@
 name: security-reviewer-eval
 description: Evaluates the security-reviewer custom agent
 skill: security-reviewer
+schemaVersion: "1.0"
 version: "1.0"
 
 config:

--- a/examples/grader-showcase/eval.yaml
+++ b/examples/grader-showcase/eval.yaml
@@ -16,6 +16,7 @@ description: |
   of configuration options and use cases.
 
 skill: general-coding-assistant
+schemaVersion: "1.0"
 version: "1.0"
 
 config:

--- a/examples/repo-resources/eval.yaml
+++ b/examples/repo-resources/eval.yaml
@@ -1,5 +1,6 @@
 name: repo-resources-example
 skill: repo-resources
+schemaVersion: "1.0"
 version: "1.0"
 
 config:

--- a/internal/graders/inline_script_grader_test.go
+++ b/internal/graders/inline_script_grader_test.go
@@ -164,6 +164,9 @@ func TestEmptyAssertions(t *testing.T) {
 	results, err := grader.Grade(context.Background(), &Context{})
 	require.NoError(t, err)
 
+	require.GreaterOrEqual(t, results.DurationMs, int64(0))
+	results.DurationMs = 0
+
 	require.Equal(t, &models.GraderResults{
 		Name:     "test",
 		Type:     models.GraderKindInlineScript,

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -61,6 +61,7 @@ func TestHandleToolsCall_InvalidParams(t *testing.T) {
 	resp := srv.HandleRequest(context.Background(), req)
 	if resp == nil {
 		t.Fatal("expected response")
+		return
 	}
 	if resp.Error == nil {
 		t.Fatal("expected error for invalid params")
@@ -86,6 +87,7 @@ func TestHandleToolsCall_TaskList(t *testing.T) {
 	resp := srv.HandleRequest(context.Background(), req)
 	if resp == nil {
 		t.Fatal("expected response")
+		return
 	}
 	// Should get an error result (eval file doesn't exist) but not a protocol error.
 	data, _ := json.Marshal(resp.Result)
@@ -114,6 +116,7 @@ func TestHandleToolsCall_TaskList_InvalidArgs(t *testing.T) {
 	resp := srv.HandleRequest(context.Background(), req)
 	if resp == nil {
 		t.Fatal("expected response")
+		return
 	}
 	data, _ := json.Marshal(resp.Result)
 	var result toolsCallResult
@@ -140,6 +143,7 @@ func TestHandleToolsCall_NilArguments(t *testing.T) {
 	resp := srv.HandleRequest(context.Background(), req)
 	if resp == nil {
 		t.Fatal("expected response")
+		return
 	}
 	if resp.Error != nil {
 		t.Fatalf("unexpected protocol error: %v", resp.Error)
@@ -177,6 +181,7 @@ func TestDispatchTool_UnknownTool(t *testing.T) {
 	_, rpcErr := srv.dispatchTool(context.Background(), "nonexistent_tool", json.RawMessage(`{}`))
 	if rpcErr == nil {
 		t.Fatal("expected error for unknown tool")
+		return
 	}
 	if rpcErr.Code != jsonrpc.CodeMethodNotFound {
 		t.Errorf("error code = %d, want %d", rpcErr.Code, jsonrpc.CodeMethodNotFound)

--- a/internal/models/grader_params.go
+++ b/internal/models/grader_params.go
@@ -256,8 +256,10 @@ func decodeYAMLNode[T GraderParameters](node *yaml.Node) (T, error) {
 	}
 
 	decoder := yaml.NewDecoder(bytes.NewReader(params))
-	decoder.KnownFields(true)
 	if err := decoder.Decode(&target); err != nil {
+		return target, fmt.Errorf("failed to decode grader parameters of type %T: %w", target, err)
+	}
+	if err := warnUnknownYAMLFields(params, "grader config", fmt.Sprintf("%T", target), &target); err != nil {
 		return target, fmt.Errorf("failed to decode grader parameters of type %T: %w", target, err)
 	}
 

--- a/internal/models/grader_validation_test.go
+++ b/internal/models/grader_validation_test.go
@@ -34,7 +34,7 @@ graders:
       - "hello"
 `,
 			expectError: true,
-			errorMsg:    "field assertions not found",
+			errorMsg:    "must have at least one assertion",
 		},
 		{
 			name: "code grader with no assertions at all",

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"math"
 	"sort"
 	"time"
@@ -83,6 +84,7 @@ type ResponderInfo struct {
 
 // EvaluationOutcome represents the complete result of an evaluation run
 type EvaluationOutcome struct {
+	SchemaVersion   string                   `json:"schemaVersion"`
 	RunID           string                   `json:"eval_id"`
 	SkillTested     string                   `json:"skill"`
 	BenchName       string                   `json:"eval_name"`
@@ -96,6 +98,14 @@ type EvaluationOutcome struct {
 	Metadata        map[string]any           `json:"metadata,omitempty"`
 	IsBaseline      bool                     `json:"is_baseline,omitempty"`
 	BaselineOutcome *EvaluationOutcome       `json:"baseline_outcome,omitempty"`
+}
+
+func (o EvaluationOutcome) MarshalJSON() ([]byte, error) {
+	type alias EvaluationOutcome
+	if o.SchemaVersion == "" {
+		o.SchemaVersion = CurrentSchemaVersion
+	}
+	return json.Marshal(alias(o))
 }
 
 type OutcomeSetup struct {

--- a/internal/models/outcome_schema_test.go
+++ b/internal/models/outcome_schema_test.go
@@ -1,0 +1,90 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func minimalOutcomeJSON(schemaVersion string) string {
+	versionField := ""
+	if schemaVersion != "" {
+		versionField = `"schemaVersion": "` + schemaVersion + `",`
+	}
+	return `{
+  ` + versionField + `
+  "eval_id": "run-1",
+  "skill": "test-skill",
+  "eval_name": "test-eval",
+  "timestamp": "2026-01-01T00:00:00Z",
+  "config": {
+    "runs_per_test": 1,
+    "model_id": "gpt-4o",
+    "engine_type": "mock",
+    "timeout_sec": 60
+  },
+  "summary": {
+    "total_tests": 1,
+    "succeeded": 1,
+    "failed": 0,
+    "errors": 0,
+    "skipped": 0,
+    "success_rate": 1,
+    "aggregate_score": 1,
+    "weighted_score": 1,
+    "min_score": 1,
+    "max_score": 1,
+    "std_dev": 0,
+    "duration_ms": 100
+  },
+  "metrics": {},
+  "tasks": []
+}`
+}
+
+func TestParseEvaluationOutcome_DefaultsSchemaVersion(t *testing.T) {
+	outcome, err := ParseEvaluationOutcome([]byte(minimalOutcomeJSON("")), "results.json")
+	if err != nil {
+		t.Fatalf("ParseEvaluationOutcome() error = %v", err)
+	}
+	if outcome.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("schemaVersion = %q, want %q", outcome.SchemaVersion, CurrentSchemaVersion)
+	}
+}
+
+func TestParseEvaluationOutcome_AllowsSameMajorFutureMinorAndUnknownField(t *testing.T) {
+	data := strings.Replace(minimalOutcomeJSON("1.1"), `"tasks": []`, `"futureField": true, "tasks": []`, 1)
+	outcome, err := ParseEvaluationOutcome([]byte(data), "results.json")
+	if err != nil {
+		t.Fatalf("ParseEvaluationOutcome() error = %v", err)
+	}
+	if outcome.SchemaVersion != "1.1" {
+		t.Fatalf("schemaVersion = %q, want 1.1", outcome.SchemaVersion)
+	}
+}
+
+func TestParseEvaluationOutcome_RejectsDifferentMajorSchemaVersion(t *testing.T) {
+	_, err := ParseEvaluationOutcome([]byte(minimalOutcomeJSON("2.0")), "results.json")
+	if err == nil {
+		t.Fatal("expected different major schemaVersion to be rejected")
+	}
+	if !strings.Contains(err.Error(), "waza migrate") {
+		t.Fatalf("error %q did not include migration hint", err)
+	}
+}
+
+func TestEvaluationOutcomeMarshalDefaultsSchemaVersion(t *testing.T) {
+	data, err := json.Marshal(EvaluationOutcome{
+		RunID:       "run-1",
+		SkillTested: "test-skill",
+		BenchName:   "test-eval",
+		Timestamp:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(data), `"schemaVersion":"1.0"`) {
+		t.Fatalf("marshaled outcome missing default schemaVersion: %s", data)
+	}
+}

--- a/internal/models/schema_version.go
+++ b/internal/models/schema_version.go
@@ -37,7 +37,7 @@ func ValidateSchemaVersion(artifact, source, version string) (string, error) {
 		return "", err
 	}
 	if major != currentMajor {
-		return "", fmt.Errorf("%s %s uses schemaVersion %q, but this waza supports schemaVersion %s; run \"waza migrate <file>\" to migrate the artifact file", artifact, source, version, CurrentSchemaVersion)
+		return "", fmt.Errorf("%s %s uses schemaVersion %q (major %d), but this waza supports schema major %d (current schemaVersion %s); run \"waza migrate <file>\" to migrate the artifact file", artifact, source, version, major, currentMajor, CurrentSchemaVersion)
 	}
 	return version, nil
 }

--- a/internal/models/schema_version.go
+++ b/internal/models/schema_version.go
@@ -42,6 +42,33 @@ func ValidateSchemaVersion(artifact, source, version string) (string, error) {
 	return version, nil
 }
 
+// ProbeEvaluationOutcomeSchemaVersion cheaply detects whether data has the
+// top-level shape of a results.json artifact and returns its declared version.
+func ProbeEvaluationOutcomeSchemaVersion(data []byte) (version string, ok bool, err error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return "", false, err
+	}
+	if !hasEvaluationOutcomeShape(fields) {
+		return "", false, nil
+	}
+	if raw, exists := fields["schemaVersion"]; exists && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &version); err != nil {
+			return "", false, fmt.Errorf("schemaVersion must be a string: %w", err)
+		}
+	}
+	return version, true, nil
+}
+
+func hasEvaluationOutcomeShape(fields map[string]json.RawMessage) bool {
+	for _, key := range []string{"eval_id", "runId", "eval_name", "summary", "tasks"} {
+		if _, ok := fields[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func parseSchemaVersion(version string) (major int, minor int, err error) {
 	parts := strings.Split(version, ".")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {

--- a/internal/models/schema_version.go
+++ b/internal/models/schema_version.go
@@ -25,7 +25,7 @@ func defaultSchemaVersion(version string) string {
 	return version
 }
 
-func validateSchemaVersion(artifact, source, version string) (string, error) {
+func ValidateSchemaVersion(artifact, source, version string) (string, error) {
 	version = defaultSchemaVersion(version)
 
 	major, _, err := parseSchemaVersion(version)
@@ -37,7 +37,7 @@ func validateSchemaVersion(artifact, source, version string) (string, error) {
 		return "", err
 	}
 	if major != currentMajor {
-		return "", fmt.Errorf("%s %s uses schemaVersion %q, but this waza supports schemaVersion %s; run \"waza migrate %s\" to migrate the file", artifact, source, version, CurrentSchemaVersion, source)
+		return "", fmt.Errorf("%s %s uses schemaVersion %q, but this waza supports schemaVersion %s; run \"waza migrate <file>\" to migrate the artifact file", artifact, source, version, CurrentSchemaVersion)
 	}
 	return version, nil
 }
@@ -121,7 +121,7 @@ func ParseEvaluationOutcome(data []byte, source string) (*EvaluationOutcome, err
 	if err := json.Unmarshal(data, &header); err != nil {
 		return nil, err
 	}
-	version, err := validateSchemaVersion("results.json", source, header.SchemaVersion)
+	version, err := ValidateSchemaVersion("results.json", source, header.SchemaVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/models/schema_version.go
+++ b/internal/models/schema_version.go
@@ -1,0 +1,141 @@
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// CurrentSchemaVersion is the current MAJOR.MINOR schema version for public artifacts.
+	CurrentSchemaVersion = "1.0"
+)
+
+func defaultSchemaVersion(version string) string {
+	if strings.TrimSpace(version) == "" {
+		return CurrentSchemaVersion
+	}
+	return version
+}
+
+func validateSchemaVersion(artifact, source, version string) (string, error) {
+	version = defaultSchemaVersion(version)
+
+	major, _, err := parseSchemaVersion(version)
+	if err != nil {
+		return "", fmt.Errorf("%s %s has invalid schemaVersion %q: %w", artifact, source, version, err)
+	}
+	currentMajor, _, err := parseSchemaVersion(CurrentSchemaVersion)
+	if err != nil {
+		return "", err
+	}
+	if major != currentMajor {
+		return "", fmt.Errorf("%s %s uses schemaVersion %q, but this waza supports schemaVersion %s; run \"waza migrate %s\" to migrate the file", artifact, source, version, CurrentSchemaVersion, source)
+	}
+	return version, nil
+}
+
+func parseSchemaVersion(version string) (major int, minor int, err error) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return 0, 0, fmt.Errorf("expected MAJOR.MINOR")
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil || major < 0 {
+		return 0, 0, fmt.Errorf("major version must be a non-negative integer")
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil || minor < 0 {
+		return 0, 0, fmt.Errorf("minor version must be a non-negative integer")
+	}
+	return major, minor, nil
+}
+
+func warnUnknownYAMLFields(data []byte, artifact, source string, target any) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(target); err != nil {
+		if messages, ok := unknownYAMLFieldMessages(err); ok {
+			for _, msg := range messages {
+				slog.Warn("unknown schema field ignored for same-major compatibility", "artifact", artifact, "source", source, "detail", msg)
+			}
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func unknownYAMLFieldMessages(err error) ([]string, bool) {
+	var typeErr *yaml.TypeError
+	if !errors.As(err, &typeErr) {
+		return nil, false
+	}
+	if len(typeErr.Errors) == 0 {
+		return nil, false
+	}
+	messages := make([]string, 0, len(typeErr.Errors))
+	for _, msg := range typeErr.Errors {
+		if !strings.Contains(msg, "field ") || !strings.Contains(msg, " not found in type ") {
+			return nil, false
+		}
+		messages = append(messages, msg)
+	}
+	return messages, true
+}
+
+func warnUnknownJSONFields(data []byte, artifact, source string, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		if strings.Contains(err.Error(), "json: unknown field ") {
+			slog.Warn("unknown schema field ignored for same-major compatibility", "artifact", artifact, "source", source, "detail", err.Error())
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// LoadEvaluationOutcome loads a results.json file with schema-version compatibility checks.
+func LoadEvaluationOutcome(path string) (*EvaluationOutcome, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEvaluationOutcome(data, path)
+}
+
+// ParseEvaluationOutcome decodes an EvaluationOutcome and defaults missing schemaVersion to the current version.
+func ParseEvaluationOutcome(data []byte, source string) (*EvaluationOutcome, error) {
+	var header struct {
+		SchemaVersion string `json:"schemaVersion"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return nil, err
+	}
+	version, err := validateSchemaVersion("results.json", source, header.SchemaVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	var outcome EvaluationOutcome
+	if err := json.Unmarshal(data, &outcome); err != nil {
+		return nil, err
+	}
+	outcome.SchemaVersion = version
+
+	var strict EvaluationOutcome
+	if err := warnUnknownJSONFields(data, "results.json", source, &strict); err != nil {
+		return nil, err
+	}
+
+	return &outcome, nil
+}

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -309,7 +309,7 @@ func LoadEvalSpec(path string) (*EvalSpec, error) {
 	if err := yaml.Unmarshal(data, &header); err != nil {
 		return nil, fmt.Errorf("parsing eval spec YAML (%s): %w", path, err)
 	}
-	version, err := validateSchemaVersion("eval.yaml", path, header.SchemaVersion)
+	version, err := ValidateSchemaVersion("eval.yaml", path, header.SchemaVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -14,23 +14,50 @@ import (
 //
 // Deprecated alias: BenchmarkSpec is provided for backward compatibility.
 type EvalSpec struct {
-	SpecIdentity `yaml:",inline"`
-	SkillName    string            `yaml:"skill"`
-	Version      string            `yaml:"version"`
-	Config       Config            `yaml:"config"`
-	Hooks        hooks.HooksConfig `yaml:"hooks,omitempty"`
-	Inputs       map[string]string `yaml:"inputs,omitempty" json:"inputs,omitempty"`
-	TasksFrom    string            `yaml:"tasks_from,omitempty" json:"tasks_from,omitempty"`
-	Range        [2]int            `yaml:"range,omitempty" json:"range,omitempty"`
-	Graders      []GraderConfig    `yaml:"graders"`
-	Metrics      []MeasurementDef  `yaml:"metrics"`
-	Tasks        []string          `yaml:"tasks"`
-	Baseline     bool              `yaml:"baseline,omitempty" json:"baseline,omitempty"`
+	SchemaVersion string `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty"`
+	SpecIdentity  `yaml:",inline"`
+	SkillName     string            `yaml:"skill"`
+	Version       string            `yaml:"version"`
+	Config        Config            `yaml:"config"`
+	Hooks         hooks.HooksConfig `yaml:"hooks,omitempty"`
+	Inputs        map[string]string `yaml:"inputs,omitempty" json:"inputs,omitempty"`
+	TasksFrom     string            `yaml:"tasks_from,omitempty" json:"tasks_from,omitempty"`
+	Range         [2]int            `yaml:"range,omitempty" json:"range,omitempty"`
+	Graders       []GraderConfig    `yaml:"graders"`
+	Metrics       []MeasurementDef  `yaml:"metrics"`
+	Tasks         []string          `yaml:"tasks"`
+	Baseline      bool              `yaml:"baseline,omitempty" json:"baseline,omitempty"`
 }
 
 type SpecIdentity struct {
 	Name        string `yaml:"name" json:"name"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+
+type strictEvalSpec struct {
+	SchemaVersion string `yaml:"schemaVersion,omitempty"`
+	SpecIdentity  `yaml:",inline"`
+	SkillName     string            `yaml:"skill"`
+	Version       string            `yaml:"version"`
+	Config        Config            `yaml:"config"`
+	Hooks         hooks.HooksConfig `yaml:"hooks,omitempty"`
+	Inputs        map[string]string `yaml:"inputs,omitempty"`
+	TasksFrom     string            `yaml:"tasks_from,omitempty"`
+	Range         [2]int            `yaml:"range,omitempty"`
+	Graders       []strictGrader    `yaml:"graders"`
+	Metrics       []MeasurementDef  `yaml:"metrics"`
+	Tasks         []string          `yaml:"tasks"`
+	Baseline      bool              `yaml:"baseline,omitempty"`
+}
+
+type strictGrader struct {
+	Kind       GraderKind `yaml:"type"`
+	Identifier string     `yaml:"name"`
+	ScriptPath string     `yaml:"script,omitempty"`
+	Rubric     string     `yaml:"rubric,omitempty"`
+	ModelID    string     `yaml:"model,omitempty"`
+	Weight     float64    `yaml:"weight,omitempty"`
+	Parameters yaml.Node  `yaml:"config,omitempty"`
 }
 
 // Config controls execution behavior
@@ -94,8 +121,10 @@ func (g *GraderConfig) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	decoder := yaml.NewDecoder(bytes.NewReader(bytesData))
-	decoder.KnownFields(true)
 	if err := decoder.Decode(&raw); err != nil {
+		return err
+	}
+	if err := warnUnknownYAMLFields(bytesData, "grader", fmt.Sprintf("grader %q", raw.Identifier), &rawGraderConfig{}); err != nil {
 		return err
 	}
 
@@ -274,11 +303,26 @@ func LoadEvalSpec(path string) (*EvalSpec, error) {
 		return nil, err
 	}
 
+	var header struct {
+		SchemaVersion string `yaml:"schemaVersion"`
+	}
+	if err := yaml.Unmarshal(data, &header); err != nil {
+		return nil, fmt.Errorf("parsing eval spec YAML (%s): %w", path, err)
+	}
+	version, err := validateSchemaVersion("eval.yaml", path, header.SchemaVersion)
+	if err != nil {
+		return nil, err
+	}
+
 	var spec EvalSpec
 
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
 	if err := decoder.Decode(&spec); err != nil {
+		return nil, fmt.Errorf("parsing eval spec YAML (%s): %w", path, err)
+	}
+	spec.SchemaVersion = version
+
+	if err := warnUnknownYAMLFields(data, "eval.yaml", path, &strictEvalSpec{}); err != nil {
 		return nil, fmt.Errorf("parsing eval spec YAML (%s): %w", path, err)
 	}
 

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -57,7 +57,7 @@ config:
 			expectError: false,
 		},
 		{
-			name: "unknown field",
+			name: "unknown field warns but remains compatible",
 			specYAML: `name: valid
 skill: test-skill
 unknownElement: should cause error
@@ -67,7 +67,7 @@ config:
   executor: mock
   model: test-model
 `,
-			expectError: true,
+			expectError: false,
 		},
 		{
 			name: "invalid spec with zero trials",
@@ -93,6 +93,55 @@ config:
 				t.Errorf("LoadEvalSpec() error = %v, expectError %v", err, tt.expectError)
 			}
 		})
+	}
+}
+
+func TestLoadEvalSpec_DefaultsSchemaVersion(t *testing.T) {
+	tempDir := t.TempDir()
+	specPath := filepath.Join(tempDir, "spec.yaml")
+	err := os.WriteFile(specPath, []byte(`name: compatible
+skill: test-skill
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: test-model
+`), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write spec file: %v", err)
+	}
+
+	spec, err := LoadEvalSpec(specPath)
+	if err != nil {
+		t.Fatalf("LoadEvalSpec() error = %v", err)
+	}
+	if spec.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("schemaVersion = %q, want %q", spec.SchemaVersion, CurrentSchemaVersion)
+	}
+}
+
+func TestLoadEvalSpec_RejectsDifferentMajorSchemaVersion(t *testing.T) {
+	tempDir := t.TempDir()
+	specPath := filepath.Join(tempDir, "spec.yaml")
+	err := os.WriteFile(specPath, []byte(`name: incompatible
+skill: test-skill
+schemaVersion: "2.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: test-model
+`), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write spec file: %v", err)
+	}
+
+	_, err = LoadEvalSpec(specPath)
+	if err == nil {
+		t.Fatal("expected LoadEvalSpec to reject a different major schemaVersion")
+	}
+	if !strings.Contains(err.Error(), "waza migrate") {
+		t.Fatalf("error %q did not include migration hint", err)
 	}
 }
 

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -197,7 +197,7 @@ func (v *ValidatorInline) EffectiveWeight() float64 {
 }
 
 func (v *ValidatorInline) UnmarshalYAML(node *yaml.Node) error {
-	// We need to unmarshal into a separate struct to apply KnownFields strict parsing, since ValidatorInline has flexible fields based on the Kind.
+	// Decode through a raw struct because ValidatorInline has flexible fields based on the Kind.
 	type rawValidatorInline struct {
 		Identifier string     `yaml:"name"`
 		Kind       GraderKind `yaml:"type,omitempty"`
@@ -215,8 +215,10 @@ func (v *ValidatorInline) UnmarshalYAML(node *yaml.Node) error {
 		return fmt.Errorf("failed to marshal validator config: %w", err)
 	}
 	decoder := yaml.NewDecoder(bytes.NewReader(bytesData))
-	decoder.KnownFields(true)
 	if err := decoder.Decode(&raw); err != nil {
+		return err
+	}
+	if err := warnUnknownYAMLFields(bytesData, "task validator", fmt.Sprintf("validator %q", raw.Identifier), &rawValidatorInline{}); err != nil {
 		return err
 	}
 
@@ -385,8 +387,11 @@ func LoadTestCase(path string) (*TestCase, error) {
 
 	var tc TestCase
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true) // Strict parsing to catch unknown fields
 	if err := decoder.Decode(&tc); err != nil {
+		return nil, fmt.Errorf("parsing test case YAML: %w", err)
+	}
+
+	if err := warnUnknownYAMLFields(data, "task YAML", path, &TestCase{}); err != nil {
 		return nil, fmt.Errorf("parsing test case YAML: %w", err)
 	}
 

--- a/internal/models/testcase_test.go
+++ b/internal/models/testcase_test.go
@@ -81,7 +81,7 @@ inputs:
 	}
 }
 
-func TestLoadTestCase_UnknownFieldRejected(t *testing.T) {
+func TestLoadTestCase_UnknownFieldIgnoredForCompatibility(t *testing.T) {
 	yamlData := `id: tc-bogus
 name: has bogus field
 bogus_field: true
@@ -96,12 +96,12 @@ expected:
 	if err := os.WriteFile(p, []byte(yamlData), 0o644); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
-	_, err := LoadTestCase(p)
-	if err == nil {
-		t.Fatal("expected error for unknown field 'bogus_field', got nil")
+	tc, err := LoadTestCase(p)
+	if err != nil {
+		t.Fatalf("LoadTestCase returned error for same-major unknown field: %v", err)
 	}
-	if !strings.Contains(err.Error(), "bogus_field") {
-		t.Errorf("error should mention bogus_field, got: %v", err)
+	if tc.TestID != "tc-bogus" {
+		t.Errorf("TestID = %q, want tc-bogus", tc.TestID)
 	}
 }
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -81,6 +81,7 @@ func EvalYAMLWithTaskGlob(name, engine, model, taskGlob string) string {
 	return fmt.Sprintf(`name: %s-eval
 description: Evaluation suite for %s.
 skill: %s
+schemaVersion: "1.0"
 version: "1.0"
 config:
   trials_per_task: 1

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -67,6 +67,7 @@ func TestEvalYAML(t *testing.T) {
 
 	assert.Contains(t, content, "name: code-analyzer-eval")
 	assert.Contains(t, content, "skill: code-analyzer")
+	assert.Contains(t, content, `schemaVersion: "1.0"`)
 	assert.Contains(t, content, "executor: copilot-sdk")
 	assert.Contains(t, content, "model: claude-sonnet-4.6")
 	assert.Contains(t, content, "type: code")

--- a/internal/storage/azure_blob.go
+++ b/internal/storage/azure_blob.go
@@ -239,12 +239,12 @@ func (abs *AzureBlobStore) Download(ctx context.Context, runID string) (*models.
 		return nil, fmt.Errorf("azure blob download: reading blob: %w", err)
 	}
 
-	var outcome models.EvaluationOutcome
-	if err := json.Unmarshal(data, &outcome); err != nil {
+	outcome, err := models.ParseEvaluationOutcome(data, runID)
+	if err != nil {
 		return nil, fmt.Errorf("azure blob download: unmarshaling outcome: %w", err)
 	}
 
-	return &outcome, nil
+	return outcome, nil
 }
 
 // findBlobBySuffix lists blobs and returns the first whose name ends with suffix.

--- a/internal/storage/azure_blob.go
+++ b/internal/storage/azure_blob.go
@@ -239,7 +239,7 @@ func (abs *AzureBlobStore) Download(ctx context.Context, runID string) (*models.
 		return nil, fmt.Errorf("azure blob download: reading blob: %w", err)
 	}
 
-	outcome, err := models.ParseEvaluationOutcome(data, runID)
+	outcome, err := models.ParseEvaluationOutcome(data, blobPath)
 	if err != nil {
 		return nil, fmt.Errorf("azure blob download: unmarshaling outcome: %w", err)
 	}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -167,14 +167,17 @@ func (ls *LocalStore) load() error {
 			return nil
 		}
 
-		var outcome models.EvaluationOutcome
-		if err := json.Unmarshal(data, &outcome); err != nil {
+		var probe models.EvaluationOutcome
+		if err := json.Unmarshal(data, &probe); err != nil {
+			return nil
+		}
+		if probe.BenchName == "" && probe.Digest.TotalTests == 0 {
 			return nil
 		}
 
-		// Skip non-EvaluationOutcome JSON files.
-		if outcome.BenchName == "" && outcome.Digest.TotalTests == 0 {
-			return nil
+		outcome, err := models.ParseEvaluationOutcome(data, path)
+		if err != nil {
+			return fmt.Errorf("loading outcome %s: %w", path, err)
 		}
 
 		if outcome.RunID == "" {
@@ -185,7 +188,7 @@ func (ls *LocalStore) load() error {
 			outcome.RunID = strings.TrimSuffix(filepath.ToSlash(relPath), ".json")
 		}
 
-		ls.cache[outcome.RunID] = &outcome
+		ls.cache[outcome.RunID] = outcome
 		return nil
 	})
 

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -177,7 +178,8 @@ func (ls *LocalStore) load() error {
 
 		outcome, err := models.ParseEvaluationOutcome(data, path)
 		if err != nil {
-			return fmt.Errorf("loading outcome %s: %w", path, err)
+			slog.Warn("skipping unreadable results artifact", "path", path, "error", err)
+			return nil
 		}
 
 		if outcome.RunID == "" {

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -167,11 +167,11 @@ func (ls *LocalStore) load() error {
 			return nil
 		}
 
-		var probe models.EvaluationOutcome
-		if err := json.Unmarshal(data, &probe); err != nil {
+		_, ok, err := models.ProbeEvaluationOutcomeSchemaVersion(data)
+		if err != nil {
 			return nil
 		}
-		if probe.BenchName == "" && probe.Digest.TotalTests == 0 {
+		if !ok {
 			return nil
 		}
 

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -462,6 +462,34 @@ func TestLocalStore_NonResultJSON(t *testing.T) {
 	}
 }
 
+func TestLocalStore_LoadSkipsIncompatibleResultJSON(t *testing.T) {
+	dir := t.TempDir()
+
+	badResult := `{"schemaVersion":"2.0","eval_name":"future","tasks":[]}`
+	if err := os.WriteFile(filepath.Join(dir, "future.json"), []byte(badResult), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outcome := makeOutcome("valid-run", "skill-x", "model-y", 5, 10)
+	data, _ := json.MarshalIndent(outcome, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "valid.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewLocalStore(dir)
+	results, err := store.List(context.Background(), ListOptions{})
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("List() returned %d, want 1 (incompatible result JSON should be skipped)", len(results))
+	}
+	if results[0].RunID != "valid-run" {
+		t.Errorf("RunID = %q, want valid-run", results[0].RunID)
+	}
+}
+
 func TestLocalStore_Compare_NonexistentRun(t *testing.T) {
 	dir := t.TempDir()
 	store := NewLocalStore(dir)

--- a/internal/validation/compatibility_test.go
+++ b/internal/validation/compatibility_test.go
@@ -1,0 +1,70 @@
+package validation
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaCompatibilityFixtures(t *testing.T) {
+	fixtures := []struct {
+		name string
+		path string
+		load func(string) error
+	}{
+		{
+			name: "eval 1.0",
+			path: filepath.Join("testdata", "eval-1.0.yaml"),
+			load: func(path string) error {
+				spec, err := models.LoadEvalSpec(path)
+				if err != nil {
+					return err
+				}
+				require.Equal(t, "1.0", spec.SchemaVersion)
+				return nil
+			},
+		},
+		{
+			name: "results 1.0",
+			path: filepath.Join("testdata", "results-1.0.json"),
+			load: func(path string) error {
+				outcome, err := models.LoadEvaluationOutcome(path)
+				if err != nil {
+					return err
+				}
+				require.Equal(t, "1.0", outcome.SchemaVersion)
+				return nil
+			},
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			require.NoError(t, fixture.load(fixture.path))
+		})
+	}
+}
+
+func TestSchemaCompatibilityAllowsPriorSameMajorMinor(t *testing.T) {
+	dir := t.TempDir()
+
+	evalData, err := os.ReadFile(filepath.Join("testdata", "eval-1.0.yaml"))
+	require.NoError(t, err)
+	evalData = []byte(strings.Replace(string(evalData), `schemaVersion: "1.0"`, `schemaVersion: "1.0"`+"\nfuture_eval_field: true", 1))
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, evalData, 0o644))
+	spec, err := models.LoadEvalSpec(evalPath)
+	require.NoError(t, err)
+	require.Equal(t, "1.0", spec.SchemaVersion)
+
+	resultsData, err := os.ReadFile(filepath.Join("testdata", "results-1.0.json"))
+	require.NoError(t, err)
+	resultsData = []byte(strings.Replace(string(resultsData), `"tasks": [`, `"future_results_field": true, "tasks": [`, 1))
+	outcome, err := models.ParseEvaluationOutcome(resultsData, "results.json")
+	require.NoError(t, err)
+	require.Equal(t, "1.0", outcome.SchemaVersion)
+}

--- a/internal/validation/testdata/eval-1.0.yaml
+++ b/internal/validation/testdata/eval-1.0.yaml
@@ -1,0 +1,16 @@
+schemaVersion: "1.0"
+name: schema-compat-eval
+description: Compatibility fixture for the current eval.yaml schema.
+skill: schema-compat
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: gpt-4o
+metrics:
+  - name: accuracy
+    weight: 1.0
+    threshold: 0.8
+tasks:
+  - "tasks/*.yaml"

--- a/internal/validation/testdata/results-1.0.json
+++ b/internal/validation/testdata/results-1.0.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "1.0",
+  "eval_id": "run-compat-1",
+  "skill": "schema-compat",
+  "eval_name": "schema-compat-eval",
+  "timestamp": "2026-01-01T00:00:00Z",
+  "config": {
+    "runs_per_test": 1,
+    "model_id": "gpt-4o",
+    "engine_type": "mock",
+    "timeout_sec": 60
+  },
+  "summary": {
+    "total_tests": 1,
+    "succeeded": 1,
+    "failed": 0,
+    "errors": 0,
+    "skipped": 0,
+    "success_rate": 1,
+    "aggregate_score": 1,
+    "weighted_score": 1,
+    "min_score": 1,
+    "max_score": 1,
+    "std_dev": 0,
+    "duration_ms": 100
+  },
+  "metrics": {},
+  "tasks": [
+    {
+      "test_id": "task-1",
+      "display_name": "Task 1",
+      "status": "passed",
+      "runs": []
+    }
+  ]
+}

--- a/internal/webapi/additional_test.go
+++ b/internal/webapi/additional_test.go
@@ -173,6 +173,37 @@ func TestFileStoreGetRunSummaryAndReload(t *testing.T) {
 	}
 }
 
+func TestFileStoreSkipsIncompatibleResultJSON(t *testing.T) {
+	dir := t.TempDir()
+	ts := time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC)
+
+	outcome := models.EvaluationOutcome{
+		RunID:     "valid-run",
+		BenchName: "bench-a",
+		Timestamp: ts,
+		Setup:     models.OutcomeSetup{ModelID: "gpt-4o"},
+		Digest:    models.OutcomeDigest{TotalTests: 1, Succeeded: 1},
+	}
+	writeOutcomeFile(t, filepath.Join(dir, "valid-run.json"), outcome)
+
+	badResult := `{"schemaVersion":"2.0","eval_name":"future","tasks":[]}`
+	if err := os.WriteFile(filepath.Join(dir, "future.json"), []byte(badResult), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewFileStore(dir)
+	runs, err := store.ListRuns("", "")
+	if err != nil {
+		t.Fatalf("ListRuns() error: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("ListRuns() returned %d, want 1", len(runs))
+	}
+	if runs[0].ID != "valid-run" {
+		t.Errorf("ID = %q, want valid-run", runs[0].ID)
+	}
+}
+
 func TestOutcomeToDetailMapsStatsTranscriptAndDigest(t *testing.T) {
 	significant := true
 	success := true

--- a/internal/webapi/additional_test.go
+++ b/internal/webapi/additional_test.go
@@ -300,6 +300,7 @@ func TestOutcomeToDetailMapsResponder(t *testing.T) {
 	responder := detail.Tasks[0].Responder
 	if responder == nil {
 		t.Fatal("expected responder")
+		return
 	}
 	if responder.Outcome != "abstained" {
 		t.Errorf("expected outcome abstained, got %q", responder.Outcome)

--- a/internal/webapi/store.go
+++ b/internal/webapi/store.go
@@ -2,7 +2,7 @@ package webapi
 
 import (
 	"errors"
-	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -96,7 +96,8 @@ func (fs *FileStore) load() error {
 
 		outcome, err := models.ParseEvaluationOutcome(data, path)
 		if err != nil {
-			return fmt.Errorf("loading outcome %s: %w", path, err)
+			slog.Warn("skipping unreadable results artifact", "path", path, "error", err)
+			return nil
 		}
 
 		if outcome.RunID == "" {

--- a/internal/webapi/store.go
+++ b/internal/webapi/store.go
@@ -3,6 +3,7 @@ package webapi
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -86,14 +87,17 @@ func (fs *FileStore) load() error {
 			return nil
 		}
 
-		var outcome models.EvaluationOutcome
-		if err := json.Unmarshal(data, &outcome); err != nil {
+		var probe models.EvaluationOutcome
+		if err := json.Unmarshal(data, &probe); err != nil {
+			return nil
+		}
+		if probe.BenchName == "" && probe.Digest.TotalTests == 0 {
 			return nil
 		}
 
-		// Validate that this is a real EvaluationOutcome, not summary.json or other JSON
-		if outcome.BenchName == "" && outcome.Digest.TotalTests == 0 {
-			return nil
+		outcome, err := models.ParseEvaluationOutcome(data, path)
+		if err != nil {
+			return fmt.Errorf("loading outcome %s: %w", path, err)
 		}
 
 		if outcome.RunID == "" {
@@ -104,7 +108,7 @@ func (fs *FileStore) load() error {
 			}
 			outcome.RunID = strings.TrimSuffix(filepath.ToSlash(relPath), ".json")
 		}
-		fs.runs[outcome.RunID] = &outcome
+		fs.runs[outcome.RunID] = outcome
 		return nil
 	})
 

--- a/internal/webapi/store.go
+++ b/internal/webapi/store.go
@@ -1,7 +1,6 @@
 package webapi
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -87,11 +86,11 @@ func (fs *FileStore) load() error {
 			return nil
 		}
 
-		var probe models.EvaluationOutcome
-		if err := json.Unmarshal(data, &probe); err != nil {
+		ok, err := isOutcomeJSON(data)
+		if err != nil {
 			return nil
 		}
-		if probe.BenchName == "" && probe.Digest.TotalTests == 0 {
+		if !ok {
 			return nil
 		}
 
@@ -120,6 +119,11 @@ func (fs *FileStore) load() error {
 	fs.loaded = true
 	fs.loadErr = nil
 	return nil
+}
+
+func isOutcomeJSON(data []byte) (bool, error) {
+	_, ok, err := models.ProbeEvaluationOutcomeSchemaVersion(data)
+	return ok, err
 }
 
 // ensureLoaded loads data if not already loaded.

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -27,6 +27,12 @@
       "minLength": 1,
       "description": "Name of the skill being evaluated."
     },
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+$",
+      "default": "1.0",
+      "description": "Schema version for this evaluation artifact. Uses MAJOR.MINOR; omitted files default to 1.0."
+    },
     "version": {
       "type": "string",
       "minLength": 1,

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -57,6 +57,7 @@ export default defineConfig({
 						{ label: 'CLI Commands', slug: 'reference/cli' },
 						{ label: 'YAML Schema', slug: 'reference/schema' },
 						{ label: 'Rubric Library', slug: 'reference/rubrics' },
+						{ label: 'Schema Changes', slug: 'reference/schema-changes' },
 						{ label: 'Releases', slug: 'reference/releases' },
 					],
 				},

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -15,6 +15,7 @@ The evaluation spec defines the benchmark configuration, graders, and task files
 name: code-explainer-eval
 description: Evaluation suite for code-explainer skill
 skill: code-explainer
+schemaVersion: "1.0"
 version: "1.0"
 
 config:
@@ -52,6 +53,7 @@ tasks:
 | `name`        | string | ✓        | Eval suite name                                                                            |
 | `description` | string | ✗        | What the eval tests                                                                        |
 | `skill`       | string | ✓        | Associated skill or custom agent name (`SKILL.md` or `.agent.md`)                       |
+| `schemaVersion` | string | ✗     | Public schema version for this artifact; defaults to `1.0`                              |
 | `version`     | string | ✗        | Version number (e.g., "1.0")                                                               |
 | `inputs`      | object | ✗        | Key-value map of global template variables (see [Template Variables](#template-variables)) |
 | `tasks_from`  | string | ✗        | Path to an external YAML file containing the task list                                     |
@@ -59,6 +61,8 @@ tasks:
 | `baseline`    | bool   | ✗        | Mark this spec as a baseline for A/B comparison                                            |
 
 `skill` is required.
+
+`schemaVersion` uses `MAJOR.MINOR` format. Omit it for legacy files that should default to `1.0`; add it to new evals so future schema migrations are explicit. See [Schema Changes](/reference/schema-changes/) for the compatibility policy.
 
 ## Targeting Custom Agents
 
@@ -70,6 +74,7 @@ Waza supports evaluating VS Code custom agents (`.agent.md` files) alongside tra
 name: security-agent-eval
 description: Evaluate the security-reviewer custom agent
 skill: security-reviewer  # Points to security-reviewer.agent.md
+schemaVersion: "1.0"
 version: "1.0"
 
 config:
@@ -131,6 +136,7 @@ Set `inject_skill_body: false` when the eval is measuring whether the agent invo
 name: xyz-trigger
 description: Trigger-precision tasks for the xyz skill
 skill: xyz
+schemaVersion: "1.0"
 version: "1.0"
 
 config:

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -524,6 +524,29 @@ waza spec verify skills/pr-summarizer evals/pr-summarizer/eval.yaml \
   --format github-actions
 ```
 
+## waza migrate
+
+Check or migrate a public schema artifact.
+
+```bash
+waza migrate <file>
+```
+
+The current schema version is `1.0`, so v1 `eval.yaml` and `results.json` files are already current and this command makes no file changes. When Waza introduces a future breaking schema, this command is where explicit major-version migrations will run.
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<file>` | Path to a schema artifact such as `eval.yaml` or `results.json` |
+
+### Examples
+
+```bash
+waza migrate eval.yaml
+waza migrate results.json
+```
+
 ## waza coverage
 
 Generate an eval coverage grid for discovered skills and custom agents.

--- a/site/src/content/docs/reference/schema-changes.md
+++ b/site/src/content/docs/reference/schema-changes.md
@@ -1,0 +1,45 @@
+---
+title: Schema Changes
+description: Versioning policy and changelog for waza public schema artifacts.
+---
+
+Waza public artifacts use an explicit `schemaVersion` field so checked-in eval suites, baselines, and dashboard data remain stable across CLI upgrades.
+
+## Versioned artifacts
+
+| Artifact | Field | Current version |
+|---|---|---|
+| `eval.yaml` | `schemaVersion` | `1.0` |
+| `results.json` | `schemaVersion` | `1.0` |
+| `snapshot.json` | `schemaVersion` | Not yet emitted |
+| Dashboard/SSE event envelope | `schemaVersion` | `1.0` |
+
+## Policy
+
+Schema versions use `MAJOR.MINOR` format with no patch component.
+
+- **MINOR** changes are backward-compatible additions, usually optional fields. Readers accept same-major artifacts and warn when they see unknown fields.
+- **MAJOR** changes are breaking. Readers refuse artifacts from a different major version and point to `waza migrate <file>`.
+- Missing `schemaVersion` defaults to `1.0` for backward compatibility with existing `eval.yaml` and `results.json` files.
+- New artifacts should include `schemaVersion: "1.0"` or `"schemaVersion": "1.0"` explicitly.
+
+## Migration command
+
+Use `waza migrate <file>` when a reader reports an incompatible major version.
+
+```bash
+waza migrate eval.yaml
+waza migrate results.json
+```
+
+For schema `1.0`, the command is a no-op because there is no prior major version to migrate from.
+
+## Changelog
+
+### 1.0
+
+- Added `schemaVersion` to `eval.yaml`.
+- Added `schemaVersion` to `results.json`.
+- Added `schemaVersion` to the dashboard SSE event envelope type.
+- Established same-major unknown-field warnings and cross-major reader errors.
+- Added the `waza migrate <file>` command stub for future major migrations.

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -15,6 +15,7 @@ Main evaluation configuration file.
 name: code-explainer-eval # Required: eval suite name
 description: "..." # Required: what this eval tests
 skill: code-explainer # Required: skill name
+schemaVersion: "1.0" # Optional: schema version; defaults to 1.0
 version: "1.0" # Optional: version number
 
 config:
@@ -82,6 +83,20 @@ Version number of the evaluation suite.
 ```yaml
 version: "1.0"
 ```
+
+### schemaVersion
+
+**Type:** string  
+**Required:** no  
+**Default:** `1.0`
+
+Schema version for the public artifact shape. It uses `MAJOR.MINOR` format with no patch component. Same-major minor additions are backward-compatible; readers ignore unknown fields and warn. Different major versions are rejected with a migration hint.
+
+```yaml
+schemaVersion: "1.0"
+```
+
+See [Schema Changes](/reference/schema-changes/) for the versioning policy and changelog.
 
 ## config Section
 

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>waza — eval dashboard</title>
-    <script type="module" crossorigin src="/assets/index-xEGvLQbd.js"></script>
+    <script type="module" crossorigin src="/assets/index-TKq7t3qa.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-B61WIPUK.css">
   </head>
   <body class="bg-zinc-900 text-zinc-100 antialiased">

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -16,6 +16,7 @@ export interface SSEEventData {
 }
 
 export interface SSEEvent {
+  schemaVersion?: string;
   type: "task_start" | "task_complete" | "grader_result" | "run_complete";
   data: SSEEventData;
   timestamp: string;


### PR DESCRIPTION
## Summary
- Adds `schemaVersion` support for `eval.yaml` and `results.json`, defaulting missing versions to `1.0` for backward compatibility.
- Implements same-major compatibility with unknown-field warnings and cross-major errors that point to `waza migrate <file>`.
- Adds a stub `waza migrate <file>` command for future major-version migrations.
- Adds schema compatibility fixtures/tests under `internal/validation/testdata/` and updates docs/site references with a schema changes changelog page.
- Adds `schemaVersion` to the dashboard SSE event envelope type.

## Notes
- `snapshot.json` and `waza gate` output are not currently emitted in this branch; the schema policy docs reserve those artifacts for the related in-flight features that introduce them.
- The results golden fixture is force-added because the repo ignores generated `results-*.json` files by default.

## Validation
- `/opt/homebrew/bin/go test ./...`
- `/opt/homebrew/bin/golangci-lint run`
- `cd site && npm run build`
- `cd web && npm run build`
- `cd web && npm run lint`

Closes #368