### PR TITLE
feat: spec verify command (closes #361)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Verify that an eval suite exercises the promises made in `SKILL.md`. The command
 | `--skill <path>` | Path to `SKILL.md` or a skill directory |
 | `--eval <path>` | Path to `eval.yaml` |
 | `--format <fmt>` | Output format: `human`, `json`, or `github-actions` |
-| `--warn` | Report uncovered requirements and exit 0 (default) |
+| `--warn` | Report uncovered requirements and exit 0 (default); set false to suppress GitHub Actions warning annotations |
 | `--fail` | Exit 1 when uncovered requirements are greater than or equal to `--threshold` |
 | `--threshold <n>` | Uncovered requirement threshold for `--fail` (default: 1) |
 | `--semantic` | Opt in to LLM-assisted semantic matching after deterministic matching |

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ waza check skills/my-skill
 waza suggest skills/my-skill --dry-run
 waza suggest skills/my-skill --apply
 
+# Verify eval coverage against SKILL.md requirements
+waza spec verify skills/my-skill evals/my-skill/eval.yaml
+waza spec verify skills/my-skill evals/my-skill/eval.yaml --fail --format github-actions
+
 # Note: 'generate' is available as an alias for 'new' (see below for new command)
 # Note: Custom agents (.agent.md) are supported — see https://microsoft.github.io/waza/guides/custom-agents/
 
@@ -415,6 +419,28 @@ Generate a skill-to-eval coverage grid showing which skills are fully covered, p
 |------|-------|-------------|
 | `--format <fmt>` | `-f` | Output format: `text`, `markdown`, or `json` (default: `text`) |
 | `--path <dir>` | | Additional directory to scan for skills/evals (repeatable) |
+
+### `waza spec verify [skill-path] [eval.yaml]`
+
+Verify that an eval suite exercises the promises made in `SKILL.md`. The command deterministically parses the description, `USE FOR` triggers, `DO NOT USE FOR` triggers, and parameter blocks into requirement IDs such as `req-use-001` and `req-dont-001`, then maps each requirement to matching task IDs.
+
+| Flag | Description |
+|------|-------------|
+| `--skill <path>` | Path to `SKILL.md` or a skill directory |
+| `--eval <path>` | Path to `eval.yaml` |
+| `--format <fmt>` | Output format: `human`, `json`, or `github-actions` |
+| `--warn` | Report uncovered requirements and exit 0 (default) |
+| `--fail` | Exit 1 when uncovered requirements are greater than or equal to `--threshold` |
+| `--threshold <n>` | Uncovered requirement threshold for `--fail` (default: 1) |
+| `--semantic` | Opt in to LLM-assisted semantic matching after deterministic matching |
+| `--judge-model <model>` | Judge model for `--semantic` (defaults to `config.judge_model`, then `config.model`) |
+
+**Example:**
+
+```bash
+waza spec verify skills/pr-summarizer evals/pr-summarizer/eval.yaml
+waza spec verify --skill skills/pr-summarizer --eval evals/pr-summarizer/eval.yaml --format json
+```
 
 ### `waza models`
 

--- a/cmd/waza/cmd_spec.go
+++ b/cmd/waza/cmd_spec.go
@@ -314,7 +314,15 @@ func renderSpecVerifyGitHubActions(w io.Writer, report *specverify.Report, warn,
 		if len(row.CoveredBy) > 0 {
 			continue
 		}
-		fmt.Fprintf(w, "::%s file=%s,line=%d,title=Uncovered spec requirement::%s %s\n", level, row.Requirement.Source.File, row.Requirement.Source.StartLine, row.Requirement.ID, escapeGitHubActions(row.Requirement.Text)) //nolint:errcheck
+		_, _ = fmt.Fprintf(
+			w,
+			"::%s file=%s,line=%d,title=Uncovered spec requirement::%s %s\n",
+			level,
+			escapeGitHubActionsProperty(githubActionsAnnotationPath(row.Requirement.Source.File)),
+			row.Requirement.Source.StartLine,
+			row.Requirement.ID,
+			escapeGitHubActionsMessage(row.Requirement.Text),
+		)
 	}
 }
 
@@ -326,10 +334,31 @@ func coveredTaskList(items []specverify.CoveredBy) string {
 	return strings.Join(ids, ", ")
 }
 
-func escapeGitHubActions(s string) string {
+func githubActionsAnnotationPath(path string) string {
+	if !filepath.IsAbs(path) {
+		return filepath.ToSlash(path)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	rel, err := filepath.Rel(wd, path)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func escapeGitHubActionsMessage(s string) string {
 	s = strings.ReplaceAll(s, "%", "%25")
 	s = strings.ReplaceAll(s, "\r", "%0D")
 	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
+}
+
+func escapeGitHubActionsProperty(s string) string {
+	s = escapeGitHubActionsMessage(s)
 	s = strings.ReplaceAll(s, ":", "%3A")
+	s = strings.ReplaceAll(s, ",", "%2C")
 	return s
 }

--- a/cmd/waza/cmd_spec.go
+++ b/cmd/waza/cmd_spec.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/microsoft/waza/internal/execution"
+	"github.com/microsoft/waza/internal/specverify"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var newSpecVerifyEngine = func(modelID string) execution.AgentEngine {
+	return execution.NewCopilotEngineBuilder(modelID, nil).Build()
+}
+
+type specVerifyFlags struct {
+	skillPath       string
+	evalPath        string
+	format          string
+	warn            bool
+	fail            bool
+	failThreshold   int
+	semantic        bool
+	judgeModel      string
+	semanticTimeout time.Duration
+}
+
+func newSpecCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "spec",
+		Short: "Verify eval coverage against SKILL.md requirements",
+	}
+	cmd.AddCommand(newSpecVerifyCommand())
+	return cmd
+}
+
+func newSpecVerifyCommand() *cobra.Command {
+	flags := &specVerifyFlags{
+		format:          "human",
+		warn:            true,
+		failThreshold:   1,
+		semanticTimeout: 30 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "verify [skill-path] [eval.yaml]",
+		Short: "Verify eval coverage for SKILL.md requirements",
+		Long: `Parse SKILL.md into machine-readable requirements and verify that eval tasks
+exercise the description, USE FOR triggers, DO NOT USE FOR triggers, and parameter blocks.
+
+Deterministic matching always runs first. Use --semantic to allow an LLM judge to
+fill deterministic coverage gaps with the configured judge model.`,
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSpecVerifyCommand(cmd, args, flags)
+		},
+		SilenceErrors: true,
+	}
+
+	cmd.Flags().StringVar(&flags.skillPath, "skill", "", "Path to SKILL.md or skill directory")
+	cmd.Flags().StringVar(&flags.evalPath, "eval", "", "Path to eval.yaml")
+	cmd.Flags().StringVar(&flags.format, "format", "human", "Output format: human, json, github-actions")
+	cmd.Flags().BoolVar(&flags.warn, "warn", true, "Warn on uncovered requirements and exit 0")
+	cmd.Flags().BoolVar(&flags.fail, "fail", false, "Exit 1 when uncovered requirements are greater than or equal to --threshold")
+	cmd.Flags().IntVar(&flags.failThreshold, "threshold", 1, "Uncovered requirement count threshold for --fail")
+	cmd.Flags().BoolVar(&flags.semantic, "semantic", false, "Use the configured judge model to fill deterministic coverage gaps")
+	cmd.Flags().StringVar(&flags.judgeModel, "judge-model", "", "Judge model for --semantic (defaults to eval config judge_model, then model)")
+	cmd.Flags().DurationVar(&flags.semanticTimeout, "semantic-timeout", 30*time.Second, "Timeout per semantic judge check")
+	return cmd
+}
+
+func runSpecVerifyCommand(cmd *cobra.Command, args []string, flags *specVerifyFlags) error {
+	if flags.format != "human" && flags.format != "json" && flags.format != "github-actions" {
+		return fmt.Errorf("invalid format %q: expected human, json, or github-actions", flags.format)
+	}
+	if flags.failThreshold < 1 {
+		return fmt.Errorf("--threshold must be at least 1")
+	}
+	if flags.fail {
+		flags.warn = false
+	}
+
+	skillInput := flags.skillPath
+	evalInput := flags.evalPath
+	if len(args) > 0 {
+		skillInput = args[0]
+	}
+	if len(args) > 1 {
+		evalInput = args[1]
+	}
+
+	skillPath, err := resolveSpecSkillPath(skillInput)
+	if err != nil {
+		return err
+	}
+	evalPath, err := resolveSpecEvalPath(evalInput, skillPath)
+	if err != nil {
+		return err
+	}
+
+	opts := specverify.Options{
+		SkillPath:     skillPath,
+		EvalPath:      evalPath,
+		Semantic:      flags.semantic,
+		FailThreshold: flags.failThreshold,
+	}
+
+	var shutdown func(context.Context) error
+	if flags.semantic {
+		judgeModel, err := resolveSpecJudgeModel(evalPath, flags.judgeModel)
+		if err != nil {
+			return err
+		}
+		engine := newSpecVerifyEngine(judgeModel)
+		if err := engine.Initialize(cmd.Context()); err != nil {
+			return err
+		}
+		opts.JudgeModel = judgeModel
+		opts.Matcher = &specverify.EngineSemanticMatcher{
+			Engine:  engine,
+			ModelID: judgeModel,
+			Timeout: flags.semanticTimeout,
+		}
+		shutdown = engine.Shutdown
+	}
+	if shutdown != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		defer func() {
+			_ = shutdown(shutdownCtx)
+			_ = execution.ShutdownSharedClient(shutdownCtx)
+		}()
+	}
+
+	report, err := specverify.Verify(cmd.Context(), opts)
+	if err != nil {
+		return err
+	}
+
+	switch flags.format {
+	case "human":
+		renderSpecVerifyHuman(cmd.OutOrStdout(), report)
+	case "json":
+		if err := renderSpecVerifyJSON(cmd.OutOrStdout(), report); err != nil {
+			return err
+		}
+	case "github-actions":
+		renderSpecVerifyGitHubActions(cmd.OutOrStdout(), report, flags.fail)
+	}
+
+	if flags.fail && report.Summary.UncoveredRequirements >= flags.failThreshold {
+		return &TestFailureError{Message: fmt.Sprintf("spec verify failed: %d uncovered requirement(s) >= threshold %d", report.Summary.UncoveredRequirements, flags.failThreshold)}
+	}
+	return nil
+}
+
+func resolveSpecSkillPath(input string) (string, error) {
+	if strings.TrimSpace(input) == "" {
+		input = "."
+	}
+	path, err := filepath.Abs(input)
+	if err != nil {
+		return "", fmt.Errorf("resolving skill path: %w", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("invalid skill path %q: %w", input, err)
+	}
+	if info.IsDir() {
+		candidate := filepath.Join(path, "SKILL.md")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+		return resolveSingleDiscoveredSkill(path)
+	}
+	if filepath.Base(path) != "SKILL.md" {
+		return "", fmt.Errorf("expected SKILL.md or skill directory, got %s", input)
+	}
+	return path, nil
+}
+
+func resolveSingleDiscoveredSkill(root string) (string, error) {
+	var found []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || name == "node_modules" || name == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == "SKILL.md" {
+			found = append(found, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("searching for SKILL.md under %s: %w", root, err)
+	}
+	if len(found) == 0 {
+		return "", fmt.Errorf("no SKILL.md found under %s", root)
+	}
+	if len(found) > 1 {
+		return "", fmt.Errorf("multiple SKILL.md files found under %s; pass --skill or run from a skill directory", root)
+	}
+	return found[0], nil
+}
+
+func resolveSpecEvalPath(input, skillPath string) (string, error) {
+	if strings.TrimSpace(input) != "" {
+		path, err := filepath.Abs(input)
+		if err != nil {
+			return "", fmt.Errorf("resolving eval path: %w", err)
+		}
+		if _, err := os.Stat(path); err != nil {
+			return "", fmt.Errorf("invalid eval path %q: %w", input, err)
+		}
+		return path, nil
+	}
+
+	skillDir := filepath.Dir(skillPath)
+	candidates := []string{
+		filepath.Join(skillDir, "eval.yaml"),
+		filepath.Join(skillDir, "eval.yml"),
+		filepath.Join(skillDir, "evals", "eval.yaml"),
+		filepath.Join(skillDir, "evals", "eval.yml"),
+		filepath.Join(skillDir, "tests", "eval.yaml"),
+		filepath.Join(skillDir, "tests", "eval.yml"),
+	}
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("no eval.yaml found for %s; pass --eval or provide eval.yaml as the second argument", skillPath)
+}
+
+func resolveSpecJudgeModel(evalPath, override string) (string, error) {
+	if strings.TrimSpace(override) != "" {
+		return override, nil
+	}
+	spec, err := specverifyLoadEvalConfig(evalPath)
+	if err != nil {
+		return "", err
+	}
+	if spec.JudgeModel != "" {
+		return spec.JudgeModel, nil
+	}
+	if spec.ModelID != "" {
+		return spec.ModelID, nil
+	}
+	return "", errors.New("--semantic requires --judge-model or config.judge_model/config.model in eval.yaml")
+}
+
+type specVerifyEvalConfig struct {
+	ModelID    string `yaml:"model"`
+	JudgeModel string `yaml:"judge_model"`
+}
+
+func specverifyLoadEvalConfig(evalPath string) (*specVerifyEvalConfig, error) {
+	data, err := os.ReadFile(evalPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading eval.yaml: %w", err)
+	}
+	var raw struct {
+		Config specVerifyEvalConfig `yaml:"config"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing eval.yaml: %w", err)
+	}
+	return &raw.Config, nil
+}
+
+func renderSpecVerifyHuman(w io.Writer, report *specverify.Report) {
+	fmt.Fprintln(w, "Spec Verification")                                                                                                                                                  //nolint:errcheck
+	fmt.Fprintf(w, "Coverage: %d/%d requirements covered (%d uncovered)\n\n", report.Summary.CoveredRequirements, report.Summary.TotalRequirements, report.Summary.UncoveredRequirements) //nolint:errcheck
+	for _, row := range report.Coverage {
+		status := "MISS"
+		target := "no task exercises this"
+		if len(row.CoveredBy) > 0 {
+			status = "OK"
+			target = "covered by tasks: [" + coveredTaskList(row.CoveredBy) + "]"
+		}
+		fmt.Fprintf(w, "%s %s  %q  -> %s (%s:%d)\n", status, row.Requirement.ID, row.Requirement.Text, target, row.Requirement.Source.File, row.Requirement.Source.StartLine) //nolint:errcheck
+	}
+}
+
+func renderSpecVerifyJSON(w io.Writer, report *specverify.Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+func renderSpecVerifyGitHubActions(w io.Writer, report *specverify.Report, fail bool) {
+	level := "warning"
+	if fail {
+		level = "error"
+	}
+	for _, row := range report.Coverage {
+		if len(row.CoveredBy) > 0 {
+			continue
+		}
+		fmt.Fprintf(w, "::%s file=%s,line=%d,title=Uncovered spec requirement::%s %s\n", level, row.Requirement.Source.File, row.Requirement.Source.StartLine, row.Requirement.ID, escapeGitHubActions(row.Requirement.Text)) //nolint:errcheck
+	}
+}
+
+func coveredTaskList(items []specverify.CoveredBy) string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.TaskID)
+	}
+	return strings.Join(ids, ", ")
+}
+
+func escapeGitHubActions(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	s = strings.ReplaceAll(s, ":", "%3A")
+	return s
+}

--- a/cmd/waza/cmd_spec.go
+++ b/cmd/waza/cmd_spec.go
@@ -153,7 +153,7 @@ func runSpecVerifyCommand(cmd *cobra.Command, args []string, flags *specVerifyFl
 			return err
 		}
 	case "github-actions":
-		renderSpecVerifyGitHubActions(cmd.OutOrStdout(), report, flags.fail)
+		renderSpecVerifyGitHubActions(cmd.OutOrStdout(), report, flags.warn, flags.fail)
 	}
 
 	if flags.fail && report.Summary.UncoveredRequirements >= flags.failThreshold {
@@ -302,7 +302,10 @@ func renderSpecVerifyJSON(w io.Writer, report *specverify.Report) error {
 	return enc.Encode(report)
 }
 
-func renderSpecVerifyGitHubActions(w io.Writer, report *specverify.Report, fail bool) {
+func renderSpecVerifyGitHubActions(w io.Writer, report *specverify.Report, warn, fail bool) {
+	if !warn && !fail {
+		return
+	}
 	level := "warning"
 	if fail {
 		level = "error"

--- a/cmd/waza/cmd_spec_test.go
+++ b/cmd/waza/cmd_spec_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/microsoft/waza/internal/specverify"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,6 +73,63 @@ func TestSpecVerifyCommandGitHubActionsHonorsWarnFalse(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Empty(t, out.String())
+}
+
+func TestSpecVerifyCommandGitHubActionsUsesRelativePathAndMessageEscaping(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	skillPath := filepath.Join(root, "skills", "example", "SKILL.md")
+
+	report := &specverify.Report{
+		Coverage: []specverify.RequirementCoverage{{
+			Requirement: specverify.Requirement{
+				ID:   "req-use-001",
+				Kind: specverify.RequirementUse,
+				Text: "needs: coverage",
+				Source: specverify.SourceSpan{
+					File:      skillPath,
+					StartLine: 7,
+				},
+			},
+			CoveredBy: []specverify.CoveredBy{},
+		}},
+	}
+
+	var out bytes.Buffer
+	renderSpecVerifyGitHubActions(&out, report, true, false)
+
+	text := out.String()
+	assert.Contains(t, text, "file=skills/example/SKILL.md")
+	assert.Contains(t, text, "::req-use-001 needs: coverage")
+	assert.NotContains(t, text, "needs%3A coverage")
+}
+
+func TestSpecVerifyCommandHumanOutputMatchesDocs(t *testing.T) {
+	report := &specverify.Report{
+		Summary: specverify.Summary{
+			TotalRequirements:     1,
+			UncoveredRequirements: 1,
+		},
+		Coverage: []specverify.RequirementCoverage{{
+			Requirement: specverify.Requirement{
+				ID:   "req-use-001",
+				Kind: specverify.RequirementUse,
+				Text: "summarize PR discussion",
+				Source: specverify.SourceSpan{
+					File:      "SKILL.md",
+					StartLine: 4,
+				},
+			},
+			CoveredBy: []specverify.CoveredBy{},
+		}},
+	}
+
+	var out bytes.Buffer
+	renderSpecVerifyHuman(&out, report)
+
+	text := out.String()
+	assert.Contains(t, text, `MISS req-use-001  "summarize PR discussion"  -> no task exercises this`)
+	assert.False(t, strings.ContainsAny(text, "✓✗→"))
 }
 
 func writeSpecVerifyFixture(t *testing.T, root string, includeNegative bool) (string, string) {

--- a/cmd/waza/cmd_spec_test.go
+++ b/cmd/waza/cmd_spec_test.go
@@ -59,6 +59,20 @@ func TestSpecVerifyCommandFailMode(t *testing.T) {
 	assert.Contains(t, err.Error(), "spec verify failed")
 }
 
+func TestSpecVerifyCommandGitHubActionsHonorsWarnFalse(t *testing.T) {
+	root := t.TempDir()
+	skillPath, evalPath := writeSpecVerifyFixture(t, root, false)
+
+	cmd := newSpecVerifyCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{skillPath, evalPath, "--format", "github-actions", "--warn=false"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, out.String())
+}
+
 func writeSpecVerifyFixture(t *testing.T, root string, includeNegative bool) (string, string) {
 	t.Helper()
 	skillPath := filepath.Join(root, "SKILL.md")

--- a/cmd/waza/cmd_spec_test.go
+++ b/cmd/waza/cmd_spec_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootCommandHasSpecSubcommand(t *testing.T) {
+	root := newRootCommand()
+	var found bool
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == "spec" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "root command should have spec subcommand")
+}
+
+func TestSpecVerifyCommandJSON(t *testing.T) {
+	root := t.TempDir()
+	skillPath, evalPath := writeSpecVerifyFixture(t, root, true)
+
+	cmd := newSpecVerifyCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{skillPath, evalPath, "--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &decoded))
+	summary, ok := decoded["summary"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(0), summary["uncovered_requirements"])
+}
+
+func TestSpecVerifyCommandFailMode(t *testing.T) {
+	root := t.TempDir()
+	skillPath, evalPath := writeSpecVerifyFixture(t, root, false)
+
+	cmd := newSpecVerifyCommand()
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{skillPath, evalPath, "--fail", "--threshold", "1"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	var testFailure *TestFailureError
+	assert.True(t, errors.As(err, &testFailure))
+	assert.Contains(t, err.Error(), "spec verify failed")
+}
+
+func writeSpecVerifyFixture(t *testing.T, root string, includeNegative bool) (string, string) {
+	t.Helper()
+	skillPath := filepath.Join(root, "SKILL.md")
+	evalPath := filepath.Join(root, "eval.yaml")
+	tasksDir := filepath.Join(root, "tasks")
+	require.NoError(t, os.MkdirAll(tasksDir, 0o755))
+
+	require.NoError(t, os.WriteFile(skillPath, []byte(`---
+name: pr-summarizer
+description: |
+  Summarize PR diffs.
+  USE FOR: summarize a PR diff.
+  DO NOT USE FOR: code review security PRs.
+---
+`), 0o644))
+	require.NoError(t, os.WriteFile(evalPath, []byte(`name: pr-summarizer-eval
+skill: pr-summarizer
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  parallel: false
+  executor: mock
+  model: mock
+graders:
+  - type: text
+    name: basic
+metrics:
+  - name: coverage
+    weight: 1
+    threshold: 1
+tasks:
+  - tasks/*.yaml
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "use.yaml"), []byte(`id: pr-summary-basic
+name: PR summary basic
+description: Summarize a PR diff.
+inputs:
+  prompt: Please summarize this PR diff.
+expected:
+  should_trigger: true
+`), 0o644))
+	if includeNegative {
+		require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "dont.yaml"), []byte(`id: security-review-negative
+name: Security review negative trigger
+description: Code review security PRs should not trigger this skill.
+inputs:
+  prompt: Please do code review security PRs.
+expected:
+  should_trigger: false
+`), 0o644))
+	}
+	return skillPath, evalPath
+}

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -69,6 +69,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newModelsCommand())
 	cmd.AddCommand(newQualityCommand())
 	cmd.AddCommand(newUpdateCommand())
+	cmd.AddCommand(newSpecCommand())
 
 	return cmd
 }

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -99,6 +99,7 @@ Cross-model testing and comprehensive metrics.
 | E3-07 | As a developer, I can run tasks in parallel | --parallel flag |
 | E3-08 | As a developer, I can filter to specific tasks | --task flag |
 | E3-09 | As a developer, I can reuse shared evals and graders from a registry | Registry design covers search/add/get UX, versioned refs, lockfile reproducibility, and safe plugin extensibility ([design](research/waza-eval-registry-design.md)) |
+| E3-10 | As a developer, I can verify eval coverage against SKILL.md requirements | `waza spec verify` maps description, trigger, anti-trigger, and parameter requirements to task coverage with CI-gateable output |
 
 ### Epic 4: Token Management (P1)
 

--- a/internal/specverify/coverage.go
+++ b/internal/specverify/coverage.go
@@ -70,6 +70,9 @@ func Verify(ctx context.Context, opts Options) (*Report, error) {
 		}
 		if len(rc.CoveredBy) == 0 && opts.Semantic && opts.Matcher != nil {
 			for _, task := range tasks {
+				if req.Kind == RequirementDont && !isNegativeTask(task) {
+					continue
+				}
 				ok, reason, err := opts.Matcher.Matches(ctx, req, task)
 				if err != nil {
 					return nil, err

--- a/internal/specverify/coverage.go
+++ b/internal/specverify/coverage.go
@@ -1,0 +1,375 @@
+package specverify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/microsoft/waza/internal/dataset"
+	"github.com/microsoft/waza/internal/models"
+	"gopkg.in/yaml.v3"
+)
+
+var wordRE = regexp.MustCompile(`[a-z0-9]+`)
+
+// SemanticMatcher can opt in to LLM-assisted coverage after deterministic matching.
+type SemanticMatcher interface {
+	Matches(ctx context.Context, req Requirement, task TaskRef) (bool, string, error)
+}
+
+// Options controls verification behavior.
+type Options struct {
+	SkillPath     string
+	EvalPath      string
+	Semantic      bool
+	JudgeModel    string
+	FailThreshold int
+	Matcher       SemanticMatcher
+}
+
+// Verify parses SKILL.md, loads eval.yaml tasks, and computes requirement coverage.
+func Verify(ctx context.Context, opts Options) (*Report, error) {
+	skillSpec, err := ParseSkillFile(opts.SkillPath)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, err := models.LoadEvalSpec(opts.EvalPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading eval spec: %w", err)
+	}
+
+	tasks, err := loadTaskRefs(spec, filepath.Dir(opts.EvalPath))
+	if err != nil {
+		return nil, err
+	}
+
+	report := &Report{
+		SkillPath:  opts.SkillPath,
+		EvalPath:   opts.EvalPath,
+		Semantic:   opts.Semantic,
+		JudgeModel: opts.JudgeModel,
+		Summary: Summary{
+			TotalRequirements: len(skillSpec.Requirements),
+			FailThreshold:     opts.FailThreshold,
+		},
+		Coverage: make([]RequirementCoverage, 0, len(skillSpec.Requirements)),
+	}
+
+	for _, req := range skillSpec.Requirements {
+		rc := RequirementCoverage{Requirement: req, CoveredBy: []CoveredBy{}}
+		for _, task := range tasks {
+			if ok, reason := deterministicMatch(req, task); ok {
+				rc.CoveredBy = append(rc.CoveredBy, coveredBy(task, "deterministic", reason))
+			}
+		}
+		if len(rc.CoveredBy) == 0 && opts.Semantic && opts.Matcher != nil {
+			for _, task := range tasks {
+				ok, reason, err := opts.Matcher.Matches(ctx, req, task)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					rc.CoveredBy = append(rc.CoveredBy, coveredBy(task, "semantic", reason))
+				}
+			}
+		}
+		if len(rc.CoveredBy) > 0 {
+			report.Summary.CoveredRequirements++
+		}
+		report.Coverage = append(report.Coverage, rc)
+	}
+
+	report.Summary.UncoveredRequirements = report.Summary.TotalRequirements - report.Summary.CoveredRequirements
+	return report, nil
+}
+
+func loadTaskRefs(spec *models.EvalSpec, specDir string) ([]TaskRef, error) {
+	if spec.TasksFrom != "" {
+		return loadTasksFromDataset(spec, specDir)
+	}
+
+	taskFiles, err := spec.ResolveTestFiles(specDir)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(taskFiles)
+	if len(taskFiles) == 0 {
+		return nil, fmt.Errorf("no task files matched patterns %v in %s", spec.Tasks, specDir)
+	}
+
+	tasks := make([]TaskRef, 0, len(taskFiles))
+	for _, path := range taskFiles {
+		tc, err := models.LoadTestCase(path)
+		if err != nil {
+			return nil, fmt.Errorf("loading task %s: %w", path, err)
+		}
+		if tc.Active != nil && !*tc.Active {
+			continue
+		}
+		tasks = append(tasks, taskRefFromTestCase(path, tc))
+	}
+	return tasks, nil
+}
+
+func loadTasksFromDataset(spec *models.EvalSpec, specDir string) ([]TaskRef, error) {
+	path := spec.TasksFrom
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(specDir, path)
+	}
+	if filepath.Ext(path) == ".csv" {
+		rows, err := loadCSVRows(path, spec.Range)
+		if err != nil {
+			return nil, fmt.Errorf("loading CSV dataset: %w", err)
+		}
+		tasks := make([]TaskRef, 0, len(rows))
+		for i, row := range rows {
+			tasks = append(tasks, taskRefFromCSVRow(path, i+1, row))
+		}
+		return tasks, nil
+	}
+
+	return nil, fmt.Errorf("spec verify supports YAML task files and CSV tasks_from datasets; unsupported tasks_from %q", spec.TasksFrom)
+}
+
+func loadCSVRows(path string, taskRange [2]int) ([]dataset.Row, error) {
+	if taskRange != [2]int{} {
+		if taskRange[0] <= 0 || taskRange[1] <= 0 {
+			return nil, fmt.Errorf("invalid range: both values must be > 0, got [%d, %d]", taskRange[0], taskRange[1])
+		}
+		if taskRange[0] > taskRange[1] {
+			return nil, fmt.Errorf("invalid range: start (%d) must be <= end (%d)", taskRange[0], taskRange[1])
+		}
+		return dataset.LoadCSVRange(path, taskRange[0], taskRange[1])
+	}
+	return dataset.LoadCSV(path)
+}
+
+func taskRefFromCSVRow(path string, rowNum int, row dataset.Row) TaskRef {
+	id := fmt.Sprintf("row-%d", rowNum)
+	if value := strings.TrimSpace(row["id"]); value != "" {
+		id = value
+	} else if value := strings.TrimSpace(row["name"]); value != "" {
+		id = value
+	}
+
+	name := fmt.Sprintf("row-%d", rowNum)
+	if value := strings.TrimSpace(row["name"]); value != "" {
+		name = value
+	}
+
+	keys := make([]string, 0, len(row))
+	for key := range row {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, key+": "+row[key])
+	}
+
+	return TaskRef{
+		ID:   id,
+		Name: name,
+		Path: fmt.Sprintf("%s#row-%d", path, rowNum),
+		Text: strings.Join(values, "\n"),
+	}
+}
+
+func taskRefFromTestCase(path string, tc *models.TestCase) TaskRef {
+	values := []string{
+		tc.TestID,
+		tc.DisplayName,
+		tc.Summary,
+		tc.Stimulus.Message,
+		tc.Stimulus.MessageFile,
+		tc.Stimulus.WorkDir,
+	}
+	values = append(values, tc.Tags...)
+	values = append(values, tc.Expectation.MustInclude...)
+	values = append(values, tc.Expectation.MustExclude...)
+	values = append(values, tc.Expectation.MayInclude...)
+	for _, outcome := range tc.Expectation.OutcomeSpecs {
+		values = append(values, outcome.Category, fmt.Sprint(outcome.Value), outcome.Predicate)
+	}
+	values = append(values, tc.Expectation.BehaviorRules.MustUseTool...)
+	values = append(values, tc.Expectation.BehaviorRules.ForbidTool...)
+	for key, value := range tc.Stimulus.Metadata {
+		values = append(values, key, fmt.Sprint(value))
+	}
+	for _, resource := range tc.Stimulus.Resources {
+		values = append(values, resource.Location, resource.Body)
+	}
+	for _, grader := range tc.Validators {
+		values = append(values, grader.Identifier, string(grader.Kind), grader.Rubric)
+		values = append(values, grader.Checks...)
+		values = append(values, graderParametersText(grader.Parameters))
+	}
+
+	return TaskRef{
+		ID:              fallbackTaskID(path, tc),
+		Name:            tc.DisplayName,
+		Path:            path,
+		Text:            strings.Join(values, "\n"),
+		ExpectedTrigger: tc.Expectation.ExpectedTrigger,
+		Metadata:        tc.Stimulus.Metadata,
+	}
+}
+
+func graderParametersText(params models.GraderParameters) string {
+	if params == nil {
+		return ""
+	}
+	data, err := yaml.Marshal(params)
+	if err != nil {
+		return fmt.Sprint(params)
+	}
+	return string(data)
+}
+
+func fallbackTaskID(path string, tc *models.TestCase) string {
+	if strings.TrimSpace(tc.TestID) != "" {
+		return strings.TrimSpace(tc.TestID)
+	}
+	if strings.TrimSpace(tc.DisplayName) != "" {
+		return strings.TrimSpace(tc.DisplayName)
+	}
+	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+}
+
+func deterministicMatch(req Requirement, task TaskRef) (bool, string) {
+	taskText := normalizeText(task.Text)
+	reqText := normalizeText(req.Text)
+	if reqText == "" || taskText == "" {
+		return false, ""
+	}
+
+	matched := strings.Contains(taskText, reqText)
+	reason := "task text contains requirement phrase"
+	if !matched && tokenCoverage(req.Text, taskText) {
+		matched = true
+		reason = "task text contains requirement keywords"
+	}
+	if !matched {
+		return false, ""
+	}
+	if req.Kind == RequirementDont && !isNegativeTask(task) {
+		return false, ""
+	}
+	return true, reason
+}
+
+func tokenCoverage(reqText, normalizedTask string) bool {
+	tokens := significantTokens(reqText)
+	if len(tokens) == 0 {
+		return false
+	}
+	matches := 0
+	for _, token := range tokens {
+		if taskContainsToken(normalizedTask, token) {
+			matches++
+		}
+	}
+	if len(tokens) <= 2 {
+		return matches == len(tokens)
+	}
+	return matches >= max(2, len(tokens)-1)
+}
+
+func taskContainsToken(normalizedTask, token string) bool {
+	if strings.Contains(normalizedTask, token) {
+		return true
+	}
+	if strings.HasSuffix(token, "s") && len(token) > 3 {
+		return strings.Contains(normalizedTask, strings.TrimSuffix(token, "s"))
+	}
+	return false
+}
+
+func significantTokens(text string) []string {
+	raw := wordRE.FindAllString(strings.ToLower(text), -1)
+	out := make([]string, 0, len(raw))
+	seen := map[string]bool{}
+	for _, token := range raw {
+		if len(token) < 3 || stopWords[token] || seen[token] {
+			continue
+		}
+		seen[token] = true
+		out = append(out, token)
+	}
+	return out
+}
+
+var stopWords = map[string]bool{
+	"the": true, "and": true, "for": true, "this": true, "that": true,
+	"with": true, "from": true, "when": true, "what": true, "does": true,
+	"use": true, "using": true, "into": true, "your": true, "you": true,
+	"new": true, "not": true,
+}
+
+func isNegativeTask(task TaskRef) bool {
+	if task.ExpectedTrigger != nil && !*task.ExpectedTrigger {
+		return true
+	}
+	text := normalizeText(task.Text)
+	for _, marker := range []string{"negative", "anti trigger", "should not trigger", "do not trigger", "forbidden skills"} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func coveredBy(task TaskRef, mode, reason string) CoveredBy {
+	return CoveredBy{
+		TaskID:   task.ID,
+		TaskName: task.Name,
+		TaskPath: task.Path,
+		Mode:     mode,
+		Reason:   reason,
+	}
+}
+
+func normalizeText(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case unicode.IsLetter(r), unicode.IsNumber(r):
+			b.WriteRune(r)
+		default:
+			b.WriteByte(' ')
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// ParseSemanticResponse accepts a compact JSON or plain yes/no judge response.
+func ParseSemanticResponse(raw string) (bool, string) {
+	var structured struct {
+		Covered bool   `json:"covered"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(extractJSON(raw)), &structured); err == nil {
+		return structured.Covered, strings.TrimSpace(structured.Reason)
+	}
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if strings.HasPrefix(normalized, "yes") || strings.Contains(normalized, `"covered":true`) {
+		return true, "semantic judge marked as covered"
+	}
+	return false, ""
+}
+
+func extractJSON(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	start := strings.Index(trimmed, "{")
+	end := strings.LastIndex(trimmed, "}")
+	if start >= 0 && end > start {
+		return trimmed[start : end+1]
+	}
+	return trimmed
+}

--- a/internal/specverify/coverage.go
+++ b/internal/specverify/coverage.go
@@ -199,7 +199,13 @@ func taskRefFromTestCase(path string, tc *models.TestCase) TaskRef {
 	}
 	values = append(values, tc.Expectation.BehaviorRules.MustUseTool...)
 	values = append(values, tc.Expectation.BehaviorRules.ForbidTool...)
-	for key, value := range tc.Stimulus.Metadata {
+	metadataKeys := make([]string, 0, len(tc.Stimulus.Metadata))
+	for key := range tc.Stimulus.Metadata {
+		metadataKeys = append(metadataKeys, key)
+	}
+	sort.Strings(metadataKeys)
+	for _, key := range metadataKeys {
+		value := tc.Stimulus.Metadata[key]
 		values = append(values, key, fmt.Sprint(value))
 	}
 	for _, resource := range tc.Stimulus.Resources {

--- a/internal/specverify/coverage_test.go
+++ b/internal/specverify/coverage_test.go
@@ -1,0 +1,152 @@
+package specverify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyComputesDeterministicCoverage(t *testing.T) {
+	root := t.TempDir()
+	skillPath := filepath.Join(root, "SKILL.md")
+	evalPath := filepath.Join(root, "eval.yaml")
+	tasksDir := filepath.Join(root, "tasks")
+	require.NoError(t, os.MkdirAll(tasksDir, 0o755))
+
+	writeFile(t, skillPath, `---
+name: pr-summarizer
+description: |
+  Summarize PR diffs.
+  USE FOR: summarize a PR diff.
+  DO NOT USE FOR: code review security PRs.
+---
+
+# PR Summarizer
+
+## Parameters
+- repository: GitHub repository URL
+`)
+	writeFile(t, evalPath, `name: pr-summarizer-eval
+skill: pr-summarizer
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  parallel: false
+  executor: mock
+  model: mock
+graders:
+  - type: text
+    name: basic
+metrics:
+  - name: coverage
+    weight: 1
+    threshold: 1
+tasks:
+  - tasks/*.yaml
+`)
+	writeFile(t, filepath.Join(tasksDir, "use.yaml"), `id: pr-summary-basic
+name: PR summary basic
+description: Summarize a PR diff for a GitHub repository.
+inputs:
+  prompt: Please summarize this PR diff for repository https://github.com/acme/app.
+expected:
+  should_trigger: true
+`)
+	writeFile(t, filepath.Join(tasksDir, "dont.yaml"), `id: security-review-negative
+name: Security review negative trigger
+description: Code review security PRs should not trigger this skill.
+inputs:
+  prompt: Please do code review security PRs.
+expected:
+  should_trigger: false
+`)
+
+	report, err := Verify(context.Background(), Options{
+		SkillPath:     skillPath,
+		EvalPath:      evalPath,
+		FailThreshold: 1,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, report.Summary.TotalRequirements)
+	assert.Equal(t, 4, report.Summary.CoveredRequirements)
+	assert.Equal(t, 0, report.Summary.UncoveredRequirements)
+
+	coverage := map[string]RequirementCoverage{}
+	for _, row := range report.Coverage {
+		coverage[row.Requirement.ID] = row
+	}
+	require.NotEmpty(t, coverage["req-use-001"].CoveredBy)
+	assert.Equal(t, "pr-summary-basic", coverage["req-use-001"].CoveredBy[0].TaskID)
+	require.NotEmpty(t, coverage["req-dont-001"].CoveredBy)
+	assert.Equal(t, "security-review-negative", coverage["req-dont-001"].CoveredBy[0].TaskID)
+}
+
+func TestParseSemanticResponse(t *testing.T) {
+	covered, reason := ParseSemanticResponse(`{"covered": true, "reason": "prompt matches"}`)
+	assert.True(t, covered)
+	assert.Equal(t, "prompt matches", reason)
+
+	covered, reason = ParseSemanticResponse("No")
+	assert.False(t, covered)
+	assert.Empty(t, reason)
+}
+
+func TestVerifyLoadsCSVTasksFromDataset(t *testing.T) {
+	root := t.TempDir()
+	skillPath := filepath.Join(root, "SKILL.md")
+	evalPath := filepath.Join(root, "eval.yaml")
+	csvPath := filepath.Join(root, "tasks.csv")
+
+	writeFile(t, skillPath, `---
+name: doc-writer
+description: |
+  Write docs.
+  USE FOR: write onboarding docs.
+---
+`)
+	writeFile(t, evalPath, `name: doc-writer-eval
+skill: doc-writer
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  parallel: false
+  executor: mock
+  model: mock
+graders:
+  - type: text
+    name: basic
+metrics:
+  - name: coverage
+    weight: 1
+    threshold: 1
+tasks_from: tasks.csv
+`)
+	writeFile(t, csvPath, "id,name,prompt\nonboarding-docs,Onboarding docs,Please write onboarding docs for the team\n")
+
+	report, err := Verify(context.Background(), Options{
+		SkillPath:     skillPath,
+		EvalPath:      evalPath,
+		FailThreshold: 1,
+	})
+	require.NoError(t, err)
+
+	coverage := map[string]RequirementCoverage{}
+	for _, row := range report.Coverage {
+		coverage[row.Requirement.ID] = row
+	}
+	require.NotEmpty(t, coverage["req-use-001"].CoveredBy)
+	assert.Equal(t, "onboarding-docs", coverage["req-use-001"].CoveredBy[0].TaskID)
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}

--- a/internal/specverify/coverage_test.go
+++ b/internal/specverify/coverage_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -95,6 +97,24 @@ func TestParseSemanticResponse(t *testing.T) {
 	covered, reason = ParseSemanticResponse("No")
 	assert.False(t, covered)
 	assert.Empty(t, reason)
+}
+
+func TestTaskRefFromTestCaseSortsMetadataKeys(t *testing.T) {
+	ref := taskRefFromTestCase("task.yaml", &models.TestCase{
+		TestID: "metadata-order",
+		Stimulus: models.TaskStimulus{
+			Metadata: map[string]any{
+				"zeta":  "last",
+				"alpha": "first",
+			},
+		},
+	})
+
+	alphaIndex := strings.Index(ref.Text, "alpha\nfirst")
+	zetaIndex := strings.Index(ref.Text, "zeta\nlast")
+	require.NotEqual(t, -1, alphaIndex)
+	require.NotEqual(t, -1, zetaIndex)
+	assert.Less(t, alphaIndex, zetaIndex)
 }
 
 func TestVerifyLoadsCSVTasksFromDataset(t *testing.T) {

--- a/internal/specverify/coverage_test.go
+++ b/internal/specverify/coverage_test.go
@@ -117,6 +117,68 @@ func TestTaskRefFromTestCaseSortsMetadataKeys(t *testing.T) {
 	assert.Less(t, alphaIndex, zetaIndex)
 }
 
+func TestSemanticDontRequirementOnlyConsidersNegativeTasks(t *testing.T) {
+	root := t.TempDir()
+	skillPath := filepath.Join(root, "SKILL.md")
+	evalPath := filepath.Join(root, "eval.yaml")
+	tasksDir := filepath.Join(root, "tasks")
+	require.NoError(t, os.MkdirAll(tasksDir, 0o755))
+
+	writeFile(t, skillPath, `---
+name: pr-summarizer
+description: |
+  Summarize PR diffs.
+  DO NOT USE FOR: code review security PRs.
+---
+`)
+	writeFile(t, evalPath, `name: pr-summarizer-eval
+skill: pr-summarizer
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  parallel: false
+  executor: mock
+  model: mock
+graders:
+  - type: text
+    name: basic
+metrics:
+  - name: coverage
+    weight: 1
+    threshold: 1
+tasks:
+  - tasks/*.yaml
+`)
+	writeFile(t, filepath.Join(tasksDir, "positive.yaml"), `id: positive-task
+name: Positive task
+description: Code review security PRs.
+inputs:
+  prompt: Please do code review security PRs.
+expected:
+  should_trigger: true
+`)
+
+	report, err := Verify(context.Background(), Options{
+		SkillPath:     skillPath,
+		EvalPath:      evalPath,
+		Semantic:      true,
+		FailThreshold: 1,
+		Matcher:       alwaysMatchSemanticMatcher{},
+	})
+	require.NoError(t, err)
+
+	var dont RequirementCoverage
+	for _, row := range report.Coverage {
+		if row.Requirement.ID == "req-dont-001" {
+			dont = row
+			break
+		}
+	}
+	require.Equal(t, "req-dont-001", dont.Requirement.ID)
+	assert.Empty(t, dont.CoveredBy)
+}
+
 func TestVerifyLoadsCSVTasksFromDataset(t *testing.T) {
 	root := t.TempDir()
 	skillPath := filepath.Join(root, "SKILL.md")
@@ -169,4 +231,10 @@ func writeFile(t *testing.T, path string, content string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+type alwaysMatchSemanticMatcher struct{}
+
+func (alwaysMatchSemanticMatcher) Matches(context.Context, Requirement, TaskRef) (bool, string, error) {
+	return true, "matched", nil
 }

--- a/internal/specverify/parse.go
+++ b/internal/specverify/parse.go
@@ -1,0 +1,378 @@
+package specverify
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/waza/internal/scaffold"
+	"github.com/microsoft/waza/internal/skill"
+	"gopkg.in/yaml.v3"
+)
+
+var parameterHeadingRE = regexp.MustCompile(`(?i)^#{1,6}\s+.*\b(parameters?|inputs?|arguments?)\b`)
+
+// ParseSkillFile deterministically extracts requirements from a SKILL.md file.
+func ParseSkillFile(path string) (*ParsedSkillSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading SKILL.md: %w", err)
+	}
+
+	var sk skill.Skill
+	if err := sk.UnmarshalText(data); err != nil {
+		return nil, fmt.Errorf("parsing SKILL.md: %w", err)
+	}
+	if strings.TrimSpace(sk.Frontmatter.Name) == "" {
+		sk.Frontmatter.Name = filepath.Base(filepath.Dir(path))
+	}
+
+	lines := splitLines(string(data))
+	requirements := make([]Requirement, 0)
+
+	description := strings.TrimSpace(sk.Frontmatter.Description)
+	if description != "" {
+		descSpan := descriptionSourceSpan(path, sk.FrontmatterNode, lines)
+		descriptionText := descriptionRequirementText(description)
+		if descriptionText != "" {
+			requirements = append(requirements, Requirement{
+				ID:     "req-description-001",
+				Kind:   RequirementDescription,
+				Text:   descriptionText,
+				Source: descSpan,
+			})
+		}
+
+		useFor, doNotUseFor := scaffold.ParseTriggerPhrases(description)
+		for i, p := range useFor {
+			text := strings.TrimSpace(p.Prompt)
+			if text == "" {
+				continue
+			}
+			requirements = append(requirements, Requirement{
+				ID:     fmt.Sprintf("req-use-%03d", i+1),
+				Kind:   RequirementUse,
+				Text:   text,
+				Source: findTextSpan(path, lines, descSpan, text),
+			})
+		}
+		for i, p := range doNotUseFor {
+			text := strings.TrimSpace(p.Prompt)
+			if text == "" {
+				continue
+			}
+			requirements = append(requirements, Requirement{
+				ID:     fmt.Sprintf("req-dont-%03d", i+1),
+				Kind:   RequirementDont,
+				Text:   text,
+				Source: findTextSpan(path, lines, descSpan, text),
+			})
+		}
+	}
+
+	params := parseFrontmatterParameters(path, sk.FrontmatterNode)
+	params = append(params, parseBodyParameters(path, sk.Body, frontmatterEndLine(lines))...)
+	for i, param := range params {
+		param.ID = fmt.Sprintf("req-param-%03d", i+1)
+		requirements = append(requirements, param)
+	}
+
+	return &ParsedSkillSpec{
+		SkillName:    strings.TrimSpace(sk.Frontmatter.Name),
+		SkillPath:    path,
+		Requirements: requirements,
+	}, nil
+}
+
+func parseFrontmatterParameters(path string, node *yaml.Node) []Requirement {
+	if node == nil {
+		return nil
+	}
+	mapping := yamlMapping(node)
+	if mapping == nil {
+		return nil
+	}
+
+	var params []Requirement
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := strings.ToLower(strings.TrimSpace(mapping.Content[i].Value))
+		if key != "parameters" && key != "params" && key != "inputs" {
+			continue
+		}
+		value := mapping.Content[i+1]
+		switch value.Kind {
+		case yaml.SequenceNode:
+			for _, item := range value.Content {
+				text := nodeText(item)
+				if text == "" {
+					continue
+				}
+				params = append(params, Requirement{
+					Kind:   RequirementParameter,
+					Text:   text,
+					Source: SourceSpan{File: path, StartLine: item.Line + 1, EndLine: item.Line + 1},
+				})
+			}
+		case yaml.MappingNode:
+			for j := 0; j+1 < len(value.Content); j += 2 {
+				text := strings.TrimSpace(value.Content[j].Value)
+				desc := nodeText(value.Content[j+1])
+				if desc != "" {
+					text += ": " + desc
+				}
+				params = append(params, Requirement{
+					Kind:   RequirementParameter,
+					Text:   text,
+					Source: SourceSpan{File: path, StartLine: value.Content[j].Line + 1, EndLine: value.Content[j+1].Line + 1},
+				})
+			}
+		case yaml.ScalarNode:
+			text := strings.TrimSpace(value.Value)
+			if text != "" {
+				params = append(params, Requirement{
+					Kind:   RequirementParameter,
+					Text:   text,
+					Source: SourceSpan{File: path, StartLine: value.Line + 1, EndLine: value.Line + 1},
+				})
+			}
+		}
+	}
+	return params
+}
+
+func parseBodyParameters(path, body string, bodyStartLine int) []Requirement {
+	lines := splitLines(body)
+	var params []Requirement
+
+	for i := 0; i < len(lines); i++ {
+		if !parameterHeadingRE.MatchString(strings.TrimSpace(lines[i])) {
+			continue
+		}
+		for j := i + 1; j < len(lines); j++ {
+			line := strings.TrimSpace(lines[j])
+			if line == "" {
+				continue
+			}
+			if strings.HasPrefix(line, "#") {
+				break
+			}
+			if reqText, ok := parseParameterLine(line); ok {
+				params = append(params, Requirement{
+					Kind: RequirementParameter,
+					Text: reqText,
+					Source: SourceSpan{
+						File:      path,
+						StartLine: bodyStartLine + j,
+						EndLine:   bodyStartLine + j,
+					},
+				})
+			}
+		}
+	}
+	return params
+}
+
+func parseParameterLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "|") && strings.HasSuffix(line, "|") {
+		cells := splitMarkdownTableRow(line)
+		if len(cells) < 2 || isMarkdownSeparatorRow(cells) {
+			return "", false
+		}
+		key := cleanParameterName(cells[0])
+		if key == "" || strings.EqualFold(key, "property") || strings.EqualFold(key, "parameter") || strings.EqualFold(key, "name") {
+			return "", false
+		}
+		return key + ": " + strings.TrimSpace(cells[1]), true
+	}
+
+	if strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") {
+		text := strings.TrimSpace(line[2:])
+		if key, rest, ok := strings.Cut(text, ":"); ok {
+			key = cleanParameterName(key)
+			rest = strings.TrimSpace(rest)
+			if key != "" && rest != "" {
+				return key + ": " + rest, true
+			}
+		}
+		if key, rest, ok := strings.Cut(text, " - "); ok {
+			key = cleanParameterName(key)
+			rest = strings.TrimSpace(rest)
+			if key != "" && rest != "" {
+				return key + ": " + rest, true
+			}
+		}
+		text = cleanParameterName(text)
+		if text != "" {
+			return text, true
+		}
+	}
+	return "", false
+}
+
+func splitMarkdownTableRow(line string) []string {
+	trimmed := strings.Trim(line, "|")
+	raw := strings.Split(trimmed, "|")
+	cells := make([]string, 0, len(raw))
+	for _, cell := range raw {
+		cells = append(cells, strings.TrimSpace(cell))
+	}
+	return cells
+}
+
+func isMarkdownSeparatorRow(cells []string) bool {
+	if len(cells) == 0 {
+		return false
+	}
+	for _, cell := range cells {
+		clean := strings.Trim(cell, ":- ")
+		if clean != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func cleanParameterName(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "`* ")
+	return s
+}
+
+func nodeText(node *yaml.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return strings.TrimSpace(node.Value)
+	case yaml.MappingNode:
+		parts := make([]string, 0, len(node.Content)/2)
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := strings.TrimSpace(node.Content[i].Value)
+			value := nodeText(node.Content[i+1])
+			if key != "" && value != "" {
+				parts = append(parts, key+": "+value)
+			}
+		}
+		return strings.Join(parts, ", ")
+	default:
+		return ""
+	}
+}
+
+func yamlMapping(node *yaml.Node) *yaml.Node {
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	return node
+}
+
+func descriptionSourceSpan(path string, node *yaml.Node, lines []string) SourceSpan {
+	mapping := yamlMapping(node)
+	if mapping != nil {
+		for i := 0; i+1 < len(mapping.Content); i += 2 {
+			if mapping.Content[i].Value == "description" {
+				start := mapping.Content[i].Line + 1
+				end := mapping.Content[i+1].Line + 1
+				if mapping.Content[i+1].Kind == yaml.ScalarNode && mapping.Content[i+1].Style == yaml.LiteralStyle {
+					end = blockScalarEndLine(lines, start)
+				}
+				return SourceSpan{File: path, StartLine: start, EndLine: end}
+			}
+		}
+	}
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "description:") {
+			return SourceSpan{File: path, StartLine: i + 1, EndLine: i + 1}
+		}
+	}
+	return SourceSpan{File: path, StartLine: 1, EndLine: 1}
+}
+
+func blockScalarEndLine(lines []string, start int) int {
+	end := start
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "---" {
+			break
+		}
+		if strings.TrimSpace(line) != "" && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			break
+		}
+		end = i + 1
+	}
+	return end
+}
+
+func findTextSpan(path string, lines []string, within SourceSpan, text string) SourceSpan {
+	needle := normalizeForSearch(text)
+	start := max(1, within.StartLine)
+	end := min(len(lines), max(within.EndLine, within.StartLine))
+	for i := start; i <= end; i++ {
+		if strings.Contains(normalizeForSearch(lines[i-1]), needle) {
+			return SourceSpan{File: path, StartLine: i, EndLine: i}
+		}
+	}
+	for i, line := range lines {
+		if strings.Contains(normalizeForSearch(line), needle) {
+			return SourceSpan{File: path, StartLine: i + 1, EndLine: i + 1}
+		}
+	}
+	return within
+}
+
+func frontmatterEndLine(lines []string) int {
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return 1
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return i + 1
+		}
+	}
+	return 1
+}
+
+func splitLines(s string) []string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.Split(s, "\n")
+}
+
+func singleLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func descriptionRequirementText(description string) string {
+	text := singleLine(description)
+	upper := strings.ToUpper(text)
+	end := len(text)
+	for _, label := range []string{"USE FOR:", "DO NOT USE FOR:", "INVOKES:", "FOR SINGLE OPERATIONS:"} {
+		if idx := strings.Index(upper, label); idx >= 0 && idx < end {
+			end = idx
+		}
+	}
+	return strings.TrimRight(strings.TrimSpace(text[:end]), ".")
+}
+
+func normalizeForSearch(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(s)), " ")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/specverify/parse_test.go
+++ b/internal/specverify/parse_test.go
@@ -1,0 +1,98 @@
+package specverify
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSkillFileExtractsRequirementsWithSpans(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SKILL.md")
+	content := `---
+name: pr-summarizer
+description: |
+  Summarize PR diffs.
+  USE FOR: summarize a PR diff, summarize PR discussion.
+  DO NOT USE FOR: code review security PRs (use security-review).
+---
+
+# PR Summarizer
+
+## Parameters
+- repository: GitHub repository URL
+- pr_number: Pull request number
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	spec, err := ParseSkillFile(path)
+	require.NoError(t, err)
+
+	byID := map[string]Requirement{}
+	for _, req := range spec.Requirements {
+		byID[req.ID] = req
+	}
+
+	assert.Equal(t, "pr-summarizer", spec.SkillName)
+	assert.Equal(t, "Summarize PR diffs", byID["req-description-001"].Text)
+	assert.Equal(t, RequirementUse, byID["req-use-001"].Kind)
+	assert.Equal(t, "summarize a PR diff", byID["req-use-001"].Text)
+	assert.Equal(t, 5, byID["req-use-001"].Source.StartLine)
+	assert.Equal(t, RequirementDont, byID["req-dont-001"].Kind)
+	assert.Equal(t, "code review security PRs", byID["req-dont-001"].Text)
+	assert.Equal(t, 6, byID["req-dont-001"].Source.StartLine)
+	assert.Equal(t, RequirementParameter, byID["req-param-001"].Kind)
+	assert.Equal(t, "repository: GitHub repository URL", byID["req-param-001"].Text)
+	assert.Equal(t, path, byID["req-param-001"].Source.File)
+	assert.Equal(t, 12, byID["req-param-001"].Source.StartLine)
+	assert.Equal(t, "pr_number: Pull request number", byID["req-param-002"].Text)
+}
+
+func TestParseSkillFileCleansBacktickParameterNames(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SKILL.md")
+	content := `---
+name: deployer
+description: Deploy applications.
+---
+
+## Parameters
+- ` + "`environment`" + `: Target deployment environment
+- ` + "`region`" + ` - Azure region
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	spec, err := ParseSkillFile(path)
+	require.NoError(t, err)
+
+	require.Len(t, spec.Requirements, 3)
+	assert.Equal(t, "environment: Target deployment environment", spec.Requirements[1].Text)
+	assert.Equal(t, "region: Azure region", spec.Requirements[2].Text)
+}
+
+func TestParseSkillFileExistingCorpus(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "..", "examples", "code-explainer", "SKILL.md"),
+		filepath.Join("..", "..", "skills", "waza", "SKILL.md"),
+		filepath.Join("..", "..", ".github", "skills", "azd-publish", "SKILL.md"),
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			if _, err := os.Stat(path); err != nil {
+				t.Skipf("corpus skill not present: %s", path)
+			}
+			spec, err := ParseSkillFile(path)
+			require.NoError(t, err)
+			require.NotEmpty(t, spec.Requirements)
+			for _, req := range spec.Requirements {
+				assert.NotEmpty(t, req.ID)
+				assert.NotEmpty(t, req.Text)
+				assert.Greater(t, req.Source.StartLine, 0)
+				assert.GreaterOrEqual(t, req.Source.EndLine, req.Source.StartLine)
+			}
+		})
+	}
+}

--- a/internal/specverify/semantic.go
+++ b/internal/specverify/semantic.go
@@ -1,0 +1,88 @@
+package specverify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/microsoft/waza/internal/execution"
+)
+
+// EngineSemanticMatcher uses the configured judge model to fill deterministic coverage gaps.
+type EngineSemanticMatcher struct {
+	Engine  execution.AgentEngine
+	ModelID string
+	Timeout time.Duration
+}
+
+// Matches asks the judge whether a task exercises a requirement.
+func (m *EngineSemanticMatcher) Matches(ctx context.Context, req Requirement, task TaskRef) (bool, string, error) {
+	if m.Engine == nil {
+		return false, "", fmt.Errorf("semantic matching requires an execution engine")
+	}
+	timeout := m.Timeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	judgeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	prompt := semanticPrompt(req, task)
+	resp, err := m.Engine.Execute(judgeCtx, &execution.ExecutionRequest{
+		ModelID:              m.ModelID,
+		Message:              prompt,
+		EphemeralSession:     true,
+		SkipWorkspaceCapture: true,
+	})
+	if err != nil {
+		return false, "", fmt.Errorf("semantic match for %s against task %s: %w", req.ID, task.ID, err)
+	}
+	if resp == nil {
+		return false, "", fmt.Errorf("semantic match for %s against task %s: empty judge response", req.ID, task.ID)
+	}
+	if !resp.Success {
+		msg := strings.TrimSpace(resp.ErrorMsg)
+		if msg == "" {
+			msg = "judge execution failed"
+		}
+		return false, "", fmt.Errorf("semantic match for %s against task %s: %s", req.ID, task.ID, msg)
+	}
+	covered, reason := ParseSemanticResponse(resp.FinalOutput)
+	return covered, reason, nil
+}
+
+func semanticPrompt(req Requirement, task TaskRef) string {
+	return fmt.Sprintf(`You are verifying whether a waza eval task exercises one SKILL.md requirement.
+
+Return only compact JSON:
+{"covered":true|false,"reason":"short reason"}
+
+Requirement:
+- id: %s
+- kind: %s
+- text: %q
+
+Task:
+- id: %s
+- name: %s
+- expected_trigger: %s
+- content:
+%s
+
+Rules:
+- "covered" is true only if the task prompt, metadata, expectations, or graders would exercise this requirement.
+- For kind "dont", covered is true only if the task is a negative trigger test.
+- Do not infer coverage from unrelated implementation details.
+`, req.ID, req.Kind, req.Text, task.ID, task.Name, expectedTriggerText(task.ExpectedTrigger), task.Text)
+}
+
+func expectedTriggerText(v *bool) string {
+	if v == nil {
+		return "unspecified"
+	}
+	if *v {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/specverify/types.go
+++ b/internal/specverify/types.go
@@ -1,0 +1,76 @@
+package specverify
+
+// RequirementKind identifies the part of SKILL.md a requirement came from.
+type RequirementKind string
+
+const (
+	RequirementDescription RequirementKind = "description"
+	RequirementUse         RequirementKind = "use"
+	RequirementDont        RequirementKind = "dont"
+	RequirementParameter   RequirementKind = "parameter"
+)
+
+// SourceSpan points back to the SKILL.md source lines for a parsed requirement.
+type SourceSpan struct {
+	File      string `json:"file"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+}
+
+// Requirement is a machine-readable SKILL.md promise.
+type Requirement struct {
+	ID     string          `json:"id"`
+	Kind   RequirementKind `json:"kind"`
+	Text   string          `json:"text"`
+	Source SourceSpan      `json:"source"`
+}
+
+// ParsedSkillSpec contains deterministic requirements extracted from SKILL.md.
+type ParsedSkillSpec struct {
+	SkillName    string        `json:"skill_name"`
+	SkillPath    string        `json:"skill_path"`
+	Requirements []Requirement `json:"requirements"`
+}
+
+// TaskRef captures the task fields needed for coverage reporting.
+type TaskRef struct {
+	ID              string         `json:"id"`
+	Name            string         `json:"name,omitempty"`
+	Path            string         `json:"path,omitempty"`
+	Text            string         `json:"-"`
+	ExpectedTrigger *bool          `json:"expected_trigger,omitempty"`
+	Metadata        map[string]any `json:"-"`
+}
+
+// CoveredBy describes one task that exercises a requirement.
+type CoveredBy struct {
+	TaskID   string `json:"task_id"`
+	TaskName string `json:"task_name,omitempty"`
+	TaskPath string `json:"task_path,omitempty"`
+	Mode     string `json:"mode"`
+	Reason   string `json:"reason"`
+}
+
+// RequirementCoverage reports task coverage for one requirement.
+type RequirementCoverage struct {
+	Requirement Requirement `json:"requirement"`
+	CoveredBy   []CoveredBy `json:"covered_by"`
+}
+
+// Summary captures aggregate verification results.
+type Summary struct {
+	TotalRequirements     int `json:"total_requirements"`
+	CoveredRequirements   int `json:"covered_requirements"`
+	UncoveredRequirements int `json:"uncovered_requirements"`
+	FailThreshold         int `json:"fail_threshold,omitempty"`
+}
+
+// Report is the full machine-readable output for spec verification.
+type Report struct {
+	SkillPath  string                `json:"skill_path"`
+	EvalPath   string                `json:"eval_path"`
+	Semantic   bool                  `json:"semantic"`
+	JudgeModel string                `json:"judge_model,omitempty"`
+	Summary    Summary               `json:"summary"`
+	Coverage   []RequirementCoverage `json:"coverage"`
+}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -43,6 +43,7 @@ export default defineConfig({
 						{ label: 'Writing Eval Specs', slug: 'guides/eval-yaml' },
 						{ label: 'Evaluating Custom Agents', slug: 'guides/custom-agents' },
 						{ label: 'Validators & Graders', slug: 'guides/graders' },
+						{ label: 'Spec Verification', slug: 'guides/spec-verify' },
 						{ label: 'Token Limits', slug: 'guides/token-limits' },
 						{ label: 'Web Dashboard', slug: 'guides/dashboard' },
 						{ label: 'Explore the Dashboard', slug: 'guides/dashboard-explore' },

--- a/site/src/content/docs/guides/ci-cd.mdx
+++ b/site/src/content/docs/guides/ci-cd.mdx
@@ -222,6 +222,19 @@ Use `waza tokens compare` to track token usage across PRs and fail if budgets ar
 
 This compares token counts between your main branch and current branch. Exit code is non-zero if any limit is exceeded with `--strict`.
 
+### Spec Coverage Checks
+
+Use `waza spec verify` to ensure eval tasks cover the `SKILL.md` description, `USE FOR` triggers, `DO NOT USE FOR` triggers, and parameter blocks. `--format github-actions` emits annotations on uncovered requirements, and `--fail` exits non-zero when uncovered requirements meet the threshold.
+
+```yaml
+- name: Verify SKILL.md eval coverage
+  run: |
+    waza spec verify skills/my-skill evals/my-skill/eval.yaml \
+      --fail \
+      --threshold 1 \
+      --format github-actions
+```
+
 ### Smart Path Filtering
 
 Run evaluations only when relevant files change:

--- a/site/src/content/docs/guides/spec-verify.mdx
+++ b/site/src/content/docs/guides/spec-verify.mdx
@@ -75,9 +75,9 @@ Example output:
 Spec Verification
 Coverage: 4/5 requirements covered (1 uncovered)
 
-✓ req-use-001  "summarize a PR diff"  → covered by tasks: [pr-summary-basic]
-✓ req-dont-001  "code review security PRs"  → covered by tasks: [security-review-negative]
-✗ req-use-002  "summarize PR discussion"  → no task exercises this
+OK req-use-001  "summarize a PR diff"  -> covered by tasks: [pr-summary-basic]
+OK req-dont-001  "code review security PRs"  -> covered by tasks: [security-review-negative]
+MISS req-use-002  "summarize PR discussion"  -> no task exercises this
 ```
 
 Add a task for `req-use-002`, or use `--semantic` if the task covers the requirement without sharing obvious keywords.

--- a/site/src/content/docs/guides/spec-verify.mdx
+++ b/site/src/content/docs/guides/spec-verify.mdx
@@ -1,0 +1,113 @@
+---
+title: Spec Verification
+description: Verify that eval tasks cover SKILL.md trigger and parameter requirements.
+---
+
+`waza spec verify` checks whether your eval suite exercises the promises made in `SKILL.md`. It is designed for agentic skills where routing quality depends on clear `USE FOR` and `DO NOT USE FOR` boundaries.
+
+## What gets verified
+
+The command parses `SKILL.md` deterministically and emits requirement IDs with source spans:
+
+| Requirement kind | Example ID | Source |
+|------------------|------------|--------|
+| Description | `req-description-001` | `description:` frontmatter |
+| Positive trigger | `req-use-001` | `USE FOR:` phrase |
+| Negative trigger | `req-dont-001` | `DO NOT USE FOR:` phrase |
+| Parameter | `req-param-001` | `parameters`, `inputs`, or `arguments` block |
+
+Deterministic matching runs first. Semantic matching is opt-in with `--semantic` and uses the configured judge model (`--judge-model`, `config.judge_model`, then `config.model`).
+
+## Worked example
+
+Given this skill description:
+
+```markdown
+---
+name: pr-summarizer
+description: |
+  Summarize PR diffs.
+  USE FOR: summarize a PR diff, summarize PR discussion.
+  DO NOT USE FOR: code review security PRs.
+---
+
+## Parameters
+- repository: GitHub repository URL
+- pr_number: Pull request number
+```
+
+And an eval with one positive and one negative task:
+
+```yaml
+tasks:
+  - tasks/*.yaml
+```
+
+```yaml
+# tasks/pr-summary-basic.yaml
+id: pr-summary-basic
+name: PR summary basic
+inputs:
+  prompt: Please summarize this PR diff for repository microsoft/waza.
+expected:
+  should_trigger: true
+```
+
+```yaml
+# tasks/security-review-negative.yaml
+id: security-review-negative
+name: Security review negative trigger
+inputs:
+  prompt: Please do code review security PRs.
+expected:
+  should_trigger: false
+```
+
+Run:
+
+```bash
+waza spec verify skills/pr-summarizer evals/pr-summarizer/eval.yaml
+```
+
+Example output:
+
+```text
+Spec Verification
+Coverage: 4/5 requirements covered (1 uncovered)
+
+✓ req-use-001  "summarize a PR diff"  → covered by tasks: [pr-summary-basic]
+✓ req-dont-001  "code review security PRs"  → covered by tasks: [security-review-negative]
+✗ req-use-002  "summarize PR discussion"  → no task exercises this
+```
+
+Add a task for `req-use-002`, or use `--semantic` if the task covers the requirement without sharing obvious keywords.
+
+## CI snippet
+
+Use `--format github-actions` to emit annotations on uncovered requirements. Add `--fail` to make uncovered requirements gate the workflow.
+
+```yaml
+name: Verify Skill Spec Coverage
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'evals/**'
+
+jobs:
+  spec-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install waza
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+      - name: Verify SKILL.md coverage
+        run: |
+          waza spec verify skills/pr-summarizer evals/pr-summarizer/eval.yaml \
+            --fail \
+            --threshold 1 \
+            --format github-actions
+```

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -479,6 +479,51 @@ waza gate --baseline baseline.json --current results.json \
 
 See the [CI/CD guide](/guides/ci-cd/#regression-gates-with-waza-gate) for full GitHub Actions and Azure DevOps snippets.
 
+## waza spec verify
+
+Verify that `eval.yaml` covers the executable contract in `SKILL.md`.
+
+```bash
+waza spec verify [skill-path] [eval.yaml]
+```
+
+The command parses the skill description, `USE FOR` triggers, `DO NOT USE FOR` triggers, and parameter blocks into deterministic requirement IDs with source spans. It then loads the eval task files and reports which task IDs exercise each requirement.
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `[skill-path]` | Path to `SKILL.md` or a skill directory |
+| `[eval.yaml]` | Path to the eval spec |
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--skill` | Path to `SKILL.md` or a skill directory |
+| `--eval` | Path to `eval.yaml` |
+| `--format` | Output format: `human` (default), `json`, `github-actions` |
+| `--warn` | Report uncovered requirements and exit 0 (default) |
+| `--fail` | Exit 1 when uncovered requirements are greater than or equal to `--threshold` |
+| `--threshold` | Uncovered requirement count threshold for `--fail` (default: `1`) |
+| `--semantic` | Opt in to LLM-assisted semantic matching after deterministic matching |
+| `--judge-model` | Judge model for `--semantic` (defaults to `config.judge_model`, then `config.model`) |
+
+### Examples
+
+```bash
+# Human-readable report
+waza spec verify skills/pr-summarizer evals/pr-summarizer/eval.yaml
+
+# Machine-readable report
+waza spec verify --skill skills/pr-summarizer --eval evals/pr-summarizer/eval.yaml --format json
+
+# GitHub Actions annotations and non-zero exit on any uncovered requirement
+waza spec verify skills/pr-summarizer evals/pr-summarizer/eval.yaml \
+  --fail \
+  --format github-actions
+```
+
 ## waza coverage
 
 Generate an eval coverage grid for discovered skills and custom agents.

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -503,7 +503,7 @@ The command parses the skill description, `USE FOR` triggers, `DO NOT USE FOR` t
 | `--skill` | Path to `SKILL.md` or a skill directory |
 | `--eval` | Path to `eval.yaml` |
 | `--format` | Output format: `human` (default), `json`, `github-actions` |
-| `--warn` | Report uncovered requirements and exit 0 (default) |
+| `--warn` | Report uncovered requirements and exit 0 (default); set false to suppress GitHub Actions warning annotations |
 | `--fail` | Exit 1 when uncovered requirements are greater than or equal to `--threshold` |
 | `--threshold` | Uncovered requirement count threshold for `--fail` (default: `1`) |
 | `--semantic` | Opt in to LLM-assisted semantic matching after deterministic matching |


### PR DESCRIPTION
## Summary
- Add `waza spec verify` with deterministic SKILL.md requirement extraction and eval task coverage reporting
- Add opt-in semantic matching, CI fail/warn modes, and human/JSON/GitHub Actions output
- Document the workflow in README, PRD, and site docs with CI examples

Closes #361

## Validation
- `/opt/homebrew/bin/go test ./...`
- `/opt/homebrew/bin/golangci-lint run`
- `cd site && PATH=/opt/homebrew/bin:$PATH npm run build`
- `/opt/homebrew/bin/go run ./cmd/waza spec verify examples/code-explainer/SKILL.md examples/code-explainer/eval.yaml --format human`
- `/opt/homebrew/bin/go run ./cmd/waza spec verify examples/code-explainer/SKILL.md examples/code-explainer/eval.yaml --format json`
- `/opt/homebrew/bin/go run ./cmd/waza spec verify examples/code-explainer/SKILL.md examples/code-explainer/eval.yaml --format github-actions --fail`