### PR TITLE
feat: add MCP server mocks (closes #363)

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,7 +943,7 @@ skills/                Example skills
 ```yaml
 name: my-eval
 skill: my-skill
-schemaVersion: "1.0"
+schemaVersion: "1.1"
 version: "1.0"
 
 config:
@@ -988,6 +988,26 @@ hooks:
       exit_codes: [0]
       error_on_fail: false
 
+mcp_mocks:
+  - name: github
+    tools:
+      list_issues:
+        input_schema:
+          type: object
+          required: [owner, repo]
+        responses:
+          - match:
+              owner: microsoft
+              repo: waza
+            return:
+              issues:
+                - number: 363
+                  title: MCP server mocks for hermetic eval
+          - match_regex:
+              repo: "^waza-.*"
+            return:
+              issues: []
+
 graders:
   - type: text
     name: pattern_check
@@ -1016,6 +1036,19 @@ tasks:
 ```
 
 `schemaVersion` uses `MAJOR.MINOR` format and defaults to `1.0` when omitted for backward compatibility. Readers allow same-major minor additions with warnings for unknown fields, but reject different majors with a hint to run `waza migrate <file>`.
+
+### MCP Mock Servers
+
+Use top-level `mcp_mocks` with `schemaVersion: "1.1"` for deterministic Copilot SDK evals that need MCP tools without live services. Waza launches each mock as a local stdio MCP server, so CI runs do not need network ports, external credentials, or real service state.
+
+```yaml
+schemaVersion: "1.1"
+mcp_mocks:
+  - name: github
+    fixtures: fixtures/mcp/github
+```
+
+Inline responses support exact full-argument matching (`match`), JSON Schema matching (`match_schema`), and per-field regex matching (`match_regex`). Unknown tools and unmatched calls fail loudly with an MCP tool error that names the missing fixture.
 
 ### Custom Input Variables
 

--- a/cmd/waza/cmd_mcp_mock.go
+++ b/cmd/waza/cmd_mcp_mock.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/microsoft/waza/internal/mcpmock"
+	"github.com/spf13/cobra"
+)
+
+func newMCPMockCommand() *cobra.Command {
+	var configBase64 string
+	cmd := &cobra.Command{
+		Use:    "__mcp-mock",
+		Short:  "Run an internal MCP mock server",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if configBase64 == "" {
+				return fmt.Errorf("--config-base64 is required")
+			}
+			data, err := base64.StdEncoding.DecodeString(configBase64)
+			if err != nil {
+				return fmt.Errorf("decode mock config: %w", err)
+			}
+			var cfg mcpmock.Config
+			if err := json.Unmarshal(data, &cfg); err != nil {
+				return fmt.Errorf("parse mock config: %w", err)
+			}
+			logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+			mcpmock.ServeStdio(context.Background(), &cfg, os.Stdin, os.Stdout, logger)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&configBase64, "config-base64", "", "base64-encoded MCP mock config")
+	return cmd
+}

--- a/cmd/waza/cmd_mcp_mock.go
+++ b/cmd/waza/cmd_mcp_mock.go
@@ -14,17 +14,15 @@ import (
 
 func newMCPMockCommand() *cobra.Command {
 	var configBase64 string
+	var configFile string
 	cmd := &cobra.Command{
 		Use:    "__mcp-mock",
 		Short:  "Run an internal MCP mock server",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if configBase64 == "" {
-				return fmt.Errorf("--config-base64 is required")
-			}
-			data, err := base64.StdEncoding.DecodeString(configBase64)
+			data, err := readMCPMockConfig(configBase64, configFile)
 			if err != nil {
-				return fmt.Errorf("decode mock config: %w", err)
+				return err
 			}
 			var cfg mcpmock.Config
 			if err := json.Unmarshal(data, &cfg); err != nil {
@@ -36,5 +34,28 @@ func newMCPMockCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&configBase64, "config-base64", "", "base64-encoded MCP mock config")
+	cmd.Flags().StringVar(&configFile, "config-file", "", "path to MCP mock config JSON")
 	return cmd
+}
+
+func readMCPMockConfig(configBase64, configFile string) ([]byte, error) {
+	switch {
+	case configFile != "":
+		data, err := os.ReadFile(configFile)
+		if err != nil {
+			return nil, fmt.Errorf("read mock config file: %w", err)
+		}
+		if err := os.Remove(configFile); err != nil {
+			return nil, fmt.Errorf("remove mock config file: %w", err)
+		}
+		return data, nil
+	case configBase64 != "":
+		data, err := base64.StdEncoding.DecodeString(configBase64)
+		if err != nil {
+			return nil, fmt.Errorf("decode mock config: %w", err)
+		}
+		return data, nil
+	default:
+		return nil, fmt.Errorf("--config-file or --config-base64 is required")
+	}
 }

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -71,6 +71,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newUpdateCommand())
 	cmd.AddCommand(newSpecCommand())
 	cmd.AddCommand(newMigrateCommand())
+	cmd.AddCommand(newMCPMockCommand())
 
 	return cmd
 }

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -47,6 +47,51 @@ config:
       args: ["-y", "@azure/mcp", "server", "start"]
 ```
 
+### Hermetic MCP Mock Servers
+
+For CI-safe Copilot SDK evals, prefer top-level `mcp_mocks` over live `config.mcp_servers`. Mock servers run as local stdio MCP servers managed by waza, so they do not bind ports, make network calls, or require service credentials. Because `mcp_mocks` is an additive eval schema field, set `schemaVersion: "1.1"`.
+
+```yaml
+name: github-triage
+skill: issue-triage
+schemaVersion: "1.1"
+version: "1.0"
+
+config:
+  trials_per_task: 1
+  executor: copilot-sdk
+  model: claude-sonnet-4.6
+  timeout_seconds: 300
+
+mcp_mocks:
+  - name: github
+    tools:
+      list_issues:
+        input_schema:
+          type: object
+          properties:
+            owner: { type: string }
+            repo: { type: string }
+          required: [owner, repo]
+        responses:
+          - match:
+              owner: microsoft
+              repo: waza
+            return:
+              issues:
+                - number: 363
+                  title: MCP server mocks for hermetic eval
+          - match_schema:
+              type: object
+              required: [owner, repo]
+            error: "No matching issue fixture"
+
+tasks:
+  - tasks/*.yaml
+```
+
+Responses are matched in order. Use `match` for exact full-argument fixtures, `match_schema` for JSON Schema matching, and `match_regex` for per-field regular expressions. Unknown tools or unmatched calls fail with a clear MCP tool error so missing fixtures do not pass silently.
+
 ### CLI Override
 
 You can override the model and runtime options at launch:

--- a/internal/copilotconfig/mcp.go
+++ b/internal/copilotconfig/mcp.go
@@ -1,10 +1,10 @@
 package copilotconfig
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -62,13 +62,14 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 	}
 
 	for _, mock := range mocks {
+		mockName := strings.TrimSpace(mock.Name)
+		if mockName != "" {
+			delete(result, mockName)
+		}
 		cfg, err := mcpmock.FromEvalConfig(mock, baseDir)
 		if err != nil {
 			warnf("Warning: mcp_mock %q config is invalid: %v, skipping\n", mock.Name, err)
 			continue
-		}
-		if _, exists := result[cfg.Name]; exists {
-			warnf("Warning: mcp_mock %q overrides an mcp_servers entry with the same name\n", cfg.Name)
 		}
 		stdio, err := mockServerConfig(*cfg)
 		if err != nil {
@@ -89,18 +90,61 @@ func mockServerConfig(cfg mcpmock.Config) (copilot.MCPStdioServerConfig, error) 
 	if err != nil {
 		return copilot.MCPStdioServerConfig{}, fmt.Errorf("marshal mock config: %w", err)
 	}
+	configFile, err := writeMockConfigFile(cfg.Name, data)
+	if err != nil {
+		return copilot.MCPStdioServerConfig{}, err
+	}
 	exe, err := os.Executable()
 	if err != nil {
 		return copilot.MCPStdioServerConfig{}, fmt.Errorf("resolve waza executable: %w", err)
 	}
-	encoded := base64.StdEncoding.EncodeToString(data)
 	return copilot.MCPStdioServerConfig{
 		Command: exe,
-		Args:    []string{"__mcp-mock", "--config-base64", encoded},
+		Args:    []string{"__mcp-mock", "--config-file", configFile},
 		Env: map[string]string{
 			"WAZA_NO_UPDATE_CHECK": "1",
 		},
 	}, nil
+}
+
+func writeMockConfigFile(name string, data []byte) (string, error) {
+	safeName := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-' || r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, name)
+	if safeName == "" {
+		safeName = "mock"
+	}
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("waza-mcp-mock-%s-*.json", safeName))
+	file, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
+	if err != nil {
+		return "", fmt.Errorf("create mock config file: %w", err)
+	}
+	if err := file.Chmod(0600); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return "", fmt.Errorf("secure mock config file: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return "", fmt.Errorf("write mock config file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(file.Name())
+		return "", fmt.Errorf("close mock config file: %w", err)
+	}
+	return file.Name(), nil
 }
 
 func decode(input map[string]any, output any) error {

--- a/internal/copilotconfig/mcp.go
+++ b/internal/copilotconfig/mcp.go
@@ -1,21 +1,38 @@
 package copilotconfig
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/microsoft/waza/internal/mcpmock"
+	"github.com/microsoft/waza/internal/models"
 )
 
 // ConvertMCPServers converts eval YAML mcp_servers entries into Copilot SDK MCP
 // configs. Invalid entries are skipped after emitting a warning through warnf.
 func ConvertMCPServers(serverConfigs map[string]any, warnf func(string, ...any)) map[string]copilot.MCPServerConfig {
+	return ConvertMCPServersWithMocks(serverConfigs, nil, "", warnf)
+}
+
+// ConvertMCPServersWithMocks converts eval YAML mcp_servers entries and
+// mcp_mocks entries into Copilot SDK MCP configs. Mock servers are exposed as
+// hermetic stdio MCP servers backed by this waza binary.
+func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCPMockConfig, baseDir string, warnf func(string, ...any)) map[string]copilot.MCPServerConfig {
+	if warnf == nil {
+		warnf = func(string, ...any) {}
+	}
 	if len(serverConfigs) == 0 {
-		return nil
+		if len(mocks) == 0 {
+			return nil
+		}
 	}
 
-	result := make(map[string]copilot.MCPServerConfig, len(serverConfigs))
+	result := make(map[string]copilot.MCPServerConfig, len(serverConfigs)+len(mocks))
 	for name, cfg := range serverConfigs {
 		cfgMap, ok := cfg.(map[string]any)
 		if !ok {
@@ -44,7 +61,46 @@ func ConvertMCPServers(serverConfigs map[string]any, warnf func(string, ...any))
 		}
 	}
 
+	for _, mock := range mocks {
+		cfg, err := mcpmock.FromEvalConfig(mock, baseDir)
+		if err != nil {
+			warnf("Warning: mcp_mock %q config is invalid: %v, skipping\n", mock.Name, err)
+			continue
+		}
+		if _, exists := result[cfg.Name]; exists {
+			warnf("Warning: mcp_mock %q overrides an mcp_servers entry with the same name\n", cfg.Name)
+		}
+		stdio, err := mockServerConfig(*cfg)
+		if err != nil {
+			warnf("Warning: mcp_mock %q could not be configured: %v, skipping\n", cfg.Name, err)
+			continue
+		}
+		result[cfg.Name] = stdio
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
 	return result
+}
+
+func mockServerConfig(cfg mcpmock.Config) (copilot.MCPStdioServerConfig, error) {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return copilot.MCPStdioServerConfig{}, fmt.Errorf("marshal mock config: %w", err)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return copilot.MCPStdioServerConfig{}, fmt.Errorf("resolve waza executable: %w", err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+	return copilot.MCPStdioServerConfig{
+		Command: exe,
+		Args:    []string{"__mcp-mock", "--config-base64", encoded},
+		Env: map[string]string{
+			"WAZA_NO_UPDATE_CHECK": "1",
+		},
+	}, nil
 }
 
 func decode(input map[string]any, output any) error {

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -1,0 +1,59 @@
+package copilotconfig
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/mcpmock"
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertMCPServersWithMocks_AddsHermeticStdioServer(t *testing.T) {
+	var warnings []string
+	servers := ConvertMCPServersWithMocks(nil, []models.MCPMockConfig{{
+		Name: "github",
+		Tools: map[string]models.MCPMockTool{
+			"list_issues": {
+				Responses: []models.MCPMockResponse{{Match: map[string]any{"owner": "octocat"}, Return: map[string]any{"issues": []any{}}}},
+			},
+		},
+	}}, t.TempDir(), func(format string, args ...any) {
+		warnings = append(warnings, fmtString(format, args...))
+	})
+
+	require.Empty(t, warnings)
+	require.Contains(t, servers, "github")
+	stdio, ok := servers["github"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.NotEmpty(t, stdio.Command)
+	require.Equal(t, "1", stdio.Env["WAZA_NO_UPDATE_CHECK"])
+	require.Len(t, stdio.Args, 3)
+	require.Equal(t, "__mcp-mock", stdio.Args[0])
+	require.Equal(t, "--config-base64", stdio.Args[1])
+
+	data, err := base64.StdEncoding.DecodeString(stdio.Args[2])
+	require.NoError(t, err)
+	var cfg mcpmock.Config
+	require.NoError(t, json.Unmarshal(data, &cfg))
+	require.Equal(t, "github", cfg.Name)
+	require.Contains(t, cfg.Tools, "list_issues")
+}
+
+func TestConvertMCPServersWithMocks_PreservesRegularServers(t *testing.T) {
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"regular": map[string]any{"type": "stdio", "command": "echo"},
+	}, nil, "", nil)
+
+	require.Contains(t, servers, "regular")
+	_, ok := servers["regular"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+}
+
+func fmtString(format string, args ...any) string {
+	return strings.TrimSpace(fmt.Sprintf(format, args...))
+}

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -1,9 +1,9 @@
 package copilotconfig
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -34,10 +34,11 @@ func TestConvertMCPServersWithMocks_AddsHermeticStdioServer(t *testing.T) {
 	require.Equal(t, "1", stdio.Env["WAZA_NO_UPDATE_CHECK"])
 	require.Len(t, stdio.Args, 3)
 	require.Equal(t, "__mcp-mock", stdio.Args[0])
-	require.Equal(t, "--config-base64", stdio.Args[1])
+	require.Equal(t, "--config-file", stdio.Args[1])
 
-	data, err := base64.StdEncoding.DecodeString(stdio.Args[2])
+	data, err := os.ReadFile(stdio.Args[2])
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(stdio.Args[2]) })
 	var cfg mcpmock.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
 	require.Equal(t, "github", cfg.Name)
@@ -52,6 +53,21 @@ func TestConvertMCPServersWithMocks_PreservesRegularServers(t *testing.T) {
 	require.Contains(t, servers, "regular")
 	_, ok := servers["regular"].(copilot.MCPStdioServerConfig)
 	require.True(t, ok)
+}
+
+func TestConvertMCPServersWithMocks_InvalidMockDisablesLiveServerFallback(t *testing.T) {
+	var warnings []string
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"github": map[string]any{"type": "stdio", "command": "echo"},
+	}, []models.MCPMockConfig{{
+		Name:     " github ",
+		Fixtures: "missing",
+	}}, t.TempDir(), func(format string, args ...any) {
+		warnings = append(warnings, fmtString(format, args...))
+	})
+
+	require.NotEmpty(t, warnings)
+	require.NotContains(t, servers, "github")
 }
 
 func fmtString(format string, args ...any) string {

--- a/internal/mcpmock/config.go
+++ b/internal/mcpmock/config.go
@@ -1,0 +1,135 @@
+package mcpmock
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/microsoft/waza/internal/models"
+)
+
+// Config is the fully resolved configuration for one deterministic MCP mock server.
+type Config struct {
+	Name  string          `json:"name"`
+	Tools map[string]Tool `json:"tools"`
+}
+
+// Tool defines one mocked MCP tool.
+type Tool struct {
+	Description string     `json:"description,omitempty"`
+	InputSchema any        `json:"input_schema,omitempty"`
+	Responses   []Response `json:"responses,omitempty"`
+}
+
+// Response defines one fixture response and its matching rules.
+type Response struct {
+	Match       map[string]any    `json:"match,omitempty"`
+	MatchSchema map[string]any    `json:"match_schema,omitempty"`
+	MatchRegex  map[string]string `json:"match_regex,omitempty"`
+	Return      any               `json:"return,omitempty"`
+	Error       string            `json:"error,omitempty"`
+}
+
+// FromEvalConfig resolves an eval.yaml mcp_mocks entry into a mock server config.
+func FromEvalConfig(mock models.MCPMockConfig, baseDir string) (*Config, error) {
+	name := strings.TrimSpace(mock.Name)
+	if name == "" {
+		return nil, fmt.Errorf("mcp_mocks entry missing name")
+	}
+
+	cfg := &Config{Name: name, Tools: make(map[string]Tool)}
+	if mock.Fixtures != "" {
+		fixtureDir := mock.Fixtures
+		if !filepath.IsAbs(fixtureDir) {
+			fixtureDir = filepath.Join(baseDir, fixtureDir)
+		}
+		if err := loadFixtureDir(cfg, fixtureDir); err != nil {
+			return nil, fmt.Errorf("mcp mock %q fixtures: %w", name, err)
+		}
+	}
+
+	for toolName, tool := range mock.Tools {
+		cfg.Tools[toolName] = Tool{
+			Description: tool.Description,
+			InputSchema: tool.InputSchema,
+			Responses:   convertResponses(tool.Responses),
+		}
+	}
+
+	if len(cfg.Tools) == 0 {
+		return nil, fmt.Errorf("mcp mock %q must define at least one tool via tools or fixtures", name)
+	}
+	for toolName, tool := range cfg.Tools {
+		if len(tool.Responses) == 0 {
+			return nil, fmt.Errorf("mcp mock %q tool %q must define at least one response", name, toolName)
+		}
+	}
+
+	return cfg, nil
+}
+
+func loadFixtureDir(cfg *Config, dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%q is not a directory", dir)
+	}
+
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var bundle struct {
+			Tools map[string]Tool `json:"tools"`
+		}
+		if err := json.Unmarshal(data, &bundle); err == nil && len(bundle.Tools) > 0 {
+			for name, tool := range bundle.Tools {
+				cfg.Tools[name] = tool
+			}
+			return nil
+		}
+
+		var tool Tool
+		if err := json.Unmarshal(data, &tool); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		cfg.Tools[name] = tool
+		return nil
+	})
+}
+
+func convertResponses(in []models.MCPMockResponse) []Response {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Response, 0, len(in))
+	for _, r := range in {
+		out = append(out, Response{
+			Match:       r.Match,
+			MatchSchema: r.MatchSchema,
+			MatchRegex:  r.MatchRegex,
+			Return:      r.Return,
+			Error:       r.Error,
+		})
+	}
+	return out
+}

--- a/internal/mcpmock/config.go
+++ b/internal/mcpmock/config.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/microsoft/waza/internal/models"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 // Config is the fully resolved configuration for one deterministic MCP mock server.
@@ -64,6 +66,11 @@ func FromEvalConfig(mock models.MCPMockConfig, baseDir string) (*Config, error) 
 	for toolName, tool := range cfg.Tools {
 		if len(tool.Responses) == 0 {
 			return nil, fmt.Errorf("mcp mock %q tool %q must define at least one response", name, toolName)
+		}
+		for i, response := range tool.Responses {
+			if err := validateResponse(response); err != nil {
+				return nil, fmt.Errorf("mcp mock %q tool %q response %d: %w", name, toolName, i, err)
+			}
 		}
 	}
 
@@ -132,4 +139,22 @@ func convertResponses(in []models.MCPMockResponse) []Response {
 		})
 	}
 	return out
+}
+
+func validateResponse(response Response) error {
+	for field, pattern := range response.MatchRegex {
+		if _, err := regexp.Compile(pattern); err != nil {
+			return fmt.Errorf("match_regex field %q has invalid regex %q: %w", field, pattern, err)
+		}
+	}
+	if len(response.MatchSchema) > 0 {
+		compiler := jsonschema.NewCompiler()
+		if err := compiler.AddResource("memory://mcp-mock-schema.json", response.MatchSchema); err != nil {
+			return fmt.Errorf("match_schema is invalid: %w", err)
+		}
+		if _, err := compiler.Compile("memory://mcp-mock-schema.json"); err != nil {
+			return fmt.Errorf("match_schema is invalid: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/mcpmock/server.go
+++ b/internal/mcpmock/server.go
@@ -1,0 +1,219 @@
+package mcpmock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"regexp"
+	"sort"
+
+	"github.com/microsoft/waza/internal/jsonrpc"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const protocolVersion = "2024-11-05"
+
+type Server struct {
+	cfg    *Config
+	logger *slog.Logger
+}
+
+func NewServer(cfg *Config, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Server{cfg: cfg, logger: logger}
+}
+
+func (s *Server) HandleRequest(_ context.Context, req *jsonrpc.Request) *jsonrpc.Response {
+	switch req.Method {
+	case "initialize":
+		return &jsonrpc.Response{
+			JSONRPC: "2.0",
+			Result: map[string]any{
+				"protocolVersion": protocolVersion,
+				"capabilities": map[string]any{
+					"tools": map[string]any{},
+				},
+				"serverInfo": map[string]string{
+					"name":    s.cfg.Name,
+					"version": "0.0.0-mock",
+				},
+			},
+			ID: req.ID,
+		}
+	case "notifications/initialized":
+		return nil
+	case "tools/list":
+		return &jsonrpc.Response{JSONRPC: "2.0", Result: map[string]any{"tools": s.toolsList()}, ID: req.ID}
+	case "tools/call":
+		return s.handleToolsCall(req)
+	default:
+		return &jsonrpc.Response{JSONRPC: "2.0", Error: jsonrpc.ErrMethodNotFound(req.Method), ID: req.ID}
+	}
+}
+
+func (s *Server) toolsList() []map[string]any {
+	names := make([]string, 0, len(s.cfg.Tools))
+	for name := range s.cfg.Tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	tools := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		tool := s.cfg.Tools[name]
+		inputSchema := tool.InputSchema
+		if inputSchema == nil {
+			inputSchema = map[string]any{"type": "object"}
+		}
+		tools = append(tools, map[string]any{
+			"name":        name,
+			"description": tool.Description,
+			"inputSchema": inputSchema,
+		})
+	}
+	return tools
+}
+
+type toolsCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+func (s *Server) handleToolsCall(req *jsonrpc.Request) *jsonrpc.Response {
+	var params toolsCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return &jsonrpc.Response{JSONRPC: "2.0", Error: jsonrpc.ErrInvalidParams(err.Error()), ID: req.ID}
+	}
+
+	var args map[string]any
+	if len(params.Arguments) == 0 || string(params.Arguments) == "null" {
+		args = map[string]any{}
+	} else if err := json.Unmarshal(params.Arguments, &args); err != nil {
+		return &jsonrpc.Response{JSONRPC: "2.0", Error: jsonrpc.ErrInvalidParams("arguments must be a JSON object"), ID: req.ID}
+	}
+
+	result, err := s.call(params.Name, args)
+	callResult := map[string]any{
+		"content": []map[string]string{{"type": "text", "text": result}},
+	}
+	if err != nil {
+		callResult["content"] = []map[string]string{{"type": "text", "text": err.Error()}}
+		callResult["isError"] = true
+	}
+	return &jsonrpc.Response{JSONRPC: "2.0", Result: callResult, ID: req.ID}
+}
+
+func (s *Server) call(toolName string, args map[string]any) (string, error) {
+	tool, ok := s.cfg.Tools[toolName]
+	if !ok {
+		return "", fmt.Errorf("mcp mock %q: unknown tool %q; add a fixture for this tool", s.cfg.Name, toolName)
+	}
+	for _, response := range tool.Responses {
+		if response.matches(args) {
+			if response.Error != "" {
+				return "", fmt.Errorf("mcp mock %q tool %q fixture error: %s", s.cfg.Name, toolName, response.Error)
+			}
+			data, err := json.Marshal(response.Return)
+			if err != nil {
+				return "", fmt.Errorf("mcp mock %q tool %q: marshal response: %w", s.cfg.Name, toolName, err)
+			}
+			return string(data), nil
+		}
+	}
+
+	data, _ := json.Marshal(args)
+	return "", fmt.Errorf("mcp mock %q: unmatched tool call %q with arguments %s; add a matching fixture response", s.cfg.Name, toolName, string(data))
+}
+
+func (r Response) matches(args map[string]any) bool {
+	if len(r.Match) == 0 && len(r.MatchSchema) == 0 && len(r.MatchRegex) == 0 {
+		return true
+	}
+	if len(r.Match) > 0 && !exactMatch(r.Match, args) {
+		return false
+	}
+	if len(r.MatchRegex) > 0 && !regexMatch(r.MatchRegex, args) {
+		return false
+	}
+	if len(r.MatchSchema) > 0 && !schemaMatch(r.MatchSchema, args) {
+		return false
+	}
+	return true
+}
+
+func exactMatch(want map[string]any, got map[string]any) bool {
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		return false
+	}
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(wantJSON, gotJSON)
+}
+
+func regexMatch(patterns map[string]string, args map[string]any) bool {
+	for field, pattern := range patterns {
+		value, ok := args[field]
+		if !ok {
+			return false
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return false
+		}
+		if !re.MatchString(fmt.Sprint(value)) {
+			return false
+		}
+	}
+	return true
+}
+
+func schemaMatch(schemaDoc map[string]any, args map[string]any) bool {
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("memory://mcp-mock-schema.json", schemaDoc); err != nil {
+		return false
+	}
+	schema, err := compiler.Compile("memory://mcp-mock-schema.json")
+	if err != nil {
+		return false
+	}
+	return schema.Validate(args) == nil
+}
+
+func ServeStdio(ctx context.Context, cfg *Config, r io.Reader, w io.Writer, logger *slog.Logger) {
+	srv := NewServer(cfg, logger)
+	transport := jsonrpc.NewTransport(r, w)
+	for {
+		req, rawJSON, err := transport.ReadRequest()
+		if err != nil {
+			if err != io.EOF {
+				logger.Debug("mcp mock read error", "error", err)
+			}
+			return
+		}
+		resp := srv.HandleRequest(ctx, req)
+		if resp == nil || !hasIDField(rawJSON) {
+			continue
+		}
+		if err := transport.WriteResponse(resp); err != nil {
+			logger.Debug("mcp mock write error", "error", err)
+			return
+		}
+	}
+}
+
+func hasIDField(raw []byte) bool {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return false
+	}
+	_, exists := obj["id"]
+	return exists
+}

--- a/internal/mcpmock/server_test.go
+++ b/internal/mcpmock/server_test.go
@@ -28,6 +28,28 @@ func TestFromEvalConfig_LoadsFixtureDirectory(t *testing.T) {
 	require.Equal(t, "List issues", cfg.Tools["list_issues"].Description)
 }
 
+func TestFromEvalConfig_RejectsInvalidMatchers(t *testing.T) {
+	_, err := FromEvalConfig(models.MCPMockConfig{
+		Name: "github",
+		Tools: map[string]models.MCPMockTool{
+			"list_issues": {
+				Responses: []models.MCPMockResponse{{MatchRegex: map[string]string{"owner": "["}, Return: map[string]any{"issues": []any{}}}},
+			},
+		},
+	}, "")
+	require.ErrorContains(t, err, "invalid regex")
+
+	_, err = FromEvalConfig(models.MCPMockConfig{
+		Name: "github",
+		Tools: map[string]models.MCPMockTool{
+			"list_issues": {
+				Responses: []models.MCPMockResponse{{MatchSchema: map[string]any{"type": 42}, Return: map[string]any{"issues": []any{}}}},
+			},
+		},
+	}, "")
+	require.ErrorContains(t, err, "match_schema is invalid")
+}
+
 func TestServerToolsCallMatchesExactSchemaAndRegex(t *testing.T) {
 	srv := NewServer(&Config{
 		Name: "github",

--- a/internal/mcpmock/server_test.go
+++ b/internal/mcpmock/server_test.go
@@ -1,0 +1,137 @@
+package mcpmock
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/waza/internal/jsonrpc"
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromEvalConfig_LoadsFixtureDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, osWriteFile(filepath.Join(dir, "list_issues.json"), `{
+		"description": "List issues",
+		"responses": [
+			{"match": {"owner": "octocat"}, "return": {"issues": [{"number": 1}]}}
+		]
+	}`))
+
+	cfg, err := FromEvalConfig(models.MCPMockConfig{Name: "github", Fixtures: dir}, "")
+	require.NoError(t, err)
+	require.Contains(t, cfg.Tools, "list_issues")
+	require.Equal(t, "List issues", cfg.Tools["list_issues"].Description)
+}
+
+func TestServerToolsCallMatchesExactSchemaAndRegex(t *testing.T) {
+	srv := NewServer(&Config{
+		Name: "github",
+		Tools: map[string]Tool{
+			"list_issues": {
+				Responses: []Response{
+					{Match: map[string]any{"owner": "octocat"}, Return: map[string]any{"source": "exact"}},
+					{MatchRegex: map[string]string{"owner": "^micro"}, Return: map[string]any{"source": "regex"}},
+					{MatchSchema: map[string]any{
+						"type":     "object",
+						"required": []any{"repo"},
+						"properties": map[string]any{
+							"repo": map[string]any{"const": "waza"},
+						},
+					}, Return: map[string]any{"source": "schema"}},
+				},
+			},
+		},
+	}, slog.Default())
+
+	requireToolJSON(t, srv, "list_issues", map[string]any{"owner": "octocat"}, `"source":"exact"`)
+	requireToolJSON(t, srv, "list_issues", map[string]any{"owner": "microsoft"}, `"source":"regex"`)
+	requireToolJSON(t, srv, "list_issues", map[string]any{"repo": "waza"}, `"source":"schema"`)
+}
+
+func TestServerUnknownAndUnmatchedCallsReturnMCPErrorResult(t *testing.T) {
+	srv := NewServer(&Config{
+		Name: "github",
+		Tools: map[string]Tool{
+			"list_issues": {Responses: []Response{{Match: map[string]any{"owner": "octocat"}, Return: map[string]any{"ok": true}}}},
+		},
+	}, slog.Default())
+
+	requireToolError(t, srv, "missing", map[string]any{}, `unknown tool "missing"`)
+	requireToolError(t, srv, "list_issues", map[string]any{"owner": "microsoft"}, `unmatched tool call "list_issues"`)
+}
+
+func TestToolsListIncludesConfiguredSchemas(t *testing.T) {
+	srv := NewServer(&Config{
+		Name: "github",
+		Tools: map[string]Tool{
+			"list_issues": {
+				Description: "List issues",
+				InputSchema: map[string]any{
+					"type": "object",
+				},
+				Responses: []Response{{Return: map[string]any{"ok": true}}},
+			},
+		},
+	}, slog.Default())
+
+	req := &jsonrpc.Request{JSONRPC: "2.0", Method: "tools/list", ID: json.RawMessage(`1`)}
+	resp := srv.HandleRequest(context.Background(), req)
+	require.Nil(t, resp.Error)
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"name":"list_issues"`)
+	require.Contains(t, string(data), `"description":"List issues"`)
+	require.Contains(t, string(data), `"inputSchema"`)
+}
+
+func requireToolJSON(t *testing.T, srv *Server, name string, args map[string]any, want string) {
+	t.Helper()
+	result := toolCall(t, srv, name, args)
+	require.False(t, result.IsError, "tool returned error: %v", result.Content)
+	require.Contains(t, result.Content[0].Text, want)
+}
+
+func requireToolError(t *testing.T, srv *Server, name string, args map[string]any, want string) {
+	t.Helper()
+	result := toolCall(t, srv, name, args)
+	require.True(t, result.IsError, "expected tool error")
+	require.Contains(t, result.Content[0].Text, want)
+}
+
+type callResult struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	IsError bool `json:"isError"`
+}
+
+func toolCall(t *testing.T, srv *Server, name string, args map[string]any) callResult {
+	t.Helper()
+	argsJSON, err := json.Marshal(args)
+	require.NoError(t, err)
+	params, err := json.Marshal(map[string]any{"name": name, "arguments": json.RawMessage(argsJSON)})
+	require.NoError(t, err)
+	resp := srv.HandleRequest(context.Background(), &jsonrpc.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  params,
+		ID:      json.RawMessage(`1`),
+	})
+	require.Nil(t, resp.Error)
+	data, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result callResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	require.Len(t, result.Content, 1)
+	return result
+}
+
+func osWriteFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -372,13 +372,14 @@ func (s *EvalSpec) Validate() error {
 		}
 		seen := make(map[string]bool, len(s.MCPMocks))
 		for i, mock := range s.MCPMocks {
-			if strings.TrimSpace(mock.Name) == "" {
+			name := strings.TrimSpace(mock.Name)
+			if name == "" {
 				return fmt.Errorf("mcp_mocks[%d].name is required", i)
 			}
-			if seen[mock.Name] {
-				return fmt.Errorf("mcp_mocks[%d].name %q is duplicated", i, mock.Name)
+			if seen[name] {
+				return fmt.Errorf("mcp_mocks[%d].name %q is duplicated", i, name)
 			}
-			seen[mock.Name] = true
+			seen[name] = true
 		}
 	}
 	if s.Config.TrialsPerTask < 1 {

--- a/internal/models/spec.go
+++ b/internal/models/spec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/microsoft/waza/internal/hooks"
 	"gopkg.in/yaml.v3"
@@ -20,6 +21,7 @@ type EvalSpec struct {
 	Version       string            `yaml:"version"`
 	Config        Config            `yaml:"config"`
 	Hooks         hooks.HooksConfig `yaml:"hooks,omitempty"`
+	MCPMocks      []MCPMockConfig   `yaml:"mcp_mocks,omitempty" json:"mcp_mocks,omitempty"`
 	Inputs        map[string]string `yaml:"inputs,omitempty" json:"inputs,omitempty"`
 	TasksFrom     string            `yaml:"tasks_from,omitempty" json:"tasks_from,omitempty"`
 	Range         [2]int            `yaml:"range,omitempty" json:"range,omitempty"`
@@ -41,6 +43,7 @@ type strictEvalSpec struct {
 	Version       string            `yaml:"version"`
 	Config        Config            `yaml:"config"`
 	Hooks         hooks.HooksConfig `yaml:"hooks,omitempty"`
+	MCPMocks      []MCPMockConfig   `yaml:"mcp_mocks,omitempty"`
 	Inputs        map[string]string `yaml:"inputs,omitempty"`
 	TasksFrom     string            `yaml:"tasks_from,omitempty"`
 	Range         [2]int            `yaml:"range,omitempty"`
@@ -84,6 +87,29 @@ type Config struct {
 	MaxAttempts          int            `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty"`
 	GroupBy              string         `yaml:"group_by,omitempty" json:"group_by,omitempty"`
 	JudgeModel           string         `yaml:"judge_model,omitempty" json:"judge_model,omitempty"`
+}
+
+// MCPMockConfig defines a deterministic MCP server mock launched for an eval.
+type MCPMockConfig struct {
+	Name     string                 `yaml:"name" json:"name"`
+	Fixtures string                 `yaml:"fixtures,omitempty" json:"fixtures,omitempty"`
+	Tools    map[string]MCPMockTool `yaml:"tools,omitempty" json:"tools,omitempty"`
+}
+
+// MCPMockTool defines a mocked MCP tool and its response fixtures.
+type MCPMockTool struct {
+	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
+	InputSchema map[string]any    `yaml:"input_schema,omitempty" json:"input_schema,omitempty"`
+	Responses   []MCPMockResponse `yaml:"responses,omitempty" json:"responses,omitempty"`
+}
+
+// MCPMockResponse defines one deterministic response for a mocked tool call.
+type MCPMockResponse struct {
+	Match       map[string]any    `yaml:"match,omitempty" json:"match,omitempty"`
+	MatchSchema map[string]any    `yaml:"match_schema,omitempty" json:"match_schema,omitempty"`
+	MatchRegex  map[string]string `yaml:"match_regex,omitempty" json:"match_regex,omitempty"`
+	Return      any               `yaml:"return,omitempty" json:"return,omitempty"`
+	Error       string            `yaml:"error,omitempty" json:"error,omitempty"`
 }
 
 // ShouldInjectSkillBody returns true unless the eval explicitly opts out of
@@ -336,6 +362,25 @@ func LoadEvalSpec(path string) (*EvalSpec, error) {
 
 // Validate checks that the spec is valid
 func (s *EvalSpec) Validate() error {
+	if len(s.MCPMocks) > 0 {
+		_, minor, err := parseSchemaVersion(s.SchemaVersion)
+		if err != nil {
+			return err
+		}
+		if minor < 1 {
+			return fmt.Errorf("mcp_mocks requires schemaVersion 1.1 or newer")
+		}
+		seen := make(map[string]bool, len(s.MCPMocks))
+		for i, mock := range s.MCPMocks {
+			if strings.TrimSpace(mock.Name) == "" {
+				return fmt.Errorf("mcp_mocks[%d].name is required", i)
+			}
+			if seen[mock.Name] {
+				return fmt.Errorf("mcp_mocks[%d].name %q is duplicated", i, mock.Name)
+			}
+			seen[mock.Name] = true
+		}
+	}
 	if s.Config.TrialsPerTask < 1 {
 		return fmt.Errorf("trials_per_task must be at least 1, got %d", s.Config.TrialsPerTask)
 	}

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -120,6 +120,92 @@ config:
 	}
 }
 
+func TestLoadEvalSpec_MCPMocksRequireSchemaVersion11(t *testing.T) {
+	tempDir := t.TempDir()
+	specPath := filepath.Join(tempDir, "spec.yaml")
+	specYAML := `name: mcp-mocks
+skill: test-skill
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: test-model
+mcp_mocks:
+  - name: github
+    tools:
+      list_issues:
+        responses:
+          - match: {owner: octocat}
+            return: {issues: []}
+tasks:
+  - tasks/*.yaml
+metrics:
+  - name: pass
+    weight: 1
+    threshold: 1
+`
+	if err := os.WriteFile(specPath, []byte(specYAML), 0644); err != nil {
+		t.Fatalf("Failed to write spec file: %v", err)
+	}
+	_, err := LoadEvalSpec(specPath)
+	if err == nil || !strings.Contains(err.Error(), "mcp_mocks requires schemaVersion 1.1") {
+		t.Fatalf("expected schemaVersion 1.1 error, got %v", err)
+	}
+
+	specYAML = "schemaVersion: \"1.1\"\n" + specYAML
+	if err := os.WriteFile(specPath, []byte(specYAML), 0644); err != nil {
+		t.Fatalf("Failed to write spec file: %v", err)
+	}
+	spec, err := LoadEvalSpec(specPath)
+	if err != nil {
+		t.Fatalf("LoadEvalSpec() error = %v", err)
+	}
+	if spec.SchemaVersion != "1.1" {
+		t.Fatalf("schemaVersion = %q, want 1.1", spec.SchemaVersion)
+	}
+	if len(spec.MCPMocks) != 1 || spec.MCPMocks[0].Name != "github" {
+		t.Fatalf("unexpected mcp_mocks: %+v", spec.MCPMocks)
+	}
+}
+
+func TestLoadEvalSpec_RejectsDuplicateMCPMockNames(t *testing.T) {
+	tempDir := t.TempDir()
+	specPath := filepath.Join(tempDir, "spec.yaml")
+	specYAML := `name: mcp-mocks
+skill: test-skill
+schemaVersion: "1.1"
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+  model: test-model
+mcp_mocks:
+  - name: github
+    tools:
+      list_issues:
+        responses:
+          - return: {issues: []}
+  - name: github
+    tools:
+      list_pull_requests:
+        responses:
+          - return: {pull_requests: []}
+tasks:
+  - tasks/*.yaml
+metrics:
+  - name: pass
+    weight: 1
+    threshold: 1
+`
+	if err := os.WriteFile(specPath, []byte(specYAML), 0644); err != nil {
+		t.Fatalf("Failed to write spec file: %v", err)
+	}
+	_, err := LoadEvalSpec(specPath)
+	if err == nil || !strings.Contains(err.Error(), `mcp_mocks[1].name "github" is duplicated`) {
+		t.Fatalf("expected duplicate mcp_mocks error, got %v", err)
+	}
+}
+
 func TestLoadEvalSpec_RejectsDifferentMajorSchemaVersion(t *testing.T) {
 	tempDir := t.TempDir()
 	specPath := filepath.Join(tempDir, "spec.yaml")

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -180,7 +180,7 @@ config:
   executor: mock
   model: test-model
 mcp_mocks:
-  - name: github
+  - name: " github "
     tools:
       list_issues:
         responses:

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1295,7 +1295,7 @@ func (r *EvalRunner) buildExecutionRequest(tc *models.TestCase) (*execution.Exec
 		SkillPaths:        resolvedSkillPaths,
 		NoSkills:          noSkills,
 		SuppressSkillBody: !spec.Config.ShouldInjectSkillBody(),
-		MCPServers:        convertMCPServers(spec.Config.ServerConfigs),
+		MCPServers:        convertMCPServers(spec.Config.ServerConfigs, spec.MCPMocks, r.cfg.SpecDir()),
 		FirstEventTimeout: r.firstEventTimeout(tc),
 	}, nil
 }
@@ -1806,8 +1806,8 @@ func containsPathTraversal(path string) bool {
 
 // convertMCPServers converts the eval YAML mcp_servers config (map[string]any)
 // into the copilot SDK's MCPServerConfig type. Returns nil if no servers configured.
-func convertMCPServers(serverConfigs map[string]any) map[string]copilot.MCPServerConfig {
-	return copilotconfig.ConvertMCPServers(serverConfigs, func(format string, args ...any) {
+func convertMCPServers(serverConfigs map[string]any, mocks []models.MCPMockConfig, baseDir string) map[string]copilot.MCPServerConfig {
+	return copilotconfig.ConvertMCPServersWithMocks(serverConfigs, mocks, baseDir, func(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, format, args...)
 	})
 }

--- a/internal/orchestration/runner_test.go
+++ b/internal/orchestration/runner_test.go
@@ -151,6 +151,38 @@ func TestBuildExecutionRequest_BasicFields(t *testing.T) {
 	assert.False(t, req.SuppressSkillBody)
 }
 
+func TestBuildExecutionRequest_MCPMocks(t *testing.T) {
+	specDir := t.TempDir()
+	spec := &models.EvalSpec{
+		SchemaVersion: "1.1",
+		SpecIdentity:  models.SpecIdentity{Name: "test-benchmark"},
+		SkillName:     "my-skill",
+		Config: models.Config{
+			EngineType:    "mock",
+			ModelID:       "gpt-4",
+			TimeoutSec:    120,
+			TrialsPerTask: 1,
+		},
+		MCPMocks: []models.MCPMockConfig{{
+			Name: "github",
+			Tools: map[string]models.MCPMockTool{
+				"list_issues": {
+					Responses: []models.MCPMockResponse{{Match: map[string]any{"owner": "octocat"}, Return: map[string]any{"issues": []any{}}}},
+				},
+			},
+		}},
+	}
+	cfg := config.NewEvalConfig(spec, config.WithSpecDir(specDir))
+	runner := NewEvalRunner(cfg, nil)
+	req, err := runner.buildExecutionRequest(&models.TestCase{
+		TestID:      "test-001",
+		DisplayName: "Test Case",
+		Stimulus:    models.TaskStimulus{Message: "Hello world"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, req.MCPServers, "github")
+}
+
 func TestBuildExecutionRequest_SuppressSkillBody(t *testing.T) {
 	injectSkillBody := false
 	spec := &models.EvalSpec{

--- a/internal/trigger/runner.go
+++ b/internal/trigger/runner.go
@@ -50,7 +50,7 @@ type taskResult struct {
 func NewRunner(spec *TestSpec, engine execution.AgentEngine, cfg *config.EvalConfig, out io.Writer) *Runner {
 	r := &Runner{spec: spec, engine: engine, cfg: cfg, out: out}
 	r.fixtures = loadFixtureDir(cfg.FixtureDir())
-	r.mcpConfig = convertMCPServers(cfg.Spec().Config.ServerConfigs)
+	r.mcpConfig = convertMCPServers(cfg.Spec().Config.ServerConfigs, cfg.Spec().MCPMocks, cfg.SpecDir())
 	return r
 }
 
@@ -249,8 +249,8 @@ func loadFixtureDir(dir string) []execution.ResourceFile {
 
 // convertMCPServers converts the eval YAML mcp_servers config (map[string]any)
 // into the copilot SDK's MCPServerConfig type.
-func convertMCPServers(serverConfigs map[string]any) map[string]copilot.MCPServerConfig {
-	return copilotconfig.ConvertMCPServers(serverConfigs, func(format string, args ...any) {
+func convertMCPServers(serverConfigs map[string]any, mocks []models.MCPMockConfig, baseDir string) map[string]copilot.MCPServerConfig {
+	return copilotconfig.ConvertMCPServersWithMocks(serverConfigs, mocks, baseDir, func(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, format, args...)
 	})
 }

--- a/internal/trigger/runner_test.go
+++ b/internal/trigger/runner_test.go
@@ -428,7 +428,7 @@ func TestConvertMCPServers_SkipsNonMapEntries(t *testing.T) {
 		"good":  map[string]any{"type": "stdio"},
 		"bad":   "not-a-map",
 		"good2": map[string]any{"type": "sse"},
-	})
+	}, nil, "")
 	require.Len(t, result, 2)
 	require.Contains(t, result, "good")
 	require.Contains(t, result, "good2")

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -44,6 +44,13 @@
     "hooks": {
       "$ref": "#/$defs/hooksConfig"
     },
+    "mcp_mocks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/mcpMock"
+      },
+      "description": "Deterministic MCP mock servers launched for hermetic evals. Requires schemaVersion 1.1 when present."
+    },
     "inputs": {
       "type": "object",
       "additionalProperties": {
@@ -206,6 +213,110 @@
           "type": "object",
           "additionalProperties": true,
           "description": "MCP server configurations keyed by server name."
+        }
+      }
+    },
+    "mcpMock": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "description": "A deterministic MCP mock server backed by inline tools and/or JSON fixture files.",
+      "anyOf": [
+        {
+          "required": [
+            "fixtures"
+          ]
+        },
+        {
+          "required": [
+            "tools"
+          ]
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP server name exposed to the agent."
+        },
+        "fixtures": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Directory containing JSON fixture files, resolved relative to eval.yaml. Each file can define one tool or a {\"tools\": {...}} bundle."
+        },
+        "tools": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/mcpMockTool"
+          },
+          "description": "Inline mocked tools keyed by MCP tool name."
+        }
+      }
+    },
+    "mcpMockTool": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Tool description returned from tools/list."
+        },
+        "input_schema": {
+          "type": "object",
+          "description": "JSON Schema input schema returned from tools/list."
+        },
+        "responses": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/mcpMockResponse"
+          },
+          "description": "Ordered fixture responses. The first matching response is returned."
+        }
+      }
+    },
+    "mcpMockResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "return"
+          ]
+        },
+        {
+          "required": [
+            "error"
+          ]
+        }
+      ],
+      "properties": {
+        "match": {
+          "type": "object",
+          "description": "Exact full-arguments match for this response."
+        },
+        "match_schema": {
+          "type": "object",
+          "description": "JSON Schema that call arguments must satisfy."
+        },
+        "match_regex": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Per-field regular expressions matched against stringified argument values."
+        },
+        "return": {
+          "description": "JSON value returned by the mocked tool."
+        },
+        "error": {
+          "type": "string",
+          "description": "Fixture error returned by the mocked tool."
         }
       }
     },

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -58,6 +58,7 @@ tasks:
 | `inputs`      | object | ✗        | Key-value map of global template variables (see [Template Variables](#template-variables)) |
 | `tasks_from`  | string | ✗        | Path to an external YAML file containing the task list                                     |
 | `hooks`       | object | ✗        | Lifecycle hooks that run shell commands at specific points (see [Hooks](#hooks))           |
+| `mcp_mocks`   | array  | ✗        | Hermetic MCP server mocks for deterministic tool-call evals; requires `schemaVersion: "1.1"` |
 | `baseline`    | bool   | ✗        | Mark this spec as a baseline for A/B comparison                                            |
 
 `skill` is required.
@@ -163,6 +164,64 @@ With this setting, Waza still discovers skills, passes them to the Copilot SDK, 
 - `60` — Quick tasks (single-file review, validation)
 - `300` — Standard tasks (code explanation, analysis)
 - `600` — Complex tasks (multi-file refactoring, design)
+
+## MCP Mock Servers
+
+Use top-level `mcp_mocks` to replace live MCP dependencies with deterministic local stdio servers. This keeps Copilot SDK evals hermetic in CI: no network listener, no port allocation, and no external service credentials. Because this is an additive eval schema field, set `schemaVersion: "1.1"` or newer.
+
+```yaml
+name: issue-triage-eval
+skill: issue-triage
+schemaVersion: "1.1"
+version: "1.0"
+
+config:
+  executor: copilot-sdk
+  model: claude-sonnet-4.6
+
+mcp_mocks:
+  - name: github
+    tools:
+      list_issues:
+        description: Return matching issues for a repository
+        input_schema:
+          type: object
+          properties:
+            owner: { type: string }
+            repo: { type: string }
+          required: [owner, repo]
+        responses:
+          - match:
+              owner: microsoft
+              repo: waza
+            return:
+              issues:
+                - number: 363
+                  title: MCP server mocks for hermetic eval
+          - match_regex:
+              repo: "^waza-.*"
+            return:
+              issues: []
+          - match_schema:
+              type: object
+              required: [owner, repo]
+            error: "No fixture for this repository"
+
+tasks:
+  - tasks/*.yaml
+```
+
+Response matching is evaluated in order. `match` requires exact full-argument equality, `match_schema` validates the call arguments against an inline JSON Schema, and `match_regex` applies regular expressions to individual argument fields. Unknown tools or calls that do not match any response fail loudly with an MCP tool error that points to the missing mock fixture.
+
+You can keep larger fixtures in JSON files instead of inline YAML:
+
+```yaml
+mcp_mocks:
+  - name: github
+    fixtures: fixtures/mcp/github
+```
+
+Each `.json` fixture can either contain a single tool definition (tool name from the filename) or a `{ "tools": { ... } }` object with multiple tools.
 
 ## Graders Section
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -120,6 +120,9 @@ waza run eval.yaml --model gpt-4o --model claude-sonnet-4.6
 # Use a different judge model for LLM-as-judge graders
 waza run eval.yaml --model gpt-4o --judge-model claude-opus-4.6
 
+# Run a Copilot SDK eval with top-level mcp_mocks fixtures and no live MCP service
+waza run eval.yaml --session-log
+
 # Parallel execution with 8 workers
 waza run eval.yaml --parallel --workers 8
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -15,7 +15,7 @@ Main evaluation configuration file.
 name: code-explainer-eval # Required: eval suite name
 description: "..." # Required: what this eval tests
 skill: code-explainer # Required: skill name
-schemaVersion: "1.0" # Optional: schema version; defaults to 1.0
+schemaVersion: "1.1" # Optional: schema version; defaults to 1.0
 version: "1.0" # Optional: version number
 
 config:
@@ -35,6 +35,15 @@ graders: # Validation rules
 
 tasks: # Test cases
   - "tasks/*.yaml" # From files
+
+mcp_mocks: # Optional: deterministic local MCP server mocks
+  - name: github
+    tools:
+      list_issues:
+        responses:
+          - match: { owner: microsoft, repo: waza }
+            return:
+              issues: []
 ```
 
 ## Top-Level Fields
@@ -97,6 +106,69 @@ schemaVersion: "1.0"
 ```
 
 See [Schema Changes](/reference/schema-changes/) for the versioning policy and changelog.
+
+### mcp_mocks
+
+**Type:** array
+**Required:** no
+**Requires:** `schemaVersion: "1.1"` or newer
+
+Defines deterministic MCP server mocks for Copilot SDK evals. Waza exposes each mock as a local stdio MCP server, so tests do not need live network services, credentials, or fixed ports.
+
+```yaml
+schemaVersion: "1.1"
+mcp_mocks:
+  - name: github
+    fixtures: fixtures/mcp/github
+```
+
+You can define tools inline:
+
+```yaml
+mcp_mocks:
+  - name: github
+    tools:
+      list_issues:
+        description: Return issues from a fixture
+        input_schema:
+          type: object
+          properties:
+            owner: { type: string }
+            repo: { type: string }
+          required: [owner, repo]
+        responses:
+          - match:
+              owner: microsoft
+              repo: waza
+            return:
+              issues:
+                - number: 363
+                  title: MCP server mocks for hermetic eval
+          - match_regex:
+              repo: "^waza-.*"
+            return:
+              issues: []
+          - match_schema:
+              type: object
+              required: [owner, repo]
+            error: "No fixture for this repository"
+```
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `name` | string | MCP server name made available to the agent |
+| `fixtures` | string | Directory of JSON tool fixtures, resolved relative to `eval.yaml` |
+| `tools` | object | Inline tool definitions keyed by tool name |
+| `description` | string | Tool description returned from `tools/list` |
+| `input_schema` | object | JSON Schema returned from `tools/list` |
+| `responses` | array | Ordered responses for `tools/call` |
+| `match` | object | Exact full-argument match |
+| `match_schema` | object | JSON Schema that the call arguments must satisfy |
+| `match_regex` | object | Per-field regular expression match |
+| `return` | any | JSON value returned as the mocked tool result |
+| `error` | string | Tool error text returned with `isError: true` |
+
+Response entries are checked in order. Unknown tools and unmatched calls fail loudly with a tool error that names the missing mock fixture.
 
 ## config Section
 
@@ -329,6 +401,8 @@ config:
     github:
       url: http://localhost:3000
 ```
+
+Use top-level [`mcp_mocks`](#mcp_mocks) for hermetic evals that should not call live MCP services.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add top-level `mcp_mocks` eval schema support gated to `schemaVersion: "1.1"`.
- Launch deterministic waza-managed stdio MCP mock servers for Copilot SDK evals, with inline/fixture-backed tools and exact, JSON Schema, and per-field regex response matching.
- Surface clear MCP tool errors for unknown tools and unmatched calls, and document hermetic MCP eval usage across README, site docs, CLI reference, and integration testing docs.

## Test plan
- `go build ./... && go test ./... && go vet ./... && golangci-lint run`
- `cd site && npm run build`

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

Closes #363