### PR TITLE
feat: regression gate command (closes #364)

### DIFF
--- a/cmd/waza/cmd_gate.go
+++ b/cmd/waza/cmd_gate.go
@@ -1,0 +1,538 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/spf13/cobra"
+)
+
+// Documented, stable exit codes for `waza gate`. CI scripts may rely on
+// these values — do not change them without a release note.
+const (
+	// GateExitPass means the candidate met every configured gate.
+	GateExitPass = 0
+	// GateExitRegression means the aggregate pass rate dropped more than the
+	// configured threshold, or a task-set policy was set to fail and tripped.
+	GateExitRegression = 1
+	// GateExitGoldenFailure means one or more golden tasks did not pass in
+	// the current run. Takes precedence over a plain regression.
+	GateExitGoldenFailure = 2
+	// GateExitConfigError means flags or input files were invalid.
+	GateExitConfigError = 3
+)
+
+// Task-set delta policies.
+const (
+	gatePolicyAllow = "allow"
+	gatePolicyWarn  = "warn"
+	gatePolicyFail  = "fail"
+)
+
+// Output formats.
+const (
+	gateFormatHuman         = "human"
+	gateFormatJSON          = "json"
+	gateFormatMarkdown      = "markdown"
+	gateFormatGitHubActions = "github-actions"
+)
+
+type gateOptions struct {
+	baselinePath     string
+	currentPath      string
+	maxRegressionPct float64
+	goldenMustPass   bool
+	onNewTasks       string
+	onRemovedTasks   string
+	format           string
+}
+
+// GateReport is the machine-readable result of a gate evaluation. It is the
+// canonical shape for `--format json` and is also rendered into the other
+// formats so downstream tools see a consistent set of fields.
+type GateReport struct {
+	BaselineFile      string         `json:"baseline_file"`
+	CurrentFile       string         `json:"current_file"`
+	BaselinePassRate  float64        `json:"baseline_pass_rate"`
+	CurrentPassRate   float64        `json:"current_pass_rate"`
+	PassRateDelta     float64        `json:"pass_rate_delta"`
+	MaxRegressionPct  float64        `json:"max_regression_pct"`
+	RegressionPct     float64        `json:"regression_pct"`
+	RegressionExceeds bool           `json:"regression_exceeds_threshold"`
+	GoldenFailures    []GoldenStatus `json:"golden_failures,omitempty"`
+	GoldenTotal       int            `json:"golden_total"`
+	NewTasks          []string       `json:"new_tasks,omitempty"`
+	RemovedTasks      []string       `json:"removed_tasks,omitempty"`
+	OnNewTasks        string         `json:"on_new_tasks"`
+	OnRemovedTasks    string         `json:"on_removed_tasks"`
+	Warnings          []string       `json:"warnings,omitempty"`
+	Errors            []string       `json:"errors,omitempty"`
+	ExitCode          int            `json:"exit_code"`
+	Outcome           string         `json:"outcome"`
+}
+
+// GoldenStatus is a single golden-task summary line for the report.
+type GoldenStatus struct {
+	TestID         string        `json:"test_id"`
+	DisplayName    string        `json:"display_name"`
+	BaselineStatus models.Status `json:"baseline_status,omitempty"`
+	CurrentStatus  models.Status `json:"current_status"`
+}
+
+func newGateCommand() *cobra.Command {
+	opts := &gateOptions{
+		maxRegressionPct: 5.0,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyWarn,
+		format:           gateFormatHuman,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "gate",
+		Short: "Regression gate for CI: compare results to a baseline and fail on regressions",
+		Long: `Compare a candidate results.json against a baseline results.json and
+fail the build when the candidate regresses beyond configured thresholds.
+
+waza gate is the CI-first counterpart to waza compare. It is opinionated,
+produces stable exit codes, and supports CI-native output formats.
+
+Exit codes (stable):
+  0  pass — all gates satisfied
+  1  regression — aggregate pass rate dropped beyond --max-regression-pct,
+     or a task-set policy was set to "fail" and tripped
+  2  golden failure — one or more "golden: true" tasks did not pass
+  3  configuration error — bad flags or unreadable input files
+
+Golden failures take precedence over plain regressions. Tasks are marked
+golden by adding 'golden: true' to the task YAML; the flag is persisted to
+results.json so the gate can read it without re-loading YAML.`,
+		Example: `  # Fail the build if pass rate drops more than 5%, or any golden task fails.
+  waza gate --baseline baseline.json --current results.json
+
+  # GitHub Actions: emit ::error:: / ::warning:: annotations and a step summary.
+  waza gate --baseline baseline.json --current results.json --format github-actions
+
+  # Forbid new tasks (e.g. a frozen suite), tolerate removed ones silently.
+  waza gate --baseline baseline.json --current results.json \
+    --on-new-tasks fail --on-removed-tasks allow`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runGate(cmd.OutOrStdout(), opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&opts.baselinePath, "baseline", "", "Path to the baseline results.json (required)")
+	f.StringVar(&opts.currentPath, "current", "", "Path to the candidate results.json (required)")
+	f.Float64Var(&opts.maxRegressionPct, "max-regression-pct", opts.maxRegressionPct,
+		"Maximum tolerated drop in pass rate, in percentage points (e.g. 5 = 5pp).")
+	f.BoolVar(&opts.goldenMustPass, "golden-must-pass", opts.goldenMustPass,
+		"Fail with exit code 2 if any task marked 'golden: true' did not pass.")
+	f.StringVar(&opts.onNewTasks, "on-new-tasks", opts.onNewTasks,
+		"Policy when current adds tasks not in baseline: allow|warn|fail.")
+	f.StringVar(&opts.onRemovedTasks, "on-removed-tasks", opts.onRemovedTasks,
+		"Policy when current is missing tasks present in baseline: allow|warn|fail.")
+	f.StringVarP(&opts.format, "format", "f", opts.format,
+		"Output format: human|json|markdown|github-actions.")
+
+	return cmd
+}
+
+func runGate(out io.Writer, opts *gateOptions) error {
+	if err := validateGateOptions(opts); err != nil {
+		return &ExitCodeError{Code: GateExitConfigError, Err: err}
+	}
+
+	baseline, err := loadOutcomeFile(opts.baselinePath)
+	if err != nil {
+		return &ExitCodeError{Code: GateExitConfigError,
+			Err: fmt.Errorf("loading baseline %s: %w", opts.baselinePath, err)}
+	}
+	current, err := loadOutcomeFile(opts.currentPath)
+	if err != nil {
+		return &ExitCodeError{Code: GateExitConfigError,
+			Err: fmt.Errorf("loading current %s: %w", opts.currentPath, err)}
+	}
+
+	report := buildGateReport(opts, baseline, current)
+
+	if err := renderGateReport(out, report, opts.format); err != nil {
+		return &ExitCodeError{Code: GateExitConfigError, Err: err}
+	}
+
+	if report.ExitCode == GateExitPass {
+		return nil
+	}
+	// Wrap a nil error so main.go honors the code without re-printing a message
+	// (renderGateReport already wrote the human/markdown/etc. summary).
+	return &ExitCodeError{Code: report.ExitCode}
+}
+
+func validateGateOptions(opts *gateOptions) error {
+	if strings.TrimSpace(opts.baselinePath) == "" {
+		return errors.New("--baseline is required")
+	}
+	if strings.TrimSpace(opts.currentPath) == "" {
+		return errors.New("--current is required")
+	}
+	if opts.maxRegressionPct < 0 {
+		return fmt.Errorf("--max-regression-pct must be >= 0, got %v", opts.maxRegressionPct)
+	}
+	if !isValidPolicy(opts.onNewTasks) {
+		return fmt.Errorf("--on-new-tasks must be one of allow|warn|fail, got %q", opts.onNewTasks)
+	}
+	if !isValidPolicy(opts.onRemovedTasks) {
+		return fmt.Errorf("--on-removed-tasks must be one of allow|warn|fail, got %q", opts.onRemovedTasks)
+	}
+	switch opts.format {
+	case gateFormatHuman, gateFormatJSON, gateFormatMarkdown, gateFormatGitHubActions:
+	default:
+		return fmt.Errorf("--format must be one of human|json|markdown|github-actions, got %q", opts.format)
+	}
+	return nil
+}
+
+func isValidPolicy(p string) bool {
+	switch p {
+	case gatePolicyAllow, gatePolicyWarn, gatePolicyFail:
+		return true
+	}
+	return false
+}
+
+// buildGateReport applies all gating rules and produces a report with the
+// final exit code. It does not perform any I/O.
+func buildGateReport(opts *gateOptions, baseline, current *models.EvaluationOutcome) *GateReport {
+	r := &GateReport{
+		BaselineFile:     opts.baselinePath,
+		CurrentFile:      opts.currentPath,
+		BaselinePassRate: baseline.Digest.SuccessRate,
+		CurrentPassRate:  current.Digest.SuccessRate,
+		MaxRegressionPct: opts.maxRegressionPct,
+		OnNewTasks:       opts.onNewTasks,
+		OnRemovedTasks:   opts.onRemovedTasks,
+	}
+
+	r.PassRateDelta = r.CurrentPassRate - r.BaselinePassRate
+	// Regression is expressed in percentage points (e.g. 0.92 -> 0.85 is 7pp).
+	if r.PassRateDelta < 0 {
+		r.RegressionPct = -r.PassRateDelta * 100.0
+	}
+	r.RegressionExceeds = r.RegressionPct > opts.maxRegressionPct
+
+	// Index outcomes by test ID for set diff + golden lookup.
+	baseByID := indexOutcomes(baseline)
+	currByID := indexOutcomes(current)
+
+	// Task-set delta.
+	for id := range currByID {
+		if _, ok := baseByID[id]; !ok {
+			r.NewTasks = append(r.NewTasks, id)
+		}
+	}
+	for id := range baseByID {
+		if _, ok := currByID[id]; !ok {
+			r.RemovedTasks = append(r.RemovedTasks, id)
+		}
+	}
+	sort.Strings(r.NewTasks)
+	sort.Strings(r.RemovedTasks)
+
+	// Golden evaluation. A task is golden if EITHER side marks it golden;
+	// this is conservative — once a task is declared golden it must stay
+	// passing across the baseline/current boundary even if the field is
+	// missing on the older results.json.
+	goldenIDs := map[string]bool{}
+	for id, t := range currByID {
+		if t.Golden {
+			goldenIDs[id] = true
+		}
+	}
+	for id, t := range baseByID {
+		if t.Golden {
+			goldenIDs[id] = true
+		}
+	}
+	r.GoldenTotal = len(goldenIDs)
+	for id := range goldenIDs {
+		cur, present := currByID[id]
+		if !present {
+			r.GoldenFailures = append(r.GoldenFailures, GoldenStatus{
+				TestID:         id,
+				DisplayName:    baseDisplayName(baseByID, id),
+				BaselineStatus: baseByID[id].Status,
+				CurrentStatus:  models.StatusNA,
+			})
+			continue
+		}
+		if cur.Status != models.StatusPassed {
+			gs := GoldenStatus{
+				TestID:        id,
+				DisplayName:   cur.DisplayName,
+				CurrentStatus: cur.Status,
+			}
+			if b, ok := baseByID[id]; ok {
+				gs.BaselineStatus = b.Status
+			}
+			r.GoldenFailures = append(r.GoldenFailures, gs)
+		}
+	}
+	sort.Slice(r.GoldenFailures, func(i, j int) bool {
+		return r.GoldenFailures[i].TestID < r.GoldenFailures[j].TestID
+	})
+
+	// Apply policies for new/removed tasks.
+	if len(r.NewTasks) > 0 {
+		msg := fmt.Sprintf("current adds %d task(s) not in baseline: %s",
+			len(r.NewTasks), strings.Join(r.NewTasks, ", "))
+		switch opts.onNewTasks {
+		case gatePolicyWarn:
+			r.Warnings = append(r.Warnings, msg)
+		case gatePolicyFail:
+			r.Errors = append(r.Errors, msg)
+		}
+	}
+	if len(r.RemovedTasks) > 0 {
+		msg := fmt.Sprintf("current is missing %d task(s) present in baseline: %s",
+			len(r.RemovedTasks), strings.Join(r.RemovedTasks, ", "))
+		switch opts.onRemovedTasks {
+		case gatePolicyWarn:
+			r.Warnings = append(r.Warnings, msg)
+		case gatePolicyFail:
+			r.Errors = append(r.Errors, msg)
+		}
+	}
+
+	// Decide exit code. Order matters: golden > regression > task-set-fail.
+	switch {
+	case opts.goldenMustPass && len(r.GoldenFailures) > 0:
+		r.ExitCode = GateExitGoldenFailure
+		r.Outcome = "golden_failure"
+	case r.RegressionExceeds:
+		r.ExitCode = GateExitRegression
+		r.Outcome = "regression"
+	case len(r.Errors) > 0:
+		r.ExitCode = GateExitRegression
+		r.Outcome = "regression"
+	default:
+		r.ExitCode = GateExitPass
+		r.Outcome = "pass"
+	}
+	return r
+}
+
+func indexOutcomes(o *models.EvaluationOutcome) map[string]models.TestOutcome {
+	out := make(map[string]models.TestOutcome, len(o.TestOutcomes))
+	for _, t := range o.TestOutcomes {
+		out[t.TestID] = t
+	}
+	return out
+}
+
+func baseDisplayName(byID map[string]models.TestOutcome, id string) string {
+	if t, ok := byID[id]; ok && t.DisplayName != "" {
+		return t.DisplayName
+	}
+	return id
+}
+
+// ----- Rendering -----
+
+func renderGateReport(out io.Writer, r *GateReport, format string) error {
+	switch format {
+	case gateFormatJSON:
+		return renderGateJSON(out, r)
+	case gateFormatMarkdown:
+		renderGateMarkdown(out, r)
+		return nil
+	case gateFormatGitHubActions:
+		renderGateGitHubActions(out, r)
+		return nil
+	default: // human
+		renderGateHuman(out, r)
+		return nil
+	}
+}
+
+func renderGateJSON(out io.Writer, r *GateReport) error {
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling gate report: %w", err)
+	}
+	_, _ = fmt.Fprintln(out, string(data))
+	return nil
+}
+
+// fprintf/fprintln wrap fmt to discard the (n, err) return values; the
+// rendering helpers below intentionally write best-effort to caller-supplied
+// io.Writers (typically a bytes.Buffer or os.Stdout). Errors here would not
+// change the gate's exit code, so silencing them keeps the code readable
+// without losing signal.
+func fprintf(w io.Writer, format string, a ...any) {
+	_, _ = fmt.Fprintf(w, format, a...)
+}
+
+func fprintln(w io.Writer, a ...any) {
+	_, _ = fmt.Fprintln(w, a...)
+}
+
+func renderGateHuman(out io.Writer, r *GateReport) {
+	fprintln(out, strings.Repeat("=", 70))
+	fprintln(out, " REGRESSION GATE")
+	fprintln(out, strings.Repeat("=", 70))
+	fprintf(out, "  baseline: %s\n", r.BaselineFile)
+	fprintf(out, "  current:  %s\n", r.CurrentFile)
+	fprintln(out)
+	fprintf(out, "  pass rate: %.1f%% -> %.1f%%  (delta %+.1fpp, max regression %.1fpp)\n",
+		r.BaselinePassRate*100, r.CurrentPassRate*100, r.PassRateDelta*100, r.MaxRegressionPct)
+	if r.RegressionExceeds {
+		fprintf(out, "  ✗ regression %.2fpp exceeds threshold %.2fpp\n", r.RegressionPct, r.MaxRegressionPct)
+	} else {
+		fprintf(out, "  ✓ regression within threshold\n")
+	}
+	fprintln(out)
+
+	fprintf(out, "  golden tasks: %d total", r.GoldenTotal)
+	if len(r.GoldenFailures) > 0 {
+		fprintf(out, ", %d FAILED\n", len(r.GoldenFailures))
+		for _, g := range r.GoldenFailures {
+			fprintf(out, "    ✗ %s (%s): %s\n", g.TestID, g.DisplayName, g.CurrentStatus)
+		}
+	} else {
+		fprintln(out, ", all passing")
+	}
+	fprintln(out)
+
+	if len(r.NewTasks) > 0 {
+		fprintf(out, "  new tasks (%s): %s\n", r.OnNewTasks, strings.Join(r.NewTasks, ", "))
+	}
+	if len(r.RemovedTasks) > 0 {
+		fprintf(out, "  removed tasks (%s): %s\n", r.OnRemovedTasks, strings.Join(r.RemovedTasks, ", "))
+	}
+	if len(r.Warnings) > 0 {
+		fprintln(out)
+		fprintln(out, "  warnings:")
+		for _, w := range r.Warnings {
+			fprintf(out, "    ! %s\n", w)
+		}
+	}
+	if len(r.Errors) > 0 {
+		fprintln(out)
+		fprintln(out, "  errors:")
+		for _, e := range r.Errors {
+			fprintf(out, "    ✗ %s\n", e)
+		}
+	}
+	fprintln(out)
+	fprintln(out, strings.Repeat("-", 70))
+	fprintf(out, "  outcome: %s  (exit %d)\n", strings.ToUpper(r.Outcome), r.ExitCode)
+	fprintln(out, strings.Repeat("=", 70))
+}
+
+func renderGateMarkdown(out io.Writer, r *GateReport) {
+	icon := "✅"
+	if r.ExitCode != GateExitPass {
+		icon = "❌"
+	}
+	fprintf(out, "## %s Waza regression gate — `%s`\n\n", icon, strings.ToUpper(r.Outcome))
+	fprintf(out, "| Metric | Baseline | Current | Delta |\n")
+	fprintf(out, "|---|---:|---:|---:|\n")
+	fprintf(out, "| Pass rate | %.1f%% | %.1f%% | %+.1fpp |\n",
+		r.BaselinePassRate*100, r.CurrentPassRate*100, r.PassRateDelta*100)
+	fprintf(out, "\n- Max tolerated regression: **%.1fpp**\n", r.MaxRegressionPct)
+	fprintf(out, "- Observed regression: **%.2fpp** %s\n",
+		r.RegressionPct, mdCheck(!r.RegressionExceeds))
+
+	fprintf(out, "- Golden tasks: **%d** total, **%d** failed %s\n",
+		r.GoldenTotal, len(r.GoldenFailures), mdCheck(len(r.GoldenFailures) == 0))
+	if len(r.GoldenFailures) > 0 {
+		fprintln(out, "\n### Golden failures")
+		fprintln(out)
+		fprintln(out, "| Task | Status |")
+		fprintln(out, "|---|---|")
+		for _, g := range r.GoldenFailures {
+			fprintf(out, "| `%s` — %s | `%s` |\n", g.TestID, g.DisplayName, g.CurrentStatus)
+		}
+	}
+
+	if len(r.NewTasks) > 0 {
+		fprintf(out, "\n- New tasks (policy `%s`): %s\n", r.OnNewTasks, mdCodeList(r.NewTasks))
+	}
+	if len(r.RemovedTasks) > 0 {
+		fprintf(out, "- Removed tasks (policy `%s`): %s\n", r.OnRemovedTasks, mdCodeList(r.RemovedTasks))
+	}
+	if len(r.Warnings) > 0 {
+		fprintln(out, "\n**Warnings**")
+		for _, w := range r.Warnings {
+			fprintf(out, "- ⚠️ %s\n", w)
+		}
+	}
+	if len(r.Errors) > 0 {
+		fprintln(out, "\n**Errors**")
+		for _, e := range r.Errors {
+			fprintf(out, "- ❌ %s\n", e)
+		}
+	}
+	fprintf(out, "\n_Exit code: %d_\n", r.ExitCode)
+}
+
+func mdCheck(ok bool) string {
+	if ok {
+		return "✅"
+	}
+	return "❌"
+}
+
+func mdCodeList(items []string) string {
+	q := make([]string, len(items))
+	for i, s := range items {
+		q[i] = "`" + s + "`"
+	}
+	return strings.Join(q, ", ")
+}
+
+// renderGateGitHubActions emits stdout suitable for inline annotations
+// (`::error::`, `::warning::`, `::notice::`), and additionally appends a
+// markdown summary to $GITHUB_STEP_SUMMARY when that env var is set.
+// This lets a single command power both the PR check and the job summary.
+func renderGateGitHubActions(out io.Writer, r *GateReport) {
+	if r.RegressionExceeds {
+		fprintf(out, "::error title=Waza regression::Pass rate dropped %.2fpp (limit %.2fpp): %.1f%% -> %.1f%%\n",
+			r.RegressionPct, r.MaxRegressionPct, r.BaselinePassRate*100, r.CurrentPassRate*100)
+	} else {
+		fprintf(out, "::notice title=Waza regression gate::Pass rate %.1f%% -> %.1f%% (delta %+.2fpp)\n",
+			r.BaselinePassRate*100, r.CurrentPassRate*100, r.PassRateDelta*100)
+	}
+	for _, g := range r.GoldenFailures {
+		fprintf(out, "::error title=Golden task failed::%s (%s) — current status %s\n",
+			g.TestID, g.DisplayName, g.CurrentStatus)
+	}
+	for _, w := range r.Warnings {
+		fprintf(out, "::warning title=Waza gate::%s\n", sanitizeGHA(w))
+	}
+	for _, e := range r.Errors {
+		fprintf(out, "::error title=Waza gate::%s\n", sanitizeGHA(e))
+	}
+
+	// Append a markdown summary to the GitHub Actions step summary file.
+	if path := os.Getenv("GITHUB_STEP_SUMMARY"); path != "" {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err == nil {
+			renderGateMarkdown(f, r)
+			_ = f.Close()
+		}
+	}
+}
+
+// sanitizeGHA strips characters that break the workflow command line format.
+func sanitizeGHA(s string) string {
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}

--- a/cmd/waza/cmd_gate.go
+++ b/cmd/waza/cmd_gate.go
@@ -67,6 +67,7 @@ type GateReport struct {
 	RegressionExceeds bool           `json:"regression_exceeds_threshold"`
 	GoldenFailures    []GoldenStatus `json:"golden_failures,omitempty"`
 	GoldenTotal       int            `json:"golden_total"`
+	GoldenMustPass    bool           `json:"golden_must_pass"`
 	NewTasks          []string       `json:"new_tasks,omitempty"`
 	RemovedTasks      []string       `json:"removed_tasks,omitempty"`
 	OnNewTasks        string         `json:"on_new_tasks"`
@@ -87,7 +88,7 @@ type GoldenStatus struct {
 
 func newGateCommand() *cobra.Command {
 	opts := &gateOptions{
-		maxRegressionPct: 5.0,
+		maxRegressionPct: 0,
 		goldenMustPass:   true,
 		onNewTasks:       gatePolicyAllow,
 		onRemovedTasks:   gatePolicyWarn,
@@ -113,8 +114,12 @@ Exit codes (stable):
 Golden failures take precedence over plain regressions. Tasks are marked
 golden by adding 'golden: true' to the task YAML; the flag is persisted to
 results.json so the gate can read it without re-loading YAML.`,
-		Example: `  # Fail the build if pass rate drops more than 5%, or any golden task fails.
+		Example: `  # Fail the build on ANY drop in pass rate (default --max-regression-pct=0),
+  # or if any golden task fails.
   waza gate --baseline baseline.json --current results.json
+
+  # Tolerate up to 5pp drop in pass rate.
+  waza gate --baseline baseline.json --current results.json --max-regression-pct 5
 
   # GitHub Actions: emit ::error:: / ::warning:: annotations and a step summary.
   waza gate --baseline baseline.json --current results.json --format github-actions
@@ -122,6 +127,8 @@ results.json so the gate can read it without re-loading YAML.`,
   # Forbid new tasks (e.g. a frozen suite), tolerate removed ones silently.
   waza gate --baseline baseline.json --current results.json \
     --on-new-tasks fail --on-removed-tasks allow`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runGate(cmd.OutOrStdout(), opts)
 		},
@@ -169,9 +176,16 @@ func runGate(out io.Writer, opts *gateOptions) error {
 	if report.ExitCode == GateExitPass {
 		return nil
 	}
-	// Wrap a nil error so main.go honors the code without re-printing a message
-	// (renderGateReport already wrote the human/markdown/etc. summary).
-	return &ExitCodeError{Code: report.ExitCode}
+	// Render already wrote the full human/markdown/etc. summary. We set
+	// SilenceErrors on the cobra command, so Cobra won't echo this string;
+	// main.go uses ExitCodeError.Code for the process exit and skips printing
+	// when the wrapped error matches the rendered outcome. We still include a
+	// short message so callers using runGate directly (tests, library use)
+	// receive context.
+	return &ExitCodeError{
+		Code: report.ExitCode,
+		Err:  fmt.Errorf("waza gate: %s (exit %d)", report.Outcome, report.ExitCode),
+	}
 }
 
 func validateGateOptions(opts *gateOptions) error {
@@ -215,6 +229,7 @@ func buildGateReport(opts *gateOptions, baseline, current *models.EvaluationOutc
 		BaselinePassRate: baseline.Digest.SuccessRate,
 		CurrentPassRate:  current.Digest.SuccessRate,
 		MaxRegressionPct: opts.maxRegressionPct,
+		GoldenMustPass:   opts.goldenMustPass,
 		OnNewTasks:       opts.onNewTasks,
 		OnRemovedTasks:   opts.onRemovedTasks,
 	}
@@ -509,9 +524,17 @@ func renderGateGitHubActions(out io.Writer, r *GateReport) {
 		fprintf(out, "::notice title=Waza regression gate::Pass rate %.1f%% -> %.1f%% (delta %+.2fpp)\n",
 			r.BaselinePassRate*100, r.CurrentPassRate*100, r.PassRateDelta*100)
 	}
+	// Golden task annotations: ::error:: when the policy enforces them,
+	// ::warning:: when --golden-must-pass=false relaxes enforcement.
+	goldenLevel := "error"
+	goldenTitle := "Golden task failed"
+	if !r.GoldenMustPass {
+		goldenLevel = "warning"
+		goldenTitle = "Golden task failed (non-blocking)"
+	}
 	for _, g := range r.GoldenFailures {
-		fprintf(out, "::error title=Golden task failed::%s (%s) — current status %s\n",
-			g.TestID, g.DisplayName, g.CurrentStatus)
+		fprintf(out, "::%s title=%s::%s (%s) — current status %s\n",
+			goldenLevel, goldenTitle, g.TestID, g.DisplayName, g.CurrentStatus)
 	}
 	for _, w := range r.Warnings {
 		fprintf(out, "::warning title=Waza gate::%s\n", sanitizeGHA(w))

--- a/cmd/waza/cmd_gate_test.go
+++ b/cmd/waza/cmd_gate_test.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/waza/internal/models"
+)
+
+// makeOutcome builds a minimal EvaluationOutcome with the given per-task
+// statuses and an explicit success rate, suitable for gate-level tests.
+func makeOutcome(successRate float64, tasks []models.TestOutcome) *models.EvaluationOutcome {
+	o := &models.EvaluationOutcome{
+		TestOutcomes: tasks,
+	}
+	o.Digest.SuccessRate = successRate
+	o.Digest.TotalTests = len(tasks)
+	for _, t := range tasks {
+		switch t.Status {
+		case models.StatusPassed:
+			o.Digest.Succeeded++
+		case models.StatusFailed:
+			o.Digest.Failed++
+		}
+	}
+	return o
+}
+
+func writeOutcomeFile(t *testing.T, dir, name string, o *models.EvaluationOutcome) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	data, err := json.Marshal(o)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(p, data, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+func defaultOpts(baseline, current string) *gateOptions {
+	return &gateOptions{
+		baselinePath:     baseline,
+		currentPath:      current,
+		maxRegressionPct: 5.0,
+		goldenMustPass:   true,
+		onNewTasks:       gatePolicyAllow,
+		onRemovedTasks:   gatePolicyWarn,
+		format:           gateFormatJSON,
+	}
+}
+
+func TestGate_PassWhenNoRegression(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "t1", Status: models.StatusPassed},
+		{TestID: "t2", Status: models.StatusPassed},
+	})
+	curr := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "t1", Status: models.StatusPassed},
+		{TestID: "t2", Status: models.StatusPassed},
+	})
+	bp := writeOutcomeFile(t, dir, "baseline.json", base)
+	cp := writeOutcomeFile(t, dir, "current.json", curr)
+
+	var buf bytes.Buffer
+	err := runGate(&buf, defaultOpts(bp, cp))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	var r GateReport
+	if err := json.Unmarshal(buf.Bytes(), &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if r.ExitCode != GateExitPass {
+		t.Errorf("expected exit %d, got %d (outcome=%s)", GateExitPass, r.ExitCode, r.Outcome)
+	}
+}
+
+func TestGate_RegressionExceedsThreshold(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.95, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	curr := makeOutcome(0.80, []models.TestOutcome{{TestID: "t1", Status: models.StatusFailed}})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	var buf bytes.Buffer
+	err := runGate(&buf, defaultOpts(bp, cp))
+	if err == nil {
+		t.Fatalf("expected non-nil error")
+	}
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected ExitCodeError, got %T", err)
+	}
+	if ec.Code != GateExitRegression {
+		t.Errorf("expected exit %d, got %d", GateExitRegression, ec.Code)
+	}
+}
+
+func TestGate_RegressionWithinThresholdPasses(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.95, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	curr := makeOutcome(0.92, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	var buf bytes.Buffer
+	if err := runGate(&buf, defaultOpts(bp, cp)); err != nil {
+		t.Fatalf("expected pass, got %v", err)
+	}
+}
+
+func TestGate_GoldenFailureTakesPrecedenceOverRegression(t *testing.T) {
+	dir := t.TempDir()
+	// Big regression AND a golden failure. Golden must win (exit 2).
+	base := makeOutcome(0.95, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusPassed},
+	})
+	curr := makeOutcome(0.50, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusFailed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	var buf bytes.Buffer
+	err := runGate(&buf, defaultOpts(bp, cp))
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected ExitCodeError, got %v", err)
+	}
+	if ec.Code != GateExitGoldenFailure {
+		t.Errorf("expected exit %d (golden), got %d", GateExitGoldenFailure, ec.Code)
+	}
+}
+
+func TestGate_GoldenMustPassFalseAllowsGoldenFailure(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusPassed},
+	})
+	curr := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusFailed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	opts := defaultOpts(bp, cp)
+	opts.goldenMustPass = false
+	var buf bytes.Buffer
+	if err := runGate(&buf, opts); err != nil {
+		t.Fatalf("expected pass (golden disabled), got %v", err)
+	}
+}
+
+func TestGate_GoldenDetectedFromBaselineEvenIfMissingInCurrent(t *testing.T) {
+	// If the baseline declares a task golden but the current results.json
+	// was produced from an older YAML missing the flag, the gate should
+	// still enforce it. This is the "conservative once-golden-always-golden"
+	// behavior documented in cmd_gate.go.
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusPassed},
+	})
+	curr := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "g1", Golden: false, Status: models.StatusFailed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	var buf bytes.Buffer
+	err := runGate(&buf, defaultOpts(bp, cp))
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != GateExitGoldenFailure {
+		t.Fatalf("expected golden failure exit %d, got %v", GateExitGoldenFailure, err)
+	}
+}
+
+func TestGate_NewTasksPolicyFailFails(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	curr := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "t1", Status: models.StatusPassed},
+		{TestID: "t2", Status: models.StatusPassed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	opts := defaultOpts(bp, cp)
+	opts.onNewTasks = gatePolicyFail
+	var buf bytes.Buffer
+	err := runGate(&buf, opts)
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != GateExitRegression {
+		t.Fatalf("expected regression exit %d for new-task fail policy, got %v", GateExitRegression, err)
+	}
+
+	var r GateReport
+	_ = json.Unmarshal(buf.Bytes(), &r)
+	if len(r.NewTasks) != 1 || r.NewTasks[0] != "t2" {
+		t.Errorf("expected new task t2, got %v", r.NewTasks)
+	}
+}
+
+func TestGate_NewTasksPolicyWarn(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	curr := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "t1", Status: models.StatusPassed},
+		{TestID: "t2", Status: models.StatusPassed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	opts := defaultOpts(bp, cp)
+	opts.onNewTasks = gatePolicyWarn
+	var buf bytes.Buffer
+	if err := runGate(&buf, opts); err != nil {
+		t.Fatalf("expected pass with warn, got %v", err)
+	}
+	var r GateReport
+	_ = json.Unmarshal(buf.Bytes(), &r)
+	if len(r.Warnings) == 0 {
+		t.Errorf("expected at least one warning, got none")
+	}
+}
+
+func TestGate_RemovedTasksPolicyFail(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "t1", Status: models.StatusPassed},
+		{TestID: "t2", Status: models.StatusPassed},
+	})
+	curr := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "t1", Status: models.StatusPassed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	opts := defaultOpts(bp, cp)
+	opts.onRemovedTasks = gatePolicyFail
+	var buf bytes.Buffer
+	err := runGate(&buf, opts)
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != GateExitRegression {
+		t.Fatalf("expected regression exit, got %v", err)
+	}
+}
+
+func TestGate_ConfigErrors(t *testing.T) {
+	cases := map[string]*gateOptions{
+		"missing baseline":  {currentPath: "x.json", format: gateFormatHuman, onNewTasks: "allow", onRemovedTasks: "warn"},
+		"missing current":   {baselinePath: "x.json", format: gateFormatHuman, onNewTasks: "allow", onRemovedTasks: "warn"},
+		"bad new policy":    {baselinePath: "a", currentPath: "b", format: gateFormatHuman, onNewTasks: "bogus", onRemovedTasks: "warn"},
+		"bad remove policy": {baselinePath: "a", currentPath: "b", format: gateFormatHuman, onNewTasks: "allow", onRemovedTasks: "bogus"},
+		"bad format":        {baselinePath: "a", currentPath: "b", format: "xml", onNewTasks: "allow", onRemovedTasks: "warn"},
+		"negative pct":      {baselinePath: "a", currentPath: "b", maxRegressionPct: -1, format: gateFormatHuman, onNewTasks: "allow", onRemovedTasks: "warn"},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := runGate(&buf, opts)
+			var ec *ExitCodeError
+			if !errors.As(err, &ec) || ec.Code != GateExitConfigError {
+				t.Fatalf("expected config error exit %d, got %v", GateExitConfigError, err)
+			}
+		})
+	}
+}
+
+func TestGate_ConfigErrorOnUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	bp := filepath.Join(dir, "does-not-exist.json")
+	cp := filepath.Join(dir, "also-missing.json")
+	var buf bytes.Buffer
+	err := runGate(&buf, defaultOpts(bp, cp))
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != GateExitConfigError {
+		t.Fatalf("expected config error exit %d, got %v", GateExitConfigError, err)
+	}
+}
+
+func TestGate_FormatGitHubActionsEmitsAnnotations(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.95, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusPassed},
+	})
+	curr := makeOutcome(0.50, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusFailed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	summaryFile := filepath.Join(dir, "step-summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryFile)
+
+	opts := defaultOpts(bp, cp)
+	opts.format = gateFormatGitHubActions
+	var buf bytes.Buffer
+	_ = runGate(&buf, opts) // error is expected; we want the output side-effects
+
+	got := buf.String()
+	if !strings.Contains(got, "::error title=Waza regression::") {
+		t.Errorf("expected regression annotation, got:\n%s", got)
+	}
+	if !strings.Contains(got, "::error title=Golden task failed::") {
+		t.Errorf("expected golden annotation, got:\n%s", got)
+	}
+
+	sum, err := os.ReadFile(summaryFile)
+	if err != nil {
+		t.Fatalf("step summary file not written: %v", err)
+	}
+	if !strings.Contains(string(sum), "Waza regression gate") {
+		t.Errorf("expected markdown summary in step summary file, got:\n%s", sum)
+	}
+}
+
+func TestGate_FormatMarkdownAndHuman(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	curr := makeOutcome(0.90, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	t.Run("markdown", func(t *testing.T) {
+		opts := defaultOpts(bp, cp)
+		opts.format = gateFormatMarkdown
+		var buf bytes.Buffer
+		if err := runGate(&buf, opts); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !strings.Contains(buf.String(), "Waza regression gate") {
+			t.Errorf("missing markdown header: %s", buf.String())
+		}
+	})
+
+	t.Run("human", func(t *testing.T) {
+		opts := defaultOpts(bp, cp)
+		opts.format = gateFormatHuman
+		var buf bytes.Buffer
+		if err := runGate(&buf, opts); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !strings.Contains(buf.String(), "REGRESSION GATE") {
+			t.Errorf("missing human header: %s", buf.String())
+		}
+	})
+}
+
+func TestGate_ReportFieldsForJSON(t *testing.T) {
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "t1", Status: models.StatusPassed},
+		{TestID: "drop", Status: models.StatusPassed},
+	})
+	curr := makeOutcome(0.85, []models.TestOutcome{
+		{TestID: "t1", Status: models.StatusPassed},
+		{TestID: "new", Status: models.StatusPassed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	opts := defaultOpts(bp, cp)
+	opts.onNewTasks = gatePolicyWarn
+	opts.onRemovedTasks = gatePolicyWarn
+	var buf bytes.Buffer
+	_ = runGate(&buf, opts)
+
+	var r GateReport
+	if err := json.Unmarshal(buf.Bytes(), &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(r.NewTasks) != 1 || r.NewTasks[0] != "new" {
+		t.Errorf("expected new=[new], got %v", r.NewTasks)
+	}
+	if len(r.RemovedTasks) != 1 || r.RemovedTasks[0] != "drop" {
+		t.Errorf("expected removed=[drop], got %v", r.RemovedTasks)
+	}
+	if r.PassRateDelta >= 0 {
+		t.Errorf("expected negative pass-rate delta, got %v", r.PassRateDelta)
+	}
+	if r.RegressionPct <= 0 {
+		t.Errorf("expected positive regression pct, got %v", r.RegressionPct)
+	}
+}
+
+func TestGoldenYAMLFieldRoundtrip(t *testing.T) {
+	// Sanity check that the YAML/JSON tags are wired correctly so a TestCase
+	// with `golden: true` is detected and a TestOutcome carries `golden: true`.
+	tc := models.TestCase{TestID: "t", Golden: true}
+	if !tc.Golden || tc.TestID != "t" {
+		t.Fatalf("TestCase fields not set: %+v", tc)
+	}
+	out, err := json.Marshal(models.TestOutcome{TestID: "t", Golden: true, Status: models.StatusPassed})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"golden":true`) {
+		t.Errorf("expected golden in JSON, got %s", out)
+	}
+}

--- a/cmd/waza/cmd_gate_test.go
+++ b/cmd/waza/cmd_gate_test.go
@@ -48,7 +48,7 @@ func defaultOpts(baseline, current string) *gateOptions {
 	return &gateOptions{
 		baselinePath:     baseline,
 		currentPath:      current,
-		maxRegressionPct: 5.0,
+		maxRegressionPct: 0,
 		goldenMustPass:   true,
 		onNewTasks:       gatePolicyAllow,
 		onRemovedTasks:   gatePolicyWarn,
@@ -112,9 +112,33 @@ func TestGate_RegressionWithinThresholdPasses(t *testing.T) {
 	bp := writeOutcomeFile(t, dir, "b.json", base)
 	cp := writeOutcomeFile(t, dir, "c.json", curr)
 
+	// Default --max-regression-pct is 0, so we must explicitly allow the 3pp drop.
+	opts := defaultOpts(bp, cp)
+	opts.maxRegressionPct = 5.0
+
 	var buf bytes.Buffer
-	if err := runGate(&buf, defaultOpts(bp, cp)); err != nil {
+	if err := runGate(&buf, opts); err != nil {
 		t.Fatalf("expected pass, got %v", err)
+	}
+}
+
+func TestGate_DefaultZeroThresholdFailsAnyRegression(t *testing.T) {
+	// With the default --max-regression-pct=0, even a 3pp drop in pass rate
+	// must trigger a regression exit (code 1).
+	dir := t.TempDir()
+	base := makeOutcome(0.95, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	curr := makeOutcome(0.92, []models.TestOutcome{{TestID: "t1", Status: models.StatusPassed}})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	var buf bytes.Buffer
+	err := runGate(&buf, defaultOpts(bp, cp))
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected ExitCodeError for regression, got %v", err)
+	}
+	if ec.Code != GateExitRegression {
+		t.Errorf("expected exit %d, got %d", GateExitRegression, ec.Code)
 	}
 }
 
@@ -389,6 +413,37 @@ func TestGate_ReportFieldsForJSON(t *testing.T) {
 	}
 	if r.RegressionPct <= 0 {
 		t.Errorf("expected positive regression pct, got %v", r.RegressionPct)
+	}
+}
+
+func TestGate_FormatGitHubActionsDemotesGoldenWhenPolicyRelaxed(t *testing.T) {
+	// With --golden-must-pass=false, a golden task failure is non-blocking,
+	// so the GitHub Actions formatter must emit ::warning:: rather than
+	// ::error:: for it — otherwise CI would surface a misleading error.
+	dir := t.TempDir()
+	base := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusPassed},
+	})
+	curr := makeOutcome(0.90, []models.TestOutcome{
+		{TestID: "g1", Golden: true, Status: models.StatusFailed},
+	})
+	bp := writeOutcomeFile(t, dir, "b.json", base)
+	cp := writeOutcomeFile(t, dir, "c.json", curr)
+
+	opts := defaultOpts(bp, cp)
+	opts.format = gateFormatGitHubActions
+	opts.goldenMustPass = false
+
+	var buf bytes.Buffer
+	if err := runGate(&buf, opts); err != nil {
+		t.Fatalf("expected pass when golden policy relaxed, got %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "::warning title=Golden task failed (non-blocking)") {
+		t.Errorf("expected warning-level golden annotation, got:\n%s", got)
+	}
+	if strings.Contains(got, "::error title=Golden task failed::") {
+		t.Errorf("did not expect error-level golden annotation when policy relaxed, got:\n%s", got)
 	}
 }
 

--- a/cmd/waza/main.go
+++ b/cmd/waza/main.go
@@ -23,8 +23,37 @@ func (e *TestFailureError) Error() string {
 	return e.Message
 }
 
+// ExitCodeError lets a subcommand request a specific process exit code while
+// still returning an error to cobra so the message is printed and usage is
+// suppressed. Used by `waza gate` to expose its documented exit code matrix
+// (0/1/2/3) independently of cobra's default behavior.
+type ExitCodeError struct {
+	Code int
+	Err  error
+}
+
+func (e *ExitCodeError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("exit code %d", e.Code)
+	}
+	return e.Err.Error()
+}
+
+func (e *ExitCodeError) Unwrap() error {
+	return e.Err
+}
+
 func main() {
 	if err := execute(); err != nil {
+		// ExitCodeError takes precedence — the subcommand picked the code.
+		var exitErr *ExitCodeError
+		if errors.As(err, &exitErr) {
+			if exitErr.Err != nil && exitErr.Err.Error() != "" {
+				fmt.Fprintln(os.Stderr, exitErr.Err.Error())
+			}
+			os.Exit(exitErr.Code)
+		}
+
 		fmt.Fprintln(os.Stderr, err)
 
 		// Check error type to determine exit code

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -54,6 +54,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newInitCommand())
 	cmd.AddCommand(tokens.NewCommand())
 	cmd.AddCommand(newCompareCommand())
+	cmd.AddCommand(newGateCommand())
 	cmd.AddCommand(newCoverageCommand())
 	cmd.AddCommand(dev.NewCommand())
 	cmd.AddCommand(newGradeCommand())

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -137,9 +137,12 @@ type MeasureResult struct {
 
 // TestOutcome represents the result of one test case
 type TestOutcome struct {
-	TestID      string             `json:"test_id"`
-	DisplayName string             `json:"display_name"`
-	Group       string             `json:"group,omitempty"`
+	TestID      string `json:"test_id"`
+	DisplayName string `json:"display_name"`
+	Group       string `json:"group,omitempty"`
+	// Golden mirrors TestCase.Golden so `waza gate` can identify
+	// must-pass tasks directly from results.json without re-reading YAML.
+	Golden      bool               `json:"golden,omitempty"`
 	Status      Status             `json:"status"`
 	Runs        []RunResult        `json:"runs"`
 	Stats       *TestStats         `json:"stats,omitempty"`

--- a/internal/models/testcase.go
+++ b/internal/models/testcase.go
@@ -22,7 +22,11 @@ type TestCase struct {
 	Summary          string          `yaml:"description,omitempty" json:"summary,omitempty"`
 	Tags             []string        `yaml:"tags,omitempty" json:"labels,omitempty"`
 	TestID           string          `yaml:"id" json:"test_id"`
-	TimeoutSec       *int            `yaml:"timeout_seconds,omitempty" json:"timeout_sec,omitempty"`
+	// Golden marks a task as a "must always pass" regression gate. When set
+	// to true, `waza gate` treats any non-pass status as a hard failure
+	// (exit code 2) regardless of the aggregate pass-rate threshold.
+	Golden     bool `yaml:"golden,omitempty" json:"golden,omitempty"`
+	TimeoutSec *int `yaml:"timeout_seconds,omitempty" json:"timeout_sec,omitempty"`
 	// FirstEventTimeoutSec overrides Config.FirstEventTimeoutSec for this task.
 	// nil inherits the eval-level value; 0 disables the check for this task.
 	FirstEventTimeoutSec *int              `yaml:"first_event_timeout_seconds,omitempty" json:"first_event_timeout_sec,omitempty"`

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -745,6 +745,7 @@ func (r *EvalRunner) runSequential(ctx context.Context, testCases []*models.Test
 				outcomes = append(outcomes, models.TestOutcome{
 					TestID:      tc.TestID,
 					DisplayName: tc.DisplayName,
+					Golden:      tc.Golden,
 					Status:      models.StatusFailed,
 					Runs:        []models.RunResult{},
 				})
@@ -832,6 +833,7 @@ func (r *EvalRunner) runConcurrent(ctx context.Context, testCases []*models.Test
 					resultChan <- result{index: idx, outcome: models.TestOutcome{
 						TestID:      test.TestID,
 						DisplayName: test.DisplayName,
+						Golden:      test.Golden,
 						Status:      models.StatusFailed,
 						Runs:        []models.RunResult{},
 					}}
@@ -1005,6 +1007,7 @@ func (r *EvalRunner) runTestUncached(ctx context.Context, tc *models.TestCase, t
 		TestID:      tc.TestID,
 		DisplayName: tc.DisplayName,
 		Group:       r.resolveGroup(),
+		Golden:      tc.Golden,
 		Status:      status,
 		Runs:        runs,
 		Stats:       stats,

--- a/site/src/content/docs/guides/ci-cd.mdx
+++ b/site/src/content/docs/guides/ci-cd.mdx
@@ -139,6 +139,75 @@ To run it manually:
 gh workflow run weekly-regression-loop.yml --repo microsoft/waza
 ```
 
+### Regression gates with `waza gate`
+
+For a focused PR gate, use [`waza gate`](/reference/cli/#waza-gate). It compares a baseline against the current run and exits with stable codes (`0` pass, `1` regression, `2` golden failure, `3` config error), making it easy to wire into any CI system.
+
+Mark business-critical tasks in your eval YAML with `golden: true` and they must always pass:
+
+```yaml
+tasks:
+  - id: critical-flow
+    golden: true
+    prompt: "..."
+    grader:
+      type: exact_match
+      expected: "OK"
+```
+
+**GitHub Actions** — annotations + step summary, with the baseline pulled from the default branch:
+
+```yaml
+- name: Download baseline from main
+  uses: dawidd6/action-download-artifact@v6
+  with:
+    workflow: eval.yml
+    branch: main
+    name: results
+    path: baseline/
+
+- name: Run current evaluation
+  run: waza run evals/main.yaml --output results.json
+
+- name: Regression gate
+  run: |
+    waza gate \
+      --baseline baseline/results.json \
+      --current results.json \
+      --max-regression-pct 5 \
+      --on-new-tasks allow \
+      --on-removed-tasks warn \
+      --format github-actions
+```
+
+The `github-actions` format emits `::error::` / `::warning::` / `::notice::` annotations and appends a markdown summary to `$GITHUB_STEP_SUMMARY`. Non-zero exit fails the step automatically.
+
+**Azure DevOps** — exit codes drive task status; `task.logissue` surfaces inline warnings/errors:
+
+```yaml
+- script: |
+    waza gate \
+      --baseline $(Pipeline.Workspace)/baseline/results.json \
+      --current $(Build.ArtifactStagingDirectory)/results.json \
+      --max-regression-pct 5 \
+      --format markdown > $(Build.ArtifactStagingDirectory)/gate-report.md
+    code=$?
+    cat $(Build.ArtifactStagingDirectory)/gate-report.md
+    if [ $code -eq 2 ]; then
+      echo "##vso[task.logissue type=error]Golden task failure"
+    elif [ $code -eq 1 ]; then
+      echo "##vso[task.logissue type=error]Regression exceeded threshold"
+    elif [ $code -eq 3 ]; then
+      echo "##vso[task.logissue type=error]waza gate configuration error"
+    fi
+    exit $code
+  displayName: 'Regression gate'
+
+- publish: $(Build.ArtifactStagingDirectory)/gate-report.md
+  artifact: gate-report
+  condition: always()
+```
+
 ### Token Budget Checks
 
 Use `waza tokens compare` to track token usage across PRs and fail if budgets are exceeded:

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -344,6 +344,7 @@ expected:
 | `expected`    | object | Validation rules and expected behavior              |
 | `skill_directories` | string[] | Skill directories for this task (overrides eval-level) |
 | `instruction_files` | string[] | Instruction files for this task (adds to eval-level files) |
+| `golden`      | bool   | Mark as a critical "golden" task — enforced by [`waza gate`](/reference/cli/#waza-gate) (must always pass) |
 
 ### Inputs Section
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -408,6 +408,72 @@ waza compare gpt4.json sonnet.json opus.json
 waza compare results-*.json --format json
 ```
 
+## waza gate
+
+Compare a current results file against a baseline and enforce regression policy. Designed for CI: emits stable exit codes and supports GitHub Actions annotations.
+
+```bash
+waza gate --baseline baseline.json --current results.json [flags]
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--baseline` | _(required)_ | Baseline results JSON (the "known good" run). |
+| `--current` | _(required)_ | Current results JSON to evaluate. |
+| `--max-regression-pct` | `0` | Maximum allowed drop in success rate (percentage points). `0` means no regression tolerated. |
+| `--golden-must-pass` | `true` | If `true`, any failing task marked `golden: true` causes a golden failure (exit 2). |
+| `--on-new-tasks` | `allow` | Policy when current has tasks not in baseline: `allow`, `warn`, `fail`. |
+| `--on-removed-tasks` | `warn` | Policy when baseline has tasks not in current: `allow`, `warn`, `fail`. |
+| `--format` | `human` | Output format: `human`, `json`, `markdown`, `github-actions`. |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Pass — within thresholds and policies. |
+| `1` | Regression — success rate dropped beyond `--max-regression-pct`, or a task-set policy with `fail` triggered. |
+| `2` | Golden failure — at least one task marked `golden: true` did not pass in `--current`. Takes precedence over regression. |
+| `3` | Config error — invalid flags, missing files, or unparseable JSON. |
+
+### Golden tasks
+
+Mark a task in your eval YAML as a golden task to enforce that it must always pass:
+
+```yaml
+tasks:
+  - id: critical-flow
+    golden: true
+    prompt: "..."
+    grader:
+      type: exact_match
+      expected: "OK"
+```
+
+`golden` is propagated into `results.json` so `waza gate` can read it without re-reading the YAML. Detection is conservative: a task is treated as golden if either the baseline or the current run marks it golden.
+
+### Examples
+
+```bash
+# Basic CI gate: no regression allowed, golden must pass
+waza gate --baseline baseline.json --current results.json
+
+# Allow up to 5 percentage-point drop, fail on new tasks
+waza gate --baseline baseline.json --current results.json \
+  --max-regression-pct 5 --on-new-tasks fail
+
+# Emit GitHub Actions annotations + step summary
+waza gate --baseline baseline.json --current results.json \
+  --format github-actions
+
+# Markdown report (e.g. for posting as a PR comment)
+waza gate --baseline baseline.json --current results.json \
+  --format markdown > gate-report.md
+```
+
+See the [CI/CD guide](/guides/ci-cd/#regression-gates-with-waza-gate) for full GitHub Actions and Azure DevOps snippets.
+
 ## waza coverage
 
 Generate an eval coverage grid for discovered skills and custom agents.


### PR DESCRIPTION
Closes #364.

Adds a new `waza gate` command for CI regression gates, plus a `golden: true` task field (absorbing #359) that gate enforces as a hard requirement.

## What's new

### `waza gate`

```bash
waza gate --baseline baseline.json --current results.json \
  [--max-regression-pct 5] \
  [--golden-must-pass] \
  [--on-new-tasks allow|warn|fail] \
  [--on-removed-tasks allow|warn|fail] \
  [--format human|json|markdown|github-actions]
```

### Stable exit codes

| Code | Meaning |
|------|---------|
| `0` | Pass |
| `1` | Regression — success rate dropped beyond `--max-regression-pct`, or a task-set `fail` policy triggered |
| `2` | Golden failure — at least one task marked `golden: true` did not pass (takes precedence over regression) |
| `3` | Config error — bad flags, missing/unparseable files |

### Golden tasks

New `golden: true` field on tasks in eval YAML. It's propagated all the way through to `results.json` (TestOutcome.Golden) so `waza gate` can enforce it from results alone, without needing to re-read the eval YAML.

**Conservative detection**: a task is treated as golden if **either** the baseline or the current run marks it golden. This avoids regressions slipping through when an older baseline predates the field.

### Output formats

- `human` (default) — colored summary with regression table, golden status, task-set deltas
- `json` — machine-readable `GateReport`
- `markdown` — PR-comment-friendly report
- `github-actions` — emits `::error::` / `::warning::` / `::notice::` annotations on stdout **and** appends a markdown summary to `$GITHUB_STEP_SUMMARY` when set

## Tests

`cmd/waza/cmd_gate_test.go` covers all acceptance criteria:

- Pass when no regression
- Regression exceeds threshold
- Golden failure takes precedence over regression
- `--golden-must-pass=false` allows golden to fail without exit 2
- Golden detected from baseline even when missing in current
- New/removed task policies (allow/warn/fail combinations)
- All four output formats render correctly
- Config errors return exit 3
- `golden` YAML roundtrip

## Docs

- `site/src/content/docs/reference/cli.mdx` — full `## waza gate` section
- `site/src/content/docs/guides/ci-cd.mdx` — GitHub Actions + Azure DevOps snippets
- `site/src/content/docs/guides/eval-yaml.mdx` — `golden` field in task fields table

## Design notes (simple choices for ambiguous spec items)

- **Golden detection**: union across baseline/current (described above) — safer for older baselines.
- **Default policy**: `--on-new-tasks=allow` (additive growth is good), `--on-removed-tasks=warn` (visibility without breaking PRs that intentionally prune tasks). Both can be overridden to `fail` for stricter CI.
- **`--max-regression-pct=0` default**: no regression tolerated unless explicitly allowed.
- **Exit-code plumbing**: introduced `ExitCodeError` in `cmd/waza/main.go` so subcommands can request specific exit codes without leaking that concern across the rest of the CLI.

## Files

- New: `cmd/waza/cmd_gate.go`, `cmd/waza/cmd_gate_test.go`
- Modified: `cmd/waza/main.go` (ExitCodeError), `cmd/waza/root.go` (register command), `internal/models/{testcase,outcome}.go` (Golden field), `internal/orchestration/runner.go` (propagate Golden through 3 emit paths), site docs.