### PR TITLE
feat: per-task tool metrics with structured arg matchers (closes #366)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,7 +1035,9 @@ tasks:
 # range: [1, 10]  # Only include rows 1-10 (0-indexed, skips header)
 ```
 
-`schemaVersion` uses `MAJOR.MINOR` format and defaults to `1.0` when omitted for backward compatibility. Readers allow same-major minor additions with warnings for unknown fields, but reject different majors with a hint to run `waza migrate <file>`.
+`schemaVersion` uses `MAJOR.MINOR` format. Missing values are interpreted as the current schema version (currently `1.1`). Readers allow same-major minor additions with warnings for unknown fields, but reject different majors with a hint to run `waza migrate <file>`.
+
+`results.json` is currently emitted at `schemaVersion` `1.1`, which adds per-turn checkpoints (`runs[].checkpoints[]`, see #358) and the normalized `runs[].tool_events[]` array (turn, sequence, tool name, args, result, success, duration; see #366). See [docs/PRD](docs/PRD.md) and [schema-changes](site/src/content/docs/reference/schema-changes.md) for details.
 
 ### MCP Mock Servers
 

--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,7 @@ tasks:
 
 `schemaVersion` uses `MAJOR.MINOR` format. Missing values are interpreted as the current schema version (currently `1.1`). Readers allow same-major minor additions with warnings for unknown fields, but reject different majors with a hint to run `waza migrate <file>`.
 
-`results.json` is currently emitted at `schemaVersion` `1.1`, which adds per-turn checkpoints (`runs[].checkpoints[]`, see #358) and the normalized `runs[].tool_events[]` array (turn, sequence, tool name, args, result, success, duration; see #366). See [docs/PRD](docs/PRD.md) and [schema-changes](site/src/content/docs/reference/schema-changes.md) for details.
+`results.json` is currently emitted at `schemaVersion` `1.1`, which adds per-turn checkpoints (`runs[].checkpoints[]`, see #358) and the normalized `runs[].tool_events[]` array (`turn`, `sequence`, `tool_call_id`, `tool_name`, `args`, `result`, `success`, `error`, `duration_ms`; see #366). See [docs/PRD](docs/PRD.md) and [schema-changes](site/src/content/docs/reference/schema-changes.md) for details.
 
 ### MCP Mock Servers
 

--- a/cmd/waza/cmd_compare.go
+++ b/cmd/waza/cmd_compare.go
@@ -224,6 +224,12 @@ func printComparisonTable(r *comparisonReport) {
 		}
 		fmt.Printf("  %+d\n", r.ToolMetrics[n-1].TotalCalls-r.ToolMetrics[0].TotalCalls)
 
+		fmt.Printf("  %-20s", "Tasks w/ tools")
+		for _, tm := range r.ToolMetrics {
+			fmt.Printf("  %-9d", tm.TasksWithTools)
+		}
+		fmt.Printf("  %+d\n", r.ToolMetrics[n-1].TasksWithTools-r.ToolMetrics[0].TasksWithTools)
+
 		fmt.Printf("  %-20s", "Avg calls/task")
 		for _, tm := range r.ToolMetrics {
 			fmt.Printf("  %-9.2f", tm.AvgCallsPerTask)
@@ -243,7 +249,7 @@ func printComparisonTable(r *comparisonReport) {
 		fmt.Printf("  %+.1f%%\n", (r.ToolMetrics[n-1].SelectionAccuracy-r.ToolMetrics[0].SelectionAccuracy)*100)
 
 		for _, bucket := range []string{"0", "1", "2", "3+"} {
-			fmt.Printf("  %-20s", "Tasks w/ "+bucket+" calls")
+			fmt.Printf("  %-20s", "Runs w/ "+bucket+" calls")
 			for _, tm := range r.ToolMetrics {
 				fmt.Printf("  %-9d", tm.CallCountHistogram[bucket])
 			}
@@ -324,28 +330,25 @@ func computeToolMetrics(o *models.EvaluationOutcome) toolMetrics {
 		callsThisTask := 0
 		successThisTask := 0
 		for _, run := range t.Runs {
-			callsThisTask += len(run.ToolEvents)
+			runCalls := len(run.ToolEvents)
+			callsThisTask += runCalls
 			for _, ev := range run.ToolEvents {
 				if ev.Success {
 					successThisTask++
 				}
 			}
-		}
-		// Average per task uses the per-task call count rather than per-run so
-		// that retried runs don't double-count for the histogram.
-		perTaskAvg := 0
-		if len(t.Runs) > 0 {
-			perTaskAvg = callsThisTask / len(t.Runs)
-		}
-		switch perTaskAvg {
-		case 0:
-			hist["0"]++
-		case 1:
-			hist["1"]++
-		case 2:
-			hist["2"]++
-		default:
-			hist["3+"]++
+			// Per-run histogram bucket: one entry per individual run so retried
+			// trials are counted independently and no truncation is required.
+			switch runCalls {
+			case 0:
+				hist["0"]++
+			case 1:
+				hist["1"]++
+			case 2:
+				hist["2"]++
+			default:
+				hist["3+"]++
+			}
 		}
 		if callsThisTask > 0 {
 			tm.TasksWithTools++

--- a/cmd/waza/cmd_compare.go
+++ b/cmd/waza/cmd_compare.go
@@ -52,6 +52,21 @@ type comparisonReport struct {
 	TotalTests     []int            `json:"total_tests"`
 	DurationsMs    []int64          `json:"durations_ms"`
 	DurationDeltaM int64            `json:"duration_delta_ms"`
+
+	// ToolMetrics summarizes per-file tool-use statistics. Added with
+	// schemaVersion 1.1 (issue #366). Files that don't include tool_events
+	// produce zero values, which is safe for delta math.
+	ToolMetrics []toolMetrics `json:"tool_metrics"`
+}
+
+// toolMetrics aggregates tool-use stats across all tasks in one outcome file.
+type toolMetrics struct {
+	TotalCalls         int            `json:"total_calls"`
+	TasksWithTools     int            `json:"tasks_with_tools"`
+	AvgCallsPerTask    float64        `json:"avg_calls_per_task"`
+	SuccessRate        float64        `json:"success_rate"`
+	SelectionAccuracy  float64        `json:"selection_accuracy"`
+	CallCountHistogram map[string]int `json:"call_count_histogram"`
 }
 
 func compareCommandE(_ *cobra.Command, args []string) error {
@@ -92,6 +107,7 @@ func buildComparisonReport(files []string, outcomes []*models.EvaluationOutcome)
 		report.SuccessRates = append(report.SuccessRates, o.Digest.SuccessRate)
 		report.TotalTests = append(report.TotalTests, o.Digest.TotalTests)
 		report.DurationsMs = append(report.DurationsMs, o.Digest.DurationMs)
+		report.ToolMetrics = append(report.ToolMetrics, computeToolMetrics(o))
 	}
 
 	n := len(outcomes)
@@ -196,6 +212,47 @@ func printComparisonTable(r *comparisonReport) {
 	fmt.Printf("  %+d\n", r.DurationDeltaM)
 	fmt.Println()
 
+	// Tool metrics (additive in schemaVersion 1.1)
+	if len(r.ToolMetrics) == n && hasAnyToolData(r.ToolMetrics) {
+		fmt.Println(strings.Repeat("-", 70))
+		fmt.Println(" TOOL USE")
+		fmt.Println(strings.Repeat("-", 70))
+
+		fmt.Printf("  %-20s", "Total calls")
+		for _, tm := range r.ToolMetrics {
+			fmt.Printf("  %-9d", tm.TotalCalls)
+		}
+		fmt.Printf("  %+d\n", r.ToolMetrics[n-1].TotalCalls-r.ToolMetrics[0].TotalCalls)
+
+		fmt.Printf("  %-20s", "Avg calls/task")
+		for _, tm := range r.ToolMetrics {
+			fmt.Printf("  %-9.2f", tm.AvgCallsPerTask)
+		}
+		fmt.Printf("  %+.2f\n", r.ToolMetrics[n-1].AvgCallsPerTask-r.ToolMetrics[0].AvgCallsPerTask)
+
+		fmt.Printf("  %-20s", "Success rate")
+		for _, tm := range r.ToolMetrics {
+			fmt.Printf("  %-9.1f%%", tm.SuccessRate*100)
+		}
+		fmt.Printf("  %+.1f%%\n", (r.ToolMetrics[n-1].SuccessRate-r.ToolMetrics[0].SuccessRate)*100)
+
+		fmt.Printf("  %-20s", "Selection accuracy")
+		for _, tm := range r.ToolMetrics {
+			fmt.Printf("  %-9.1f%%", tm.SelectionAccuracy*100)
+		}
+		fmt.Printf("  %+.1f%%\n", (r.ToolMetrics[n-1].SelectionAccuracy-r.ToolMetrics[0].SelectionAccuracy)*100)
+
+		for _, bucket := range []string{"0", "1", "2", "3+"} {
+			fmt.Printf("  %-20s", "Tasks w/ "+bucket+" calls")
+			for _, tm := range r.ToolMetrics {
+				fmt.Printf("  %-9d", tm.CallCountHistogram[bucket])
+			}
+			fmt.Printf("  %+d\n",
+				r.ToolMetrics[n-1].CallCountHistogram[bucket]-r.ToolMetrics[0].CallCountHistogram[bucket])
+		}
+		fmt.Println()
+	}
+
 	// Per-task table
 	fmt.Println(strings.Repeat("-", 70))
 	fmt.Println(" PER-TASK DELTAS")
@@ -232,6 +289,17 @@ func printComparisonTable(r *comparisonReport) {
 	fmt.Println()
 }
 
+// hasAnyToolData reports whether any file has at least one recorded tool call.
+// Suppresses the "TOOL USE" table for purely tool-free outcomes.
+func hasAnyToolData(metrics []toolMetrics) bool {
+	for _, m := range metrics {
+		if m.TotalCalls > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func printComparisonJSON(r *comparisonReport) error {
 	data, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
@@ -239,4 +307,83 @@ func printComparisonJSON(r *comparisonReport) error {
 	}
 	fmt.Println(string(data))
 	return nil
+}
+
+// computeToolMetrics aggregates per-task ToolEvents and tool_calls grader
+// outcomes into a single summary record. Tasks without ToolEvents contribute
+// zero counts; tasks without a tool_calls grader are excluded from the
+// SelectionAccuracy denominator.
+func computeToolMetrics(o *models.EvaluationOutcome) toolMetrics {
+	hist := map[string]int{"0": 0, "1": 0, "2": 0, "3+": 0}
+	tm := toolMetrics{CallCountHistogram: hist}
+
+	var totalCalls, successfulCalls int
+	var graderTasks, graderPasses int
+
+	for _, t := range o.TestOutcomes {
+		callsThisTask := 0
+		successThisTask := 0
+		for _, run := range t.Runs {
+			callsThisTask += len(run.ToolEvents)
+			for _, ev := range run.ToolEvents {
+				if ev.Success {
+					successThisTask++
+				}
+			}
+		}
+		// Average per task uses the per-task call count rather than per-run so
+		// that retried runs don't double-count for the histogram.
+		perTaskAvg := 0
+		if len(t.Runs) > 0 {
+			perTaskAvg = callsThisTask / len(t.Runs)
+		}
+		switch perTaskAvg {
+		case 0:
+			hist["0"]++
+		case 1:
+			hist["1"]++
+		case 2:
+			hist["2"]++
+		default:
+			hist["3+"]++
+		}
+		if callsThisTask > 0 {
+			tm.TasksWithTools++
+		}
+		totalCalls += callsThisTask
+		successfulCalls += successThisTask
+
+		// Selection accuracy: did the tool_calls grader pass for this task?
+		hasToolCallsGrader := false
+		allPassed := true
+		for _, run := range t.Runs {
+			for _, v := range run.Validations {
+				if v.Type != models.GraderKindToolCalls {
+					continue
+				}
+				hasToolCallsGrader = true
+				if !v.Passed {
+					allPassed = false
+				}
+			}
+		}
+		if hasToolCallsGrader {
+			graderTasks++
+			if allPassed {
+				graderPasses++
+			}
+		}
+	}
+
+	tm.TotalCalls = totalCalls
+	if len(o.TestOutcomes) > 0 {
+		tm.AvgCallsPerTask = float64(totalCalls) / float64(len(o.TestOutcomes))
+	}
+	if totalCalls > 0 {
+		tm.SuccessRate = float64(successfulCalls) / float64(totalCalls)
+	}
+	if graderTasks > 0 {
+		tm.SelectionAccuracy = float64(graderPasses) / float64(graderTasks)
+	}
+	return tm
 }

--- a/cmd/waza/cmd_compare.go
+++ b/cmd/waza/cmd_compare.go
@@ -249,7 +249,7 @@ func printComparisonTable(r *comparisonReport) {
 		fmt.Printf("  %+.1f%%\n", (r.ToolMetrics[n-1].SelectionAccuracy-r.ToolMetrics[0].SelectionAccuracy)*100)
 
 		for _, bucket := range []string{"0", "1", "2", "3+"} {
-			fmt.Printf("  %-20s", "Runs w/ "+bucket+" calls")
+			fmt.Printf("  %-20s", "Tasks w/ "+bucket+" calls")
 			for _, tm := range r.ToolMetrics {
 				fmt.Printf("  %-9d", tm.CallCountHistogram[bucket])
 			}
@@ -337,18 +337,21 @@ func computeToolMetrics(o *models.EvaluationOutcome) toolMetrics {
 					successThisTask++
 				}
 			}
-			// Per-run histogram bucket: one entry per individual run so retried
-			// trials are counted independently and no truncation is required.
-			switch runCalls {
-			case 0:
-				hist["0"]++
-			case 1:
-				hist["1"]++
-			case 2:
-				hist["2"]++
-			default:
-				hist["3+"]++
-			}
+		}
+		// Per-task histogram bucket: one entry per task (not per run), summing
+		// tool calls across every trial of that task. This keeps the
+		// distribution stable regardless of trials_per_task — a task that
+		// invoked two tools across three retries lands in "2" once, not in
+		// "0"/"1"/"2"/"3+" multiple times.
+		switch callsThisTask {
+		case 0:
+			hist["0"]++
+		case 1:
+			hist["1"]++
+		case 2:
+			hist["2"]++
+		default:
+			hist["3+"]++
 		}
 		if callsThisTask > 0 {
 			tm.TasksWithTools++

--- a/cmd/waza/cmd_compare_test.go
+++ b/cmd/waza/cmd_compare_test.go
@@ -277,3 +277,97 @@ func TestCompareCommand_ShortFormatFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "json", val)
 }
+
+// ---------------------------------------------------------------------------
+// Tool-use aggregate metrics (issue #366).
+// ---------------------------------------------------------------------------
+
+func TestComputeToolMetrics_NoToolData(t *testing.T) {
+	o := sampleOutcome("none", 0.5, 0.5, 0.5)
+	tm := computeToolMetrics(o)
+	require.Equal(t, 0, tm.TotalCalls)
+	require.Equal(t, 0, tm.TasksWithTools)
+	require.Equal(t, 0.0, tm.AvgCallsPerTask)
+	require.Equal(t, 0.0, tm.SuccessRate)
+	require.Equal(t, 0.0, tm.SelectionAccuracy)
+	// histogram exists but everything in the "0" bucket
+	require.GreaterOrEqual(t, tm.CallCountHistogram["0"], 1)
+}
+
+func TestComputeToolMetrics_TotalsAndSuccessRate(t *testing.T) {
+	o := &models.EvaluationOutcome{
+		TestOutcomes: []models.TestOutcome{
+			{
+				Runs: []models.RunResult{{
+					ToolEvents: []models.ToolEvent{
+						{ToolName: "bash", Success: true},
+						{ToolName: "view", Success: true},
+						{ToolName: "bash", Success: false},
+					},
+				}},
+			},
+			{
+				Runs: []models.RunResult{{
+					ToolEvents: []models.ToolEvent{
+						{ToolName: "edit", Success: true},
+					},
+				}},
+			},
+		},
+	}
+	tm := computeToolMetrics(o)
+	require.Equal(t, 4, tm.TotalCalls)
+	require.Equal(t, 2, tm.TasksWithTools)
+	require.InDelta(t, 2.0, tm.AvgCallsPerTask, 1e-9)
+	require.InDelta(t, 0.75, tm.SuccessRate, 1e-9)
+}
+
+func TestComputeToolMetrics_HistogramBuckets(t *testing.T) {
+	mkTask := func(n int) models.TestOutcome {
+		evs := make([]models.ToolEvent, n)
+		for i := range evs {
+			evs[i] = models.ToolEvent{ToolName: "bash", Success: true}
+		}
+		return models.TestOutcome{Runs: []models.RunResult{{ToolEvents: evs}}}
+	}
+	o := &models.EvaluationOutcome{
+		TestOutcomes: []models.TestOutcome{
+			mkTask(0), mkTask(1), mkTask(2), mkTask(5),
+		},
+	}
+	tm := computeToolMetrics(o)
+	require.Equal(t, 1, tm.CallCountHistogram["0"])
+	require.Equal(t, 1, tm.CallCountHistogram["1"])
+	require.Equal(t, 1, tm.CallCountHistogram["2"])
+	require.Equal(t, 1, tm.CallCountHistogram["3+"])
+}
+
+func TestComputeToolMetrics_SelectionAccuracy(t *testing.T) {
+	o := &models.EvaluationOutcome{
+		TestOutcomes: []models.TestOutcome{
+			{Runs: []models.RunResult{{
+				ToolEvents: []models.ToolEvent{{ToolName: "bash", Success: true}},
+				Validations: map[string]models.GraderResults{
+					"calls": {Type: models.GraderKindToolCalls, Passed: true},
+				},
+			}}},
+			{Runs: []models.RunResult{{
+				ToolEvents: []models.ToolEvent{{ToolName: "bash", Success: true}},
+				Validations: map[string]models.GraderResults{
+					"calls": {Type: models.GraderKindToolCalls, Passed: false},
+				},
+			}}},
+			// Task without a tool_calls grader is excluded from denominator.
+			{Runs: []models.RunResult{{
+				ToolEvents: []models.ToolEvent{{ToolName: "bash", Success: true}},
+			}}},
+		},
+	}
+	tm := computeToolMetrics(o)
+	require.InDelta(t, 0.5, tm.SelectionAccuracy, 1e-9)
+}
+
+func TestHasAnyToolData(t *testing.T) {
+	require.False(t, hasAnyToolData([]toolMetrics{{}, {}}))
+	require.True(t, hasAnyToolData([]toolMetrics{{}, {TotalCalls: 3}}))
+}

--- a/cmd/waza/cmd_compare_test.go
+++ b/cmd/waza/cmd_compare_test.go
@@ -374,3 +374,42 @@ func TestHasAnyToolData(t *testing.T) {
 	require.False(t, hasAnyToolData([]toolMetrics{{}, {}}))
 	require.True(t, hasAnyToolData([]toolMetrics{{}, {TotalCalls: 3}}))
 }
+
+// TestComputeToolMetrics_HistogramPerTaskAcrossTrials verifies the histogram
+// buckets per-task (summing across all trials), not per-run. With trials > 1,
+// a task that called one tool per trial should land in a single bucket
+// reflecting the total, never increment multiple buckets.
+func TestComputeToolMetrics_HistogramPerTaskAcrossTrials(t *testing.T) {
+	mkEvent := func() models.ToolEvent {
+		return models.ToolEvent{ToolName: "bash", Success: true}
+	}
+	o := &models.EvaluationOutcome{
+		TestOutcomes: []models.TestOutcome{
+			// Task with 3 trials × 1 call each → 3 calls total → bucket "3+".
+			{Runs: []models.RunResult{
+				{ToolEvents: []models.ToolEvent{mkEvent()}},
+				{ToolEvents: []models.ToolEvent{mkEvent()}},
+				{ToolEvents: []models.ToolEvent{mkEvent()}},
+			}},
+			// Task with 2 trials, one empty + one with 1 call → 1 total → "1".
+			{Runs: []models.RunResult{
+				{ToolEvents: nil},
+				{ToolEvents: []models.ToolEvent{mkEvent()}},
+			}},
+			// Task with 2 trials × 1 call each → 2 total → "2".
+			{Runs: []models.RunResult{
+				{ToolEvents: []models.ToolEvent{mkEvent()}},
+				{ToolEvents: []models.ToolEvent{mkEvent()}},
+			}},
+		},
+	}
+	tm := computeToolMetrics(o)
+	require.Equal(t, 0, tm.CallCountHistogram["0"])
+	require.Equal(t, 1, tm.CallCountHistogram["1"])
+	require.Equal(t, 1, tm.CallCountHistogram["2"])
+	require.Equal(t, 1, tm.CallCountHistogram["3+"])
+	// Total across all trials of all tasks: 3 + 1 + 2 = 6.
+	require.Equal(t, 6, tm.TotalCalls)
+	// Three tasks made tool calls.
+	require.Equal(t, 3, tm.TasksWithTools)
+}

--- a/cmd/waza/cmd_compare_test.go
+++ b/cmd/waza/cmd_compare_test.go
@@ -290,8 +290,11 @@ func TestComputeToolMetrics_NoToolData(t *testing.T) {
 	require.Equal(t, 0.0, tm.AvgCallsPerTask)
 	require.Equal(t, 0.0, tm.SuccessRate)
 	require.Equal(t, 0.0, tm.SelectionAccuracy)
-	// histogram exists but everything in the "0" bucket
-	require.GreaterOrEqual(t, tm.CallCountHistogram["0"], 1)
+	// histogram map is present; with no runs, no buckets are incremented
+	require.NotNil(t, tm.CallCountHistogram)
+	require.Equal(t, 0, tm.CallCountHistogram["1"])
+	require.Equal(t, 0, tm.CallCountHistogram["2"])
+	require.Equal(t, 0, tm.CallCountHistogram["3+"])
 }
 
 func TestComputeToolMetrics_TotalsAndSuccessRate(t *testing.T) {

--- a/internal/graders/argmatcher/matcher.go
+++ b/internal/graders/argmatcher/matcher.go
@@ -1,0 +1,463 @@
+// Package argmatcher implements structured value matchers used by the
+// tool_calls and tool_constraint graders to validate tool-call arguments.
+//
+// A Matcher is a tagged union of one of these kinds:
+//
+//	equals      — strict equality (after JSON round-trip normalization).
+//	regex       — Go regexp matched against the value's string form.
+//	contains    — substring match against the value's string form.
+//	range       — numeric range check (gte / lte / gt / lt, inclusive bounds default).
+//	json_schema — JSON Schema (draft-07+) validation of the value.
+//
+// Exactly one kind must be set per Matcher. The package decodes its YAML form
+// from a single-key mapping like:
+//
+//	query:
+//	  regex: "^auth"
+//	count:
+//	  range: { gte: 1, lte: 5 }
+//
+// Matchers are stable and replay-friendly: their decoded representation can be
+// re-serialized to JSON without loss, which keeps `tool_events[]` snapshots
+// deterministic across runs (see issue #366 / Wave 3 #367).
+package argmatcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+// Kind enumerates the matcher kinds supported by [Matcher].
+type Kind string
+
+const (
+	KindEquals     Kind = "equals"
+	KindRegex      Kind = "regex"
+	KindContains   Kind = "contains"
+	KindRange      Kind = "range"
+	KindJSONSchema Kind = "json_schema"
+)
+
+// Matcher is a tagged union of one matcher kind. Use [Matcher.Match] to test a
+// value. Construct directly or via YAML/JSON decoding.
+//
+// Exactly one of the kind-specific fields must be populated. The Compile
+// method (called automatically after YAML decoding) validates this invariant
+// and prepares any cached state (compiled regex, compiled JSON schema).
+type Matcher struct {
+	Kind Kind `json:"kind" yaml:"-"`
+
+	// Equals holds the expected literal value when Kind == KindEquals.
+	Equals any `json:"equals,omitempty" yaml:"-"`
+
+	// Regex holds the regular expression source when Kind == KindRegex.
+	Regex string `json:"regex,omitempty" yaml:"-"`
+
+	// Contains holds the substring expected to appear in the value's
+	// string form when Kind == KindContains.
+	Contains string `json:"contains,omitempty" yaml:"-"`
+
+	// Range carries the numeric bounds for Kind == KindRange.
+	Range *RangeSpec `json:"range,omitempty" yaml:"-"`
+
+	// JSONSchema carries the schema document for Kind == KindJSONSchema.
+	JSONSchema map[string]any `json:"json_schema,omitempty" yaml:"-"`
+
+	// compiled state (populated by Compile, not serialized).
+	compiledRegex  *regexp.Regexp
+	compiledSchema *jsonschema.Schema
+}
+
+// RangeSpec specifies an inclusive (gte/lte) or exclusive (gt/lt) numeric
+// bound. Any combination of fields may be set; at least one is required.
+type RangeSpec struct {
+	GTE *float64 `json:"gte,omitempty" yaml:"gte,omitempty"`
+	LTE *float64 `json:"lte,omitempty" yaml:"lte,omitempty"`
+	GT  *float64 `json:"gt,omitempty" yaml:"gt,omitempty"`
+	LT  *float64 `json:"lt,omitempty" yaml:"lt,omitempty"`
+}
+
+// UnmarshalYAML decodes a single-key mapping into a tagged Matcher.
+func (m *Matcher) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("argmatcher: expected mapping (e.g. {regex: '^foo'}), got %s", yamlKindName(node.Kind))
+	}
+	if len(node.Content) == 0 {
+		return fmt.Errorf("argmatcher: empty matcher; expected one of equals, regex, contains, range, json_schema")
+	}
+	if len(node.Content) > 2 {
+		var keys []string
+		for i := 0; i < len(node.Content); i += 2 {
+			keys = append(keys, node.Content[i].Value)
+		}
+		return fmt.Errorf("argmatcher: exactly one matcher kind allowed, got %d (%s)", len(keys), strings.Join(keys, ", "))
+	}
+
+	key := node.Content[0].Value
+	value := node.Content[1]
+
+	switch Kind(key) {
+	case KindEquals:
+		var v any
+		if err := value.Decode(&v); err != nil {
+			return fmt.Errorf("argmatcher equals: %w", err)
+		}
+		m.Kind = KindEquals
+		m.Equals = v
+	case KindRegex:
+		var s string
+		if err := value.Decode(&s); err != nil {
+			return fmt.Errorf("argmatcher regex: %w", err)
+		}
+		m.Kind = KindRegex
+		m.Regex = s
+	case KindContains:
+		var s string
+		if err := value.Decode(&s); err != nil {
+			return fmt.Errorf("argmatcher contains: %w", err)
+		}
+		m.Kind = KindContains
+		m.Contains = s
+	case KindRange:
+		var r RangeSpec
+		if err := value.Decode(&r); err != nil {
+			return fmt.Errorf("argmatcher range: %w", err)
+		}
+		m.Kind = KindRange
+		m.Range = &r
+	case KindJSONSchema:
+		var schema map[string]any
+		if err := value.Decode(&schema); err != nil {
+			return fmt.Errorf("argmatcher json_schema: %w", err)
+		}
+		m.Kind = KindJSONSchema
+		m.JSONSchema = schema
+	default:
+		return fmt.Errorf("argmatcher: unknown matcher kind %q (allowed: equals, regex, contains, range, json_schema)", key)
+	}
+
+	return m.Compile()
+}
+
+// UnmarshalJSON mirrors the YAML decoder for results-file round trips.
+func (m *Matcher) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	delete(raw, "kind")
+	if len(raw) == 0 {
+		return fmt.Errorf("argmatcher: empty matcher; expected one of equals, regex, contains, range, json_schema")
+	}
+	if len(raw) > 1 {
+		keys := make([]string, 0, len(raw))
+		for k := range raw {
+			keys = append(keys, k)
+		}
+		return fmt.Errorf("argmatcher: exactly one matcher kind allowed, got %d (%s)", len(keys), strings.Join(keys, ", "))
+	}
+	for key, value := range raw {
+		switch Kind(key) {
+		case KindEquals:
+			var v any
+			if err := json.Unmarshal(value, &v); err != nil {
+				return fmt.Errorf("argmatcher equals: %w", err)
+			}
+			m.Kind = KindEquals
+			m.Equals = v
+		case KindRegex:
+			var s string
+			if err := json.Unmarshal(value, &s); err != nil {
+				return fmt.Errorf("argmatcher regex: %w", err)
+			}
+			m.Kind = KindRegex
+			m.Regex = s
+		case KindContains:
+			var s string
+			if err := json.Unmarshal(value, &s); err != nil {
+				return fmt.Errorf("argmatcher contains: %w", err)
+			}
+			m.Kind = KindContains
+			m.Contains = s
+		case KindRange:
+			var r RangeSpec
+			if err := json.Unmarshal(value, &r); err != nil {
+				return fmt.Errorf("argmatcher range: %w", err)
+			}
+			m.Kind = KindRange
+			m.Range = &r
+		case KindJSONSchema:
+			var schema map[string]any
+			if err := json.Unmarshal(value, &schema); err != nil {
+				return fmt.Errorf("argmatcher json_schema: %w", err)
+			}
+			m.Kind = KindJSONSchema
+			m.JSONSchema = schema
+		default:
+			return fmt.Errorf("argmatcher: unknown matcher kind %q", key)
+		}
+	}
+	return m.Compile()
+}
+
+// MarshalJSON emits a single-key object matching the YAML/JSON input shape,
+// keeping `tool_events[]` snapshots stable for replay.
+func (m Matcher) MarshalJSON() ([]byte, error) {
+	switch m.Kind {
+	case KindEquals:
+		return json.Marshal(map[string]any{"equals": m.Equals})
+	case KindRegex:
+		return json.Marshal(map[string]any{"regex": m.Regex})
+	case KindContains:
+		return json.Marshal(map[string]any{"contains": m.Contains})
+	case KindRange:
+		return json.Marshal(map[string]any{"range": m.Range})
+	case KindJSONSchema:
+		return json.Marshal(map[string]any{"json_schema": m.JSONSchema})
+	case "":
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf("argmatcher: cannot marshal unknown kind %q", m.Kind)
+	}
+}
+
+// Compile validates the matcher invariants and pre-compiles any embedded
+// regex/schema. It is safe to call multiple times.
+func (m *Matcher) Compile() error {
+	switch m.Kind {
+	case KindEquals:
+		// nothing to compile; presence of value is allowed to be nil (matches null).
+	case KindRegex:
+		if m.Regex == "" {
+			return fmt.Errorf("argmatcher: regex matcher requires a non-empty pattern")
+		}
+		re, err := regexp.Compile(m.Regex)
+		if err != nil {
+			return fmt.Errorf("argmatcher: invalid regex %q: %w", m.Regex, err)
+		}
+		m.compiledRegex = re
+	case KindContains:
+		if m.Contains == "" {
+			return fmt.Errorf("argmatcher: contains matcher requires a non-empty substring")
+		}
+	case KindRange:
+		if m.Range == nil {
+			return fmt.Errorf("argmatcher: range matcher requires at least one bound (gte, lte, gt, lt)")
+		}
+		if m.Range.GTE == nil && m.Range.LTE == nil && m.Range.GT == nil && m.Range.LT == nil {
+			return fmt.Errorf("argmatcher: range matcher requires at least one bound (gte, lte, gt, lt)")
+		}
+	case KindJSONSchema:
+		if len(m.JSONSchema) == 0 {
+			return fmt.Errorf("argmatcher: json_schema matcher requires a non-empty schema")
+		}
+		schemaJSON, err := json.Marshal(m.JSONSchema)
+		if err != nil {
+			return fmt.Errorf("argmatcher: failed to serialize json_schema: %w", err)
+		}
+		var schemaVal any
+		if err := json.Unmarshal(schemaJSON, &schemaVal); err != nil {
+			return fmt.Errorf("argmatcher: failed to parse json_schema: %w", err)
+		}
+		compiler := jsonschema.NewCompiler()
+		if err := compiler.AddResource("argmatcher.json", schemaVal); err != nil {
+			return fmt.Errorf("argmatcher: failed to register json_schema: %w", err)
+		}
+		compiled, err := compiler.Compile("argmatcher.json")
+		if err != nil {
+			return fmt.Errorf("argmatcher: invalid json_schema: %w", err)
+		}
+		m.compiledSchema = compiled
+	case "":
+		return fmt.Errorf("argmatcher: matcher kind not set")
+	default:
+		return fmt.Errorf("argmatcher: unknown matcher kind %q", m.Kind)
+	}
+	return nil
+}
+
+// Match tests the value against the matcher. It returns ok=true when the
+// value satisfies the matcher and an explanation string suitable for grader
+// feedback.
+func (m *Matcher) Match(value any) (bool, string) {
+	switch m.Kind {
+	case KindEquals:
+		return matchEquals(m.Equals, value)
+	case KindRegex:
+		if m.compiledRegex == nil {
+			if err := m.Compile(); err != nil {
+				return false, err.Error()
+			}
+		}
+		return matchRegex(m.compiledRegex, m.Regex, value)
+	case KindContains:
+		return matchContains(m.Contains, value)
+	case KindRange:
+		return matchRange(m.Range, value)
+	case KindJSONSchema:
+		if m.compiledSchema == nil {
+			if err := m.Compile(); err != nil {
+				return false, err.Error()
+			}
+		}
+		return matchSchema(m.compiledSchema, value)
+	default:
+		return false, fmt.Sprintf("argmatcher: unsupported matcher kind %q", m.Kind)
+	}
+}
+
+func matchEquals(expected, actual any) (bool, string) {
+	expectedNorm, err := jsonNormalize(expected)
+	if err != nil {
+		return false, fmt.Sprintf("argmatcher equals: cannot normalise expected: %v", err)
+	}
+	actualNorm, err := jsonNormalize(actual)
+	if err != nil {
+		return false, fmt.Sprintf("argmatcher equals: cannot normalise actual: %v", err)
+	}
+	if reflect.DeepEqual(expectedNorm, actualNorm) {
+		return true, fmt.Sprintf("equals %s", renderValue(expectedNorm))
+	}
+	return false, fmt.Sprintf("expected %s, got %s", renderValue(expectedNorm), renderValue(actualNorm))
+}
+
+func matchRegex(re *regexp.Regexp, pattern string, actual any) (bool, string) {
+	s := toString(actual)
+	if re.MatchString(s) {
+		return true, fmt.Sprintf("regex %q matched", pattern)
+	}
+	return false, fmt.Sprintf("regex %q did not match %q", pattern, s)
+}
+
+func matchContains(needle string, actual any) (bool, string) {
+	s := toString(actual)
+	if strings.Contains(s, needle) {
+		return true, fmt.Sprintf("contains %q", needle)
+	}
+	return false, fmt.Sprintf("expected substring %q, got %q", needle, s)
+}
+
+func matchRange(spec *RangeSpec, actual any) (bool, string) {
+	n, ok := toFloat(actual)
+	if !ok {
+		return false, fmt.Sprintf("range: value %v is not numeric", actual)
+	}
+	if spec.GTE != nil && n < *spec.GTE {
+		return false, fmt.Sprintf("range: %v < gte %v", n, *spec.GTE)
+	}
+	if spec.GT != nil && n <= *spec.GT {
+		return false, fmt.Sprintf("range: %v <= gt %v", n, *spec.GT)
+	}
+	if spec.LTE != nil && n > *spec.LTE {
+		return false, fmt.Sprintf("range: %v > lte %v", n, *spec.LTE)
+	}
+	if spec.LT != nil && n >= *spec.LT {
+		return false, fmt.Sprintf("range: %v >= lt %v", n, *spec.LT)
+	}
+	return true, fmt.Sprintf("range: %v within bounds", n)
+}
+
+func matchSchema(schema *jsonschema.Schema, actual any) (bool, string) {
+	norm, err := jsonNormalize(actual)
+	if err != nil {
+		return false, fmt.Sprintf("json_schema: %v", err)
+	}
+	if err := schema.Validate(norm); err != nil {
+		return false, fmt.Sprintf("json_schema: %v", err)
+	}
+	return true, "json_schema: valid"
+}
+
+func jsonNormalize(v any) (any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func toString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	}
+	return 0, false
+}
+
+func renderValue(v any) string {
+	if v == nil {
+		return "null"
+	}
+	if s, ok := v.(string); ok {
+		return fmt.Sprintf("%q", s)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func yamlKindName(k yaml.Kind) string {
+	switch k {
+	case yaml.DocumentNode:
+		return "document"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.AliasNode:
+		return "alias"
+	default:
+		return fmt.Sprintf("kind(%d)", k)
+	}
+}

--- a/internal/graders/argmatcher/matcher.go
+++ b/internal/graders/argmatcher/matcher.go
@@ -227,6 +227,22 @@ func (m Matcher) MarshalJSON() ([]byte, error) {
 	}
 }
 
+// IsCompiled reports whether Compile() has cached state for the matcher's
+// kind. Only KindRegex and KindJSONSchema have compiled state; other kinds
+// return true because they need no precompilation. Primarily useful as a
+// test/diagnostic hook to verify Compile() side-effects persisted across map
+// reads (issue #366 review feedback).
+func (m *Matcher) IsCompiled() bool {
+	switch m.Kind {
+	case KindRegex:
+		return m.compiledRegex != nil
+	case KindJSONSchema:
+		return m.compiledSchema != nil
+	default:
+		return true
+	}
+}
+
 // Compile validates the matcher invariants and pre-compiles any embedded
 // regex/schema. It is safe to call multiple times.
 func (m *Matcher) Compile() error {

--- a/internal/graders/argmatcher/matcher_test.go
+++ b/internal/graders/argmatcher/matcher_test.go
@@ -1,0 +1,211 @@
+package argmatcher
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestMatcherYAMLDecode(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantErr  string
+		wantKind Kind
+	}{
+		{name: "equals string", yaml: `{equals: "hello"}`, wantKind: KindEquals},
+		{name: "equals number", yaml: `{equals: 42}`, wantKind: KindEquals},
+		{name: "equals object", yaml: `{equals: {a: 1, b: 2}}`, wantKind: KindEquals},
+		{name: "regex", yaml: `{regex: "^auth"}`, wantKind: KindRegex},
+		{name: "contains", yaml: `{contains: "abc"}`, wantKind: KindContains},
+		{name: "range gte+lte", yaml: `{range: {gte: 1, lte: 5}}`, wantKind: KindRange},
+		{name: "range gt only", yaml: `{range: {gt: 0}}`, wantKind: KindRange},
+		{name: "json_schema", yaml: `{json_schema: {type: object, required: [a]}}`, wantKind: KindJSONSchema},
+
+		{name: "empty matcher", yaml: `{}`, wantErr: "empty matcher"},
+		{name: "two keys", yaml: `{regex: "a", contains: "b"}`, wantErr: "exactly one matcher kind"},
+		{name: "unknown kind", yaml: `{wat: "x"}`, wantErr: "unknown matcher kind"},
+		{name: "regex empty", yaml: `{regex: ""}`, wantErr: "non-empty pattern"},
+		{name: "regex invalid", yaml: `{regex: "["}`, wantErr: "invalid regex"},
+		{name: "contains empty", yaml: `{contains: ""}`, wantErr: "non-empty substring"},
+		{name: "range no bounds", yaml: `{range: {}}`, wantErr: "at least one bound"},
+		{name: "json_schema empty", yaml: `{json_schema: {}}`, wantErr: "non-empty schema"},
+		{name: "json_schema invalid", yaml: `{json_schema: {type: "nonsense"}}`, wantErr: "invalid json_schema"},
+		{name: "not a mapping", yaml: `"foo"`, wantErr: "expected mapping"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m Matcher
+			err := yaml.Unmarshal([]byte(tt.yaml), &m)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if m.Kind != tt.wantKind {
+				t.Fatalf("kind = %q, want %q", m.Kind, tt.wantKind)
+			}
+		})
+	}
+}
+
+func TestMatcherEquals(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected any
+		actual   any
+		want     bool
+	}{
+		{"string match", "hello", "hello", true},
+		{"string mismatch", "hello", "world", false},
+		{"int vs float", 42, 42.0, true},
+		{"object match", map[string]any{"a": 1}, map[string]any{"a": 1.0}, true},
+		{"object mismatch", map[string]any{"a": 1}, map[string]any{"a": 2}, false},
+		{"nil match", nil, nil, true},
+		{"array match", []any{1, 2}, []any{1, 2}, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Matcher{Kind: KindEquals, Equals: tt.expected}
+			ok, msg := m.Match(tt.actual)
+			if ok != tt.want {
+				t.Fatalf("want %v, got %v (%s)", tt.want, ok, msg)
+			}
+			if msg == "" {
+				t.Fatal("expected non-empty message")
+			}
+		})
+	}
+}
+
+func TestMatcherRegex(t *testing.T) {
+	m := &Matcher{Kind: KindRegex, Regex: "^auth"}
+	if err := m.Compile(); err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := m.Match("auth-login"); !ok {
+		t.Fatal("expected match")
+	}
+	if ok, _ := m.Match("login"); ok {
+		t.Fatal("expected no match")
+	}
+	// non-string value falls back to JSON encoding
+	if ok, _ := m.Match(map[string]any{"x": 1}); ok {
+		t.Fatal("expected no match for object")
+	}
+}
+
+func TestMatcherContains(t *testing.T) {
+	m := &Matcher{Kind: KindContains, Contains: "hello"}
+	if err := m.Compile(); err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := m.Match("say hello world"); !ok {
+		t.Fatal("expected match")
+	}
+	if ok, _ := m.Match("goodbye"); ok {
+		t.Fatal("expected no match")
+	}
+}
+
+func TestMatcherRange(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+	m := &Matcher{Kind: KindRange, Range: &RangeSpec{GTE: f(1), LTE: f(5)}}
+	if err := m.Compile(); err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := m.Match(3); !ok {
+		t.Fatal("expected 3 in range")
+	}
+	if ok, _ := m.Match(0); ok {
+		t.Fatal("expected 0 below range")
+	}
+	if ok, _ := m.Match(6); ok {
+		t.Fatal("expected 6 above range")
+	}
+	if ok, _ := m.Match("not a number"); ok {
+		t.Fatal("expected non-numeric rejection")
+	}
+
+	// exclusive bounds
+	m2 := &Matcher{Kind: KindRange, Range: &RangeSpec{GT: f(0), LT: f(10)}}
+	_ = m2.Compile()
+	if ok, _ := m2.Match(0); ok {
+		t.Fatal("gt boundary should fail")
+	}
+	if ok, _ := m2.Match(10); ok {
+		t.Fatal("lt boundary should fail")
+	}
+	if ok, _ := m2.Match(5); !ok {
+		t.Fatal("5 within exclusive bounds")
+	}
+}
+
+func TestMatcherJSONSchema(t *testing.T) {
+	m := &Matcher{
+		Kind: KindJSONSchema,
+		JSONSchema: map[string]any{
+			"type":     "object",
+			"required": []any{"name"},
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+				"age":  map[string]any{"type": "integer", "minimum": 0},
+			},
+		},
+	}
+	if err := m.Compile(); err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := m.Match(map[string]any{"name": "alice", "age": 30}); !ok {
+		t.Fatal("expected valid")
+	}
+	if ok, _ := m.Match(map[string]any{"age": 30}); ok {
+		t.Fatal("expected required-field failure")
+	}
+	if ok, _ := m.Match(map[string]any{"name": "a", "age": -1}); ok {
+		t.Fatal("expected minimum failure")
+	}
+}
+
+func TestMatcherJSONRoundTrip(t *testing.T) {
+	src := `{"regex":"^auth"}`
+	var m Matcher
+	if err := json.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.Kind != KindRegex || m.Regex != "^auth" {
+		t.Fatalf("unexpected matcher: %+v", m)
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != src {
+		t.Fatalf("round trip mismatch: got %s want %s", out, src)
+	}
+}
+
+func TestMatcherJSONRejectsMultipleKinds(t *testing.T) {
+	var m Matcher
+	err := json.Unmarshal([]byte(`{"regex":"a","contains":"b"}`), &m)
+	if err == nil || !strings.Contains(err.Error(), "exactly one matcher kind") {
+		t.Fatalf("expected multi-kind error, got %v", err)
+	}
+}
+
+func TestMatcherZeroValueErrors(t *testing.T) {
+	var m Matcher
+	ok, msg := m.Match("x")
+	if ok || msg == "" {
+		t.Fatalf("zero matcher must fail, got ok=%v msg=%q", ok, msg)
+	}
+}

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -1,0 +1,84 @@
+package graders
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/microsoft/waza/internal/graders/argmatcher"
+	"github.com/microsoft/waza/internal/models"
+)
+
+// normalizeToolCallArgs returns the tool call's arguments as a generic
+// map[string]any suitable for argument matchers. Only the well-known fields
+// recognized by ToolCallArgs (path, file_text, command, description, skill)
+// are present; engine-specific extensions would require widening the SDK
+// shape. Empty-valued fields are omitted.
+func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
+	data, err := json.Marshal(call.Arguments)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling tool args: %w", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshaling tool args: %w", err)
+	}
+	out := make(map[string]any, len(raw))
+	for k, v := range raw {
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// evaluateArgMatchers returns a slice of human-readable failures describing
+// any matcher in `matchers` whose key was absent from `args` or whose value
+// failed to match. An empty slice means every matcher passed.
+func evaluateArgMatchers(matchers map[string]argmatcher.Matcher, args map[string]any) []string {
+	if len(matchers) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(matchers))
+	for k := range matchers {
+		keys = append(keys, k)
+	}
+	// deterministic order for stable feedback / replay
+	sortStrings(keys)
+
+	var failures []string
+	for _, key := range keys {
+		m := matchers[key]
+		v, present := args[key]
+		if !present {
+			failures = append(failures, fmt.Sprintf("argument %q: not present on tool call", key))
+			continue
+		}
+		ok, reason := m.Match(v)
+		if !ok {
+			failures = append(failures, fmt.Sprintf("argument %q: %s", key, reason))
+		}
+	}
+	return failures
+}
+
+// compileToolRegex compiles a tool-name matcher. Empty patterns match any
+// tool name. Case-insensitive by default.
+func compileToolRegex(pattern string) (*regexp.Regexp, error) {
+	if pattern == "" {
+		return nil, nil
+	}
+	return regexp.Compile("(?i)" + pattern)
+}
+
+// sortStrings is a tiny inline sort to avoid pulling sort.Strings into hot
+// paths from a single call site. Keeps allocations predictable.
+func sortStrings(s []string) {
+	// insertion sort — matcher keys are typically <5 entries.
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -10,10 +10,13 @@ import (
 )
 
 // normalizeToolCallArgs returns the tool call's arguments as a generic
-// map[string]any suitable for argument matchers. Only the well-known fields
-// recognized by ToolCallArgs (path, file_text, command, description, skill)
-// are present; engine-specific extensions would require widening the SDK
-// shape. Empty-valued fields are omitted.
+// map[string]any suitable for argument matchers. Known fields recognized by
+// ToolCallArgs (path, file_text, command, description, skill) are merged with
+// any engine-specific extras captured under ToolCallArgs.Extra (populated by
+// mapstructure's ",remain" support), so MCP tools and other arbitrary
+// argument keys (e.g. `query`, `limit`) are visible to matchers. Empty-valued
+// known fields are omitted to avoid spurious matches on the zero value;
+// keys in Extra are passed through as-is.
 func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	data, err := json.Marshal(call.Arguments)
 	if err != nil {
@@ -23,9 +26,20 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("unmarshaling tool args: %w", err)
 	}
-	out := make(map[string]any, len(raw))
+	out := make(map[string]any, len(raw)+len(call.Arguments.Extra))
 	for k, v := range raw {
 		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		out[k] = v
+	}
+	// Merge engine-specific extras last so they win over zero-valued known
+	// fields. Known-field collisions (e.g. an MCP tool that happens to
+	// declare a `path` arg with extra metadata) keep the typed value from
+	// ToolCallArgs since it has already been written above and Extra by
+	// construction holds only keys mapstructure could not place.
+	for k, v := range call.Arguments.Extra {
+		if _, present := out[k]; present {
 			continue
 		}
 		out[k] = v

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -3,16 +3,25 @@ package graders
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
+	"github.com/microsoft/waza/internal/graders/argmatcher"
 	"github.com/microsoft/waza/internal/models"
 )
 
 // ToolCallsGrader validates which tools an agent called during execution.
 // It checks required tools, forbidden tools, minimum calls, and maximum calls.
 type ToolCallsGrader struct {
-	name   string
-	params models.ToolCallsGraderParameters
+	name           string
+	params         models.ToolCallsGraderParameters
+	compiledExpect []compiledExpectation
+}
+
+type compiledExpectation struct {
+	raw     models.ToolExpectation
+	toolRe  *regexp.Regexp
+	matcher map[string]argmatcher.Matcher
 }
 
 // NewToolCallsGrader creates a new ToolCallsGrader, returning an error if the
@@ -22,10 +31,11 @@ func NewToolCallsGrader(name string, params models.ToolCallsGraderParameters) (*
 	hasConstraint := len(params.RequiredTools) > 0 ||
 		len(params.ForbiddenTools) > 0 ||
 		params.MinCalls != nil ||
-		params.MaxCalls != nil
+		params.MaxCalls != nil ||
+		len(params.Expect) > 0
 
 	if !hasConstraint {
-		return nil, fmt.Errorf("tool_calls grader %q: at least one constraint (required_tools, forbidden_tools, min_calls, max_calls) must be specified", name)
+		return nil, fmt.Errorf("tool_calls grader %q: at least one constraint (required_tools, forbidden_tools, min_calls, max_calls, expect) must be specified", name)
 	}
 
 	if params.MinCalls != nil && *params.MinCalls < 0 {
@@ -38,7 +48,26 @@ func NewToolCallsGrader(name string, params models.ToolCallsGraderParameters) (*
 		return nil, fmt.Errorf("tool_calls grader %q: min_calls (%d) must be <= max_calls (%d)", name, *params.MinCalls, *params.MaxCalls)
 	}
 
-	return &ToolCallsGrader{name: name, params: params}, nil
+	compiled := make([]compiledExpectation, 0, len(params.Expect))
+	for i, exp := range params.Expect {
+		if strings.TrimSpace(exp.Tool) == "" {
+			return nil, fmt.Errorf("tool_calls grader %q: expect[%d].tool: required non-empty string", name, i)
+		}
+		re, err := compileToolRegex(exp.Tool)
+		if err != nil {
+			return nil, fmt.Errorf("tool_calls grader %q: expect[%d].tool: invalid regex: %w", name, i, err)
+		}
+		mm := make(map[string]argmatcher.Matcher, len(exp.Args))
+		for k, m := range exp.Args {
+			if err := m.Compile(); err != nil {
+				return nil, fmt.Errorf("tool_calls grader %q: expect[%d].args[%s]: %w", name, i, k, err)
+			}
+			mm[k] = m
+		}
+		compiled = append(compiled, compiledExpectation{raw: exp, toolRe: re, matcher: mm})
+	}
+
+	return &ToolCallsGrader{name: name, params: params, compiledExpect: compiled}, nil
 }
 
 func (g *ToolCallsGrader) Name() string            { return g.name }
@@ -100,6 +129,21 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 			}
 		}
 
+		// Per-expectation checks: each expectation contributes one check;
+		// it passes when at least one recorded tool call matches the tool
+		// name regex AND all configured arg matchers pass on that call.
+		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
+		for _, exp := range g.compiledExpect {
+			totalChecks++
+			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			expectResults = append(expectResults, detail)
+			if matched {
+				passedChecks++
+			} else {
+				failures = append(failures, fmt.Sprintf("expectation tool=%q not satisfied: %s", exp.raw.Tool, detail["reason"]))
+			}
+		}
+
 		score := float64(passedChecks) / float64(totalChecks)
 		passed := passedChecks == totalChecks
 
@@ -113,17 +157,67 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 			calledNames = append(calledNames, name)
 		}
 
+		details := map[string]any{
+			"total_calls":   totalCalls,
+			"unique_tools":  calledNames,
+			"passed_checks": passedChecks,
+			"total_checks":  totalChecks,
+		}
+		if len(expectResults) > 0 {
+			details["expect"] = expectResults
+		}
+
 		return &models.GraderResults{
 			Name:     g.name,
 			Passed:   passed,
 			Score:    score,
 			Feedback: feedback,
-			Details: map[string]any{
-				"total_calls":   totalCalls,
-				"unique_tools":  calledNames,
-				"passed_checks": passedChecks,
-				"total_checks":  totalChecks,
-			},
+			Details:  details,
 		}, nil
 	})
+}
+
+// evaluateExpectation returns whether any of the calls satisfies the
+// expectation, and a structured detail record describing the best-effort
+// reason on failure (or the index of the satisfying call on success).
+func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+	detail := map[string]any{"tool": exp.raw.Tool}
+	if len(exp.matcher) > 0 {
+		detail["args"] = exp.raw.Args
+	}
+
+	nameMatches := 0
+	var lastReason string
+	for i, call := range calls {
+		if exp.toolRe != nil && !exp.toolRe.MatchString(call.Name) {
+			continue
+		}
+		nameMatches++
+		if len(exp.matcher) == 0 {
+			detail["matched_call_index"] = i
+			detail["matched_call_id"] = call.ID
+			return true, detail
+		}
+		args, err := normalizeToolCallArgs(call)
+		if err != nil {
+			lastReason = err.Error()
+			continue
+		}
+		failures := evaluateArgMatchers(exp.matcher, args)
+		if len(failures) == 0 {
+			detail["matched_call_index"] = i
+			detail["matched_call_id"] = call.ID
+			return true, detail
+		}
+		lastReason = strings.Join(failures, "; ")
+	}
+
+	if nameMatches == 0 {
+		detail["reason"] = "no tool call with matching name"
+	} else if lastReason != "" {
+		detail["reason"] = lastReason
+	} else {
+		detail["reason"] = "no matching call"
+	}
+	return false, detail
 }

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/microsoft/waza/internal/graders/argmatcher"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/require"
 )
@@ -352,4 +353,179 @@ func TestToolCallsGrader_Factory(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "check-tools", g.Name())
 	require.Equal(t, models.GraderKindToolCalls, g.Kind())
+}
+
+// ---------------------------------------------------------------------------
+// Expect: structured tool expectations with argument matchers (issue #366).
+// ---------------------------------------------------------------------------
+
+func TestToolCallsGrader_Expect_NoArgs_Passes(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "bash"}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{Name: "bash", Arguments: models.ToolCallArgs{Command: "ls"}}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_MissingTool_Fails(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "bash"}, {Tool: "view"}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{Name: "bash"}},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.InDelta(t, 0.5, res.Score, 0.01)
+	require.Contains(t, res.Feedback, "view")
+}
+
+func TestToolCallsGrader_Expect_RegexArgMatch_Passes(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindRegex, Regex: `^ls .*`},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash", Arguments: models.ToolCallArgs{Command: "ls -la"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_RegexArgMismatch_Fails(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindRegex, Regex: `^npm test`},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash", Arguments: models.ToolCallArgs{Command: "ls -la"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.Contains(t, res.Feedback, "command")
+}
+
+func TestToolCallsGrader_Expect_EqualsArgMatch_Passes(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "view",
+			Args: map[string]argmatcher.Matcher{
+				"path": {Kind: argmatcher.KindEquals, Equals: "/etc/hosts"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "view", Arguments: models.ToolCallArgs{Path: "/etc/hosts"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ContainsArgMatch_Passes(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindContains, Contains: "test"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash", Arguments: models.ToolCallArgs{Command: "go test ./..."}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ArgKeyMissing_Fails(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindRegex, Regex: ".+"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	// ToolCall with no Command set — arg key absent.
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{Name: "bash"}},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+}
+
+func TestToolCallsGrader_Expect_PicksLatestSameNameCall(t *testing.T) {
+	// When a tool is called multiple times, any matching invocation should
+	// satisfy the expectation.
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindEquals, Equals: "ls"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "bash", Arguments: models.ToolCallArgs{Command: "pwd"}},
+				{Name: "bash", Arguments: models.ToolCallArgs{Command: "ls"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_InvalidMatcher_ConstructError(t *testing.T) {
+	_, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindRegex, Regex: "["},
+			},
+		}},
+	})
+	require.Error(t, err)
 }

--- a/internal/graders/tool_constraint_grader.go
+++ b/internal/graders/tool_constraint_grader.go
@@ -49,10 +49,17 @@ func validateToolSpecs(specs []models.ToolSpecParameters, fieldName string) ([]m
 			}
 		}
 
+		// Persist Compile() side-effects back into the map. Map values are not
+		// addressable, so iterating gives us a value-copy of each Matcher;
+		// calling Compile() on that copy mutates only the local, and Match()
+		// would have to recompile on every call. Reassigning the (now-compiled)
+		// copy into the map preserves compiledRegex/compiledSchema for hot
+		// paths and keeps subsequent Match() calls allocation-free.
 		for argName, m := range spec.Args {
 			if err := m.Compile(); err != nil {
 				return nil, fmt.Errorf("config.%s[%d].args[%s]: %w", fieldName, i, argName, err)
 			}
+			spec.Args[argName] = m
 		}
 
 		normalized[i] = spec

--- a/internal/graders/tool_constraint_grader.go
+++ b/internal/graders/tool_constraint_grader.go
@@ -49,6 +49,12 @@ func validateToolSpecs(specs []models.ToolSpecParameters, fieldName string) ([]m
 			}
 		}
 
+		for argName, m := range spec.Args {
+			if err := m.Compile(); err != nil {
+				return nil, fmt.Errorf("config.%s[%d].args[%s]: %w", fieldName, i, argName, err)
+			}
+		}
+
 		normalized[i] = spec
 	}
 
@@ -163,6 +169,16 @@ func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool 
 		return false
 	}
 
+	if len(spec.Args) > 0 {
+		args, err := normalizeToolCallArgs(call)
+		if err != nil {
+			return false
+		}
+		if failures := evaluateArgMatchers(spec.Args, args); len(failures) > 0 {
+			return false
+		}
+	}
+
 	return true
 }
 
@@ -178,6 +194,14 @@ func describeToolSpec(spec models.ToolSpecParameters) string {
 	}
 	if spec.PathPattern != "" {
 		qualifiers = append(qualifiers, fmt.Sprintf("path_pattern: %s", spec.PathPattern))
+	}
+	if len(spec.Args) > 0 {
+		keys := make([]string, 0, len(spec.Args))
+		for k := range spec.Args {
+			keys = append(keys, k)
+		}
+		sortStrings(keys)
+		qualifiers = append(qualifiers, fmt.Sprintf("args: [%s]", strings.Join(keys, ", ")))
 	}
 
 	if len(qualifiers) == 0 {

--- a/internal/graders/tool_constraint_grader_test.go
+++ b/internal/graders/tool_constraint_grader_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/waza/internal/graders/argmatcher"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/require"
 )
@@ -414,4 +415,89 @@ func TestToolConstraintGrader_InvalidArgsPatternRegex(t *testing.T) {
 	if !strings.Contains(err.Error(), "config.reject_tools[0].command_pattern: invalid regex") {
 		t.Fatalf("unexpected error message: %v", err)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Args: structured argument matchers on tool specs (issue #366).
+// ---------------------------------------------------------------------------
+
+func TestToolConstraintGrader_ExpectTools_ArgEquals_Pass(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "view",
+			Args: map[string]argmatcher.Matcher{
+				"path": {Kind: argmatcher.KindEquals, Equals: "/etc/hosts"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"view"},
+			ToolCalls: []models.ToolCall{
+				{Name: "view", Arguments: models.ToolCallArgs{Path: "/etc/hosts"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolConstraintGrader_ExpectTools_ArgRegex_Fail(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindRegex, Regex: `^npm test`},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"bash"},
+			ToolCalls: []models.ToolCall{
+				{Name: "bash", Arguments: models.ToolCallArgs{Command: "ls"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+}
+
+func TestToolConstraintGrader_ExpectTools_ArgContains_Pass(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindContains, Contains: "go test"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"bash"},
+			ToolCalls: []models.ToolCall{
+				{Name: "bash", Arguments: models.ToolCallArgs{Command: "go test ./..."}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolConstraintGrader_InvalidArgMatcher_ConstructError(t *testing.T) {
+	_, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindRegex, Regex: "["},
+			},
+		}},
+	})
+	require.Error(t, err)
 }

--- a/internal/graders/tool_constraint_grader_test.go
+++ b/internal/graders/tool_constraint_grader_test.go
@@ -501,3 +501,110 @@ func TestToolConstraintGrader_InvalidArgMatcher_ConstructError(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for review feedback on issue #366.
+// ---------------------------------------------------------------------------
+
+// TestValidateToolSpecs_PersistsCompiledMatcher verifies that validateToolSpecs
+// writes the Compile()-mutated matcher back into spec.Args. Because the map
+// stores Matcher by value (not by pointer), Compile() mutates a local copy of
+// each matcher during iteration; if the caller does not reassign the compiled
+// copy into the map, every subsequent Match() call has to recompile the regex
+// or JSON schema. The fix is `spec.Args[argName] = m` after Compile.
+func TestValidateToolSpecs_PersistsCompiledMatcher(t *testing.T) {
+	regexMatcher := argmatcher.Matcher{Kind: argmatcher.KindRegex, Regex: `^auth`}
+	schemaMatcher := argmatcher.Matcher{
+		Kind:       argmatcher.KindJSONSchema,
+		JSONSchema: map[string]any{"type": "string"},
+	}
+	specs := []models.ToolSpecParameters{{
+		Tool: "search",
+		Args: map[string]argmatcher.Matcher{
+			"query":  regexMatcher,
+			"filter": schemaMatcher,
+		},
+	}}
+
+	normalized, err := validateToolSpecs(specs, "expect_tools")
+	require.NoError(t, err)
+	require.Len(t, normalized, 1)
+
+	for name, m := range normalized[0].Args {
+		require.Truef(t, m.IsCompiled(),
+			"matcher %q: Compile() side-effects were not persisted back into the map", name)
+	}
+
+	// Caller-side invariants should not have been mutated.
+	require.False(t, regexMatcher.IsCompiled(), "input matcher should be unchanged")
+	require.False(t, schemaMatcher.IsCompiled(), "input matcher should be unchanged")
+}
+
+// TestToolConstraintGrader_ExpectTools_MatchesExtraArgs verifies that
+// argument matchers see engine-specific argument keys (e.g. MCP-style
+// `query`/`limit`) that are not part of the fixed ToolCallArgs struct.
+// `ToolCallArgs.Extra` (mapstructure ",remain") captures these so
+// normalizeToolCallArgs can surface them.
+func TestToolConstraintGrader_ExpectTools_MatchesExtraArgs(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+				"limit": {
+					Kind:  argmatcher.KindRange,
+					Range: &argmatcher.RangeSpec{GTE: float64Ptr(1), LTE: float64Ptr(10)},
+				},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"search"},
+			ToolCalls: []models.ToolCall{
+				{
+					Name: "search",
+					Arguments: models.ToolCallArgs{
+						Extra: map[string]any{
+							"query": "find auth bypass",
+							"limit": 5,
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+// TestToolConstraintGrader_ExpectTools_MissingExtraArg verifies the inverse:
+// when the call lacks an MCP-style extra arg the matcher expects, the spec
+// does not match (so the grader reports the expected tool as unused).
+func TestToolConstraintGrader_ExpectTools_MissingExtraArg(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"search"},
+			ToolCalls: []models.ToolCall{
+				// Note: no Extra map → `query` arg absent → spec does not match.
+				{Name: "search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+}
+
+func float64Ptr(v float64) *float64 { return &v }

--- a/internal/models/events.go
+++ b/internal/models/events.go
@@ -32,6 +32,19 @@ type ToolCallArgs struct {
 
 	// filled out for skill invocations
 	Skill string `json:"skill" mapstructure:"skill"`
+
+	// Extra captures any tool-specific argument keys that aren't part of
+	// the fixed fields above (e.g. `query`/`limit` for search tools,
+	// MCP-specific payloads). Populated automatically by mapstructure's
+	// ",remain" support so argument matchers in tool_calls /
+	// tool_constraint graders can see the full argument bag.
+	//
+	// Excluded from JSON marshaling: callers consuming arguments as a
+	// generic map should use graders.normalizeToolCallArgs, which merges
+	// Extra into the known fields. Persisting the raw bag in results.json
+	// happens through RunResult.ToolEvents instead, which preserves the
+	// engine's original argument value verbatim.
+	Extra map[string]any `json:"-" mapstructure:",remain"`
 }
 
 type TranscriptEvent struct {

--- a/internal/models/grader_params.go
+++ b/internal/models/grader_params.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/microsoft/waza/internal/graders/argmatcher"
 	"gopkg.in/yaml.v3"
 )
 
@@ -119,6 +120,13 @@ type ToolSpecParameters struct {
 	CommandPattern string `yaml:"command_pattern,omitempty" json:"command_pattern,omitempty"`
 	SkillPattern   string `yaml:"skill_pattern,omitempty" json:"skill_pattern,omitempty"`
 	PathPattern    string `yaml:"path_pattern,omitempty" json:"path_pattern,omitempty"`
+
+	// Args constrains specific argument fields on the tool call using
+	// structured matchers (equals / regex / contains / range / json_schema).
+	// Keys are argument names as they appear on ToolCall.Arguments after JSON
+	// normalisation; values are matcher specs. All matchers must pass for the
+	// call to satisfy the spec.
+	Args map[string]argmatcher.Matcher `yaml:"args,omitempty" json:"args,omitempty"`
 }
 
 type ToolConstraintGraderParameters struct {
@@ -157,6 +165,28 @@ type ToolCallsGraderParameters struct {
 	ForbiddenTools []string `yaml:"forbidden_tools,omitempty" json:"forbidden_tools,omitempty"`
 	MinCalls       *int     `yaml:"min_calls,omitempty" json:"min_calls,omitempty"`
 	MaxCalls       *int     `yaml:"max_calls,omitempty" json:"max_calls,omitempty"`
+
+	// Expect is an ordered list of tool-call expectations. Each entry names
+	// the expected tool and (optionally) structured matchers for argument
+	// fields. An expectation passes when there is at least one actual tool
+	// call whose name matches and whose arguments satisfy every matcher.
+	//
+	// Unlike RequiredTools (which only checks names), Expect lets a grader
+	// assert input correctness — e.g. "list_dir was called with
+	// path matching ^src/".
+	Expect []ToolExpectation `yaml:"expect,omitempty" json:"expect,omitempty"`
+}
+
+// ToolExpectation defines one entry in [ToolCallsGraderParameters].Expect.
+type ToolExpectation struct {
+	// Tool is the expected tool name (matched as a Go regexp against the
+	// recorded tool name). A plain string is a substring match anchored by
+	// the regexp engine, so use `^foo$` for exact match.
+	Tool string `yaml:"tool" json:"tool"`
+
+	// Args holds matcher specs for tool-call argument fields. All matchers
+	// must pass for the expectation to be considered satisfied.
+	Args map[string]argmatcher.Matcher `yaml:"args,omitempty" json:"args,omitempty"`
 }
 
 func (ToolCallsGraderParameters) isGraderParameters() {}

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -196,6 +196,12 @@ type RunResult struct {
 	// configured TestCase.Checkpoint that actually ran (i.e., turn index was
 	// reached). Empty / omitted when the task defines no checkpoints.
 	Checkpoints []CheckpointOutcome `json:"checkpoints,omitempty"`
+
+	// ToolEvents is a normalized, replay-friendly record of every tool call
+	// made during the run. Added in schema version 1.1 as an additive field
+	// (see issue #366). The legacy SessionDigest.ToolCalls is preserved for
+	// backward compatibility; new consumers should prefer ToolEvents.
+	ToolEvents []ToolEvent `json:"tool_events,omitempty"`
 }
 
 // CheckpointOutcome captures the results of a single TestCase.Checkpoint that

--- a/internal/models/outcome_schema_test.go
+++ b/internal/models/outcome_schema_test.go
@@ -84,7 +84,60 @@ func TestEvaluationOutcomeMarshalDefaultsSchemaVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal() error = %v", err)
 	}
-	if !strings.Contains(string(data), `"schemaVersion":"1.1"`) {
+	if !strings.Contains(string(data), `"schemaVersion":"`+CurrentSchemaVersion+`"`) {
 		t.Fatalf("marshaled outcome missing default schemaVersion: %s", data)
+	}
+}
+
+// TestEvaluationOutcome_ToolEventsRoundTrip verifies the schema 1.1 additive
+// tool_events[] field round-trips through JSON without loss (issue #366).
+func TestEvaluationOutcome_ToolEventsRoundTrip(t *testing.T) {
+	original := &EvaluationOutcome{
+		SkillTested:   "test-skill",
+		BenchName:     "test-eval",
+		SchemaVersion: CurrentSchemaVersion,
+		Timestamp:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		TestOutcomes: []TestOutcome{{
+			TestID: "t1",
+			Runs: []RunResult{{
+				RunNumber: 1,
+				ToolEvents: []ToolEvent{
+					{
+						Turn: 1, Sequence: 1,
+						ToolCallID: "call-a", ToolName: "bash",
+						Args:    map[string]any{"command": "go test"},
+						Success: true, DurationMs: 42,
+					},
+					{
+						Turn: 1, Sequence: 2,
+						ToolCallID: "call-b", ToolName: "view",
+						Args:    map[string]any{"path": "/tmp/x"},
+						Success: false, Error: "not found",
+					},
+				},
+			}},
+		}},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// The wire field name must be `tool_events` per the documented schema.
+	if !strings.Contains(string(data), `"tool_events"`) {
+		t.Fatalf("expected tool_events field in marshaled JSON: %s", data)
+	}
+
+	var restored EvaluationOutcome
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := len(restored.TestOutcomes[0].Runs[0].ToolEvents); got != 2 {
+		t.Fatalf("ToolEvents length = %d, want 2", got)
+	}
+	te := restored.TestOutcomes[0].Runs[0].ToolEvents[0]
+	if te.ToolCallID != "call-a" || te.ToolName != "bash" || !te.Success || te.DurationMs != 42 {
+		t.Fatalf("first tool event lost fidelity: %+v", te)
 	}
 }

--- a/internal/models/schema_version.go
+++ b/internal/models/schema_version.go
@@ -16,8 +16,10 @@ import (
 const (
 	// CurrentSchemaVersion is the current MAJOR.MINOR schema version for public artifacts.
 	//
-	// 1.1 adds per-turn checkpoints (TestCase.Checkpoints / RunResult.Checkpoints) — purely
-	// additive over 1.0, so 1.0 artifacts continue to load without migration.
+	// 1.0 — initial public schema (PR #382 / issue #368).
+	// 1.1 — additive: per-turn checkpoints (TestCase.Checkpoints / RunResult.Checkpoints, #358)
+	//       and RunResult.tool_events[] for per-task tool metrics (#366). Purely additive
+	//       over 1.0, so 1.0 artifacts continue to load without migration.
 	CurrentSchemaVersion = "1.1"
 )
 

--- a/internal/models/spec_test.go
+++ b/internal/models/spec_test.go
@@ -123,7 +123,8 @@ config:
 func TestLoadEvalSpec_MCPMocksRequireSchemaVersion11(t *testing.T) {
 	tempDir := t.TempDir()
 	specPath := filepath.Join(tempDir, "spec.yaml")
-	specYAML := `name: mcp-mocks
+	specYAML := `schemaVersion: "1.0"
+name: mcp-mocks
 skill: test-skill
 config:
   trials_per_task: 1
@@ -152,7 +153,7 @@ metrics:
 		t.Fatalf("expected schemaVersion 1.1 error, got %v", err)
 	}
 
-	specYAML = "schemaVersion: \"1.1\"\n" + specYAML
+	specYAML = strings.Replace(specYAML, `schemaVersion: "1.0"`, `schemaVersion: "1.1"`, 1)
 	if err := os.WriteFile(specPath, []byte(specYAML), 0644); err != nil {
 		t.Fatalf("Failed to write spec file: %v", err)
 	}

--- a/internal/models/tool_event.go
+++ b/internal/models/tool_event.go
@@ -1,0 +1,58 @@
+package models
+
+// ToolEvent is the normalized, engine-agnostic record of a single tool call
+// emitted during an agent session. It is the canonical per-task tool record
+// surfaced in `results.json` under `runs[].tool_events` (schema version 1.1+).
+//
+// Fields are intentionally aligned with the GenAI OpenTelemetry semantic
+// conventions (see internal/telemetry) so the same record can be exported as
+// a span attribute set without translation:
+//
+//	tool_call_id   <-> gen_ai.tool.call.id
+//	tool_name      <-> gen_ai.tool.name
+//	args           <-> gen_ai.tool.arguments (JSON value)
+//	result         <-> gen_ai.tool.result    (JSON value)
+//	success        <-> waza.tool.success
+//
+// Wave 3 (#367) snapshot/replay consumes tool_events directly, so the wire
+// format must remain stable: additions are MINOR (1.x), renames/removals are
+// MAJOR (2.0).
+type ToolEvent struct {
+	// Turn is the 1-based ordinal of the assistant turn that produced this
+	// call. Multiple tool calls may share the same turn. 0 means unknown
+	// (engines that do not surface turn boundaries).
+	Turn int `json:"turn"`
+
+	// Sequence is the 1-based ordinal of this call within the run, in the
+	// order the engine emitted them. Stable across replays.
+	Sequence int `json:"sequence"`
+
+	// ToolCallID is the engine's unique identifier for this call. May be
+	// empty for engines that do not assign IDs.
+	ToolCallID string `json:"tool_call_id,omitempty"`
+
+	// ToolName is the canonical name of the tool that was invoked.
+	ToolName string `json:"tool_name"`
+
+	// Args is the call's argument payload normalised to a JSON-compatible
+	// value (object, array, scalar, or null). The exact shape depends on
+	// the tool; argmatcher matchers in tool_calls / tool_constraint graders
+	// run against this field.
+	Args any `json:"args,omitempty"`
+
+	// Result is the tool's response payload normalised to a JSON-compatible
+	// value, or nil when the engine did not surface a result.
+	Result any `json:"result,omitempty"`
+
+	// Success reports whether the engine considered the call to have
+	// completed without error.
+	Success bool `json:"success"`
+
+	// Error is the engine's failure message when Success is false. Empty
+	// for successful calls.
+	Error string `json:"error,omitempty"`
+
+	// DurationMs is the wall-clock time between the tool-start and
+	// tool-complete events when available. 0 when timing is unavailable.
+	DurationMs int64 `json:"duration_ms,omitempty"`
+}

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1270,6 +1270,7 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		WorkspaceDir:     resp.WorkspaceDir,
 		Responder:        responderInfo,
 		Checkpoints:      checkpointOutcomes,
+		ToolEvents:       buildToolEvents(resp.Events),
 	})
 }
 

--- a/internal/orchestration/tool_events.go
+++ b/internal/orchestration/tool_events.go
@@ -116,8 +116,9 @@ func normalizeResultValue(r *copilot.ToolExecutionCompleteResult) any {
 	return normalizeArgsValue(r)
 }
 
-// stringifyResult returns the first string-valued payload it can find in the
-// result, falling back to the JSON encoding. Used for error messages.
+// stringifyResult returns a JSON encoding of the tool result, or "" when r is
+// nil or marshaling fails. Used to populate ToolEvent.Error on failed calls so
+// downstream consumers have a stable, replay-friendly string representation.
 func stringifyResult(r *copilot.ToolExecutionCompleteResult) string {
 	if r == nil {
 		return ""

--- a/internal/orchestration/tool_events.go
+++ b/internal/orchestration/tool_events.go
@@ -1,0 +1,130 @@
+package orchestration
+
+import (
+	"encoding/json"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/copilotevents"
+	"github.com/microsoft/waza/internal/models"
+)
+
+// buildToolEvents derives the normalised []ToolEvent record from raw SDK
+// session events. It is a pure function of `events` so Wave 3 snapshot/replay
+// can reconstruct identical tool_events from a saved transcript.
+//
+// Event correlation:
+//   - tool.execution.start defines the call (name, arguments, turn).
+//   - tool.execution.complete attaches result, success, duration_ms.
+//
+// Turn numbering increments at each assistant.message event (1-based).
+// SDK events that arrive before the first assistant turn are tagged turn=1.
+// Calls that never received a matching complete event are still emitted with
+// Success=false and DurationMs=0.
+func buildToolEvents(events []copilot.SessionEvent) []models.ToolEvent {
+	if len(events) == 0 {
+		return nil
+	}
+
+	type pending struct {
+		event models.ToolEvent
+		start copilot.SessionEvent
+	}
+	pendingByID := make(map[string]*pending)
+	orderedIDs := make([]string, 0, len(events))
+	turn := 1
+	seenAssistant := false
+
+	for _, evt := range events {
+		switch evt.Type() {
+		case copilot.SessionEventTypeAssistantMessage:
+			if seenAssistant {
+				turn++
+			}
+			seenAssistant = true
+		case copilot.SessionEventTypeToolExecutionStart:
+			start, ok := copilotevents.ToolStart(evt)
+			if !ok || start.ToolCallID == "" || start.ToolName == "" {
+				continue
+			}
+			args := normalizeArgsValue(start.Arguments)
+			te := models.ToolEvent{
+				Turn:       turn,
+				ToolCallID: start.ToolCallID,
+				ToolName:   start.ToolName,
+				Args:       args,
+			}
+			pendingByID[start.ToolCallID] = &pending{event: te, start: evt}
+			orderedIDs = append(orderedIDs, start.ToolCallID)
+		case copilot.SessionEventTypeToolExecutionComplete:
+			complete, ok := copilotevents.ToolComplete(evt)
+			if !ok || complete.ToolCallID == "" {
+				continue
+			}
+			p, ok := pendingByID[complete.ToolCallID]
+			if !ok {
+				continue
+			}
+			p.event.Success = complete.Success
+			if complete.Result != nil {
+				p.event.Result = normalizeResultValue(complete.Result)
+			}
+			if !p.event.Success {
+				// Include the result string as the error message when
+				// available so consumers don't have to dig into Result.
+				if s := stringifyResult(complete.Result); s != "" {
+					p.event.Error = s
+				}
+			}
+			if dur := evt.Timestamp.Sub(p.start.Timestamp).Milliseconds(); dur > 0 {
+				p.event.DurationMs = dur
+			}
+		}
+	}
+
+	out := make([]models.ToolEvent, 0, len(orderedIDs))
+	for i, id := range orderedIDs {
+		p := pendingByID[id]
+		p.event.Sequence = i + 1
+		out = append(out, p.event)
+	}
+	return out
+}
+
+// normalizeArgsValue converts an arbitrary engine-provided argument payload
+// into a JSON-friendly value (map[string]any / []any / scalar). Returns nil
+// when the input is nil or fails to round-trip.
+func normalizeArgsValue(v any) any {
+	if v == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// normalizeResultValue returns a JSON-friendly snapshot of a tool result.
+func normalizeResultValue(r *copilot.ToolExecutionCompleteResult) any {
+	if r == nil {
+		return nil
+	}
+	return normalizeArgsValue(r)
+}
+
+// stringifyResult returns the first string-valued payload it can find in the
+// result, falling back to the JSON encoding. Used for error messages.
+func stringifyResult(r *copilot.ToolExecutionCompleteResult) string {
+	if r == nil {
+		return ""
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/internal/orchestration/tool_events_test.go
+++ b/internal/orchestration/tool_events_test.go
@@ -1,0 +1,142 @@
+package orchestration
+
+import (
+	"testing"
+	"time"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/stretchr/testify/require"
+)
+
+func mkEvent(ts time.Time, data copilot.SessionEventData) copilot.SessionEvent {
+	return copilot.SessionEvent{Timestamp: ts, Data: data}
+}
+
+func TestBuildToolEvents_EmptyReturnsNil(t *testing.T) {
+	require.Nil(t, buildToolEvents(nil))
+	require.Nil(t, buildToolEvents([]copilot.SessionEvent{}))
+}
+
+func TestBuildToolEvents_PairsStartAndCompleteByID(t *testing.T) {
+	t0 := time.Unix(1700000000, 0)
+	events := []copilot.SessionEvent{
+		mkEvent(t0, &copilot.ToolExecutionStartData{
+			ToolCallID: "call-a",
+			ToolName:   "bash",
+			Arguments:  map[string]any{"command": "go test ./..."},
+		}),
+		mkEvent(t0.Add(150*time.Millisecond), &copilot.ToolExecutionCompleteData{
+			ToolCallID: "call-a",
+			Success:    true,
+			Result:     &copilot.ToolExecutionCompleteResult{Content: "ok"},
+		}),
+	}
+
+	out := buildToolEvents(events)
+	require.Len(t, out, 1)
+	te := out[0]
+	require.Equal(t, "call-a", te.ToolCallID)
+	require.Equal(t, "bash", te.ToolName)
+	require.Equal(t, 1, te.Sequence)
+	require.Equal(t, 1, te.Turn)
+	require.True(t, te.Success)
+	require.Equal(t, int64(150), te.DurationMs)
+	require.Equal(t, "", te.Error)
+
+	argsMap, ok := te.Args.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "go test ./...", argsMap["command"])
+}
+
+func TestBuildToolEvents_TurnIncrementsAtAssistantMessage(t *testing.T) {
+	t0 := time.Unix(1700000000, 0)
+	events := []copilot.SessionEvent{
+		// pre-turn tool call lands in turn 1
+		mkEvent(t0, &copilot.ToolExecutionStartData{ToolCallID: "c0", ToolName: "view"}),
+		mkEvent(t0.Add(10*time.Millisecond), &copilot.ToolExecutionCompleteData{ToolCallID: "c0", Success: true}),
+		mkEvent(t0.Add(20*time.Millisecond), &copilot.AssistantMessageData{Content: "first turn"}),
+		mkEvent(t0.Add(30*time.Millisecond), &copilot.ToolExecutionStartData{ToolCallID: "c1", ToolName: "bash"}),
+		mkEvent(t0.Add(40*time.Millisecond), &copilot.ToolExecutionCompleteData{ToolCallID: "c1", Success: true}),
+		mkEvent(t0.Add(50*time.Millisecond), &copilot.AssistantMessageData{Content: "second turn"}),
+		mkEvent(t0.Add(60*time.Millisecond), &copilot.ToolExecutionStartData{ToolCallID: "c2", ToolName: "edit"}),
+		mkEvent(t0.Add(70*time.Millisecond), &copilot.ToolExecutionCompleteData{ToolCallID: "c2", Success: true}),
+	}
+
+	out := buildToolEvents(events)
+	require.Len(t, out, 3)
+	require.Equal(t, 1, out[0].Turn)
+	require.Equal(t, 1, out[1].Turn)
+	require.Equal(t, 2, out[2].Turn)
+
+	// Sequence is monotonically increasing in start order.
+	require.Equal(t, 1, out[0].Sequence)
+	require.Equal(t, 2, out[1].Sequence)
+	require.Equal(t, 3, out[2].Sequence)
+}
+
+func TestBuildToolEvents_MissingCompleteStaysPending(t *testing.T) {
+	t0 := time.Unix(1700000000, 0)
+	events := []copilot.SessionEvent{
+		mkEvent(t0, &copilot.ToolExecutionStartData{ToolCallID: "orphan", ToolName: "bash"}),
+	}
+	out := buildToolEvents(events)
+	require.Len(t, out, 1)
+	require.Equal(t, "orphan", out[0].ToolCallID)
+	require.False(t, out[0].Success)
+	require.Equal(t, int64(0), out[0].DurationMs)
+}
+
+func TestBuildToolEvents_FailureCapturesErrorMessage(t *testing.T) {
+	t0 := time.Unix(1700000000, 0)
+	events := []copilot.SessionEvent{
+		mkEvent(t0, &copilot.ToolExecutionStartData{ToolCallID: "x", ToolName: "bash"}),
+		mkEvent(t0.Add(5*time.Millisecond), &copilot.ToolExecutionCompleteData{
+			ToolCallID: "x",
+			Success:    false,
+			Result:     &copilot.ToolExecutionCompleteResult{Content: "boom"},
+		}),
+	}
+	out := buildToolEvents(events)
+	require.Len(t, out, 1)
+	require.False(t, out[0].Success)
+	require.NotEmpty(t, out[0].Error, "Error should be populated when Success=false")
+}
+
+func TestBuildToolEvents_IgnoresUnknownCompleteIDs(t *testing.T) {
+	t0 := time.Unix(1700000000, 0)
+	events := []copilot.SessionEvent{
+		mkEvent(t0, &copilot.ToolExecutionStartData{ToolCallID: "a", ToolName: "bash"}),
+		mkEvent(t0.Add(1*time.Millisecond), &copilot.ToolExecutionCompleteData{
+			ToolCallID: "ghost",
+			Success:    true,
+		}),
+	}
+	out := buildToolEvents(events)
+	require.Len(t, out, 1)
+	require.Equal(t, "a", out[0].ToolCallID)
+	require.False(t, out[0].Success, "matching event was the ghost ID; original 'a' has no complete")
+}
+
+func TestBuildToolEvents_SkipsStartEventsMissingRequiredFields(t *testing.T) {
+	t0 := time.Unix(1700000000, 0)
+	events := []copilot.SessionEvent{
+		mkEvent(t0, &copilot.ToolExecutionStartData{ToolCallID: "", ToolName: "bash"}),
+		mkEvent(t0, &copilot.ToolExecutionStartData{ToolCallID: "id", ToolName: ""}),
+		mkEvent(t0, &copilot.ToolExecutionStartData{ToolCallID: "good", ToolName: "view"}),
+		mkEvent(t0.Add(time.Millisecond), &copilot.ToolExecutionCompleteData{ToolCallID: "good", Success: true}),
+	}
+	out := buildToolEvents(events)
+	require.Len(t, out, 1)
+	require.Equal(t, "good", out[0].ToolCallID)
+}
+
+func TestBuildToolEvents_NilArgsAreNotEmitted(t *testing.T) {
+	t0 := time.Unix(1700000000, 0)
+	events := []copilot.SessionEvent{
+		mkEvent(t0, &copilot.ToolExecutionStartData{ToolCallID: "x", ToolName: "bash"}),
+		mkEvent(t0.Add(time.Millisecond), &copilot.ToolExecutionCompleteData{ToolCallID: "x", Success: true}),
+	}
+	out := buildToolEvents(events)
+	require.Len(t, out, 1)
+	require.Nil(t, out[0].Args)
+}

--- a/site/src/content/docs/guides/graders.mdx
+++ b/site/src/content/docs/guides/graders.mdx
@@ -623,7 +623,7 @@ At least one constraint must be configured. When both `min_calls` and `max_calls
 
 ### Argument matchers (schema 1.1+)
 
-When you need to assert *what* a tool was called with — not just which tools ran — use the `expect:` field with structured argument matchers. Each entry names a tool and a map of `args:` constraints; the grader checks every entry against the recorded `tool_events[]` for the run.
+When you need to assert *what* a tool was called with — not just which tools ran — use the `expect:` field with structured argument matchers. Each entry names a tool and a map of `args:` constraints; the grader checks every entry against the recorded tool calls for the run (the same data that is also serialized into `tool_events[]` in `results.json`).
 
 ```yaml
 - type: tool_calls
@@ -632,22 +632,29 @@ When you need to assert *what* a tool was called with — not just which tools r
     expect:
       - tool: edit
         args:
-          path: { kind: equals, equals: "src/auth.go" }
-          file_text: { kind: contains, contains: "func Login" }
+          path: { equals: "src/auth.go" }
+          file_text: { contains: "func Login" }
       - tool: bash
         args:
-          command: { kind: regex, regex: "^go test " }
+          command: { regex: "^go test " }
 ```
 
-Supported matcher kinds:
+Each matcher is a single-key mapping naming exactly one of the kinds below:
 
-| Kind          | Field         | Matches when …                                            |
-| ------------- | ------------- | --------------------------------------------------------- |
-| `equals`      | `equals`      | the argument is deeply equal to the supplied value         |
-| `regex`       | `regex`       | the stringified argument matches the supplied RE2 pattern  |
-| `contains`    | `contains`    | the stringified argument contains the supplied substring   |
-| `range`       | `range`       | the numeric argument is within `[min, max]` (inclusive)    |
-| `json_schema` | `json_schema` | the argument validates against the supplied JSON Schema    |
+| Key           | Matches when …                                                         |
+| ------------- | ---------------------------------------------------------------------- |
+| `equals`      | the argument is deeply equal to the supplied value                      |
+| `regex`       | the stringified argument matches the supplied RE2 pattern               |
+| `contains`    | the stringified argument contains the supplied substring                |
+| `range`       | the numeric argument satisfies the bounds (`gte` / `lte` / `gt` / `lt`) |
+| `json_schema` | the argument validates against the supplied JSON Schema (draft-07+)     |
+
+The `range` matcher accepts any combination of inclusive (`gte`, `lte`) and exclusive (`gt`, `lt`) bounds; at least one must be set:
+
+```yaml
+limit: { range: { gte: 1, lte: 5 } }
+score: { range: { gt: 0.0 } }
+```
 
 `tool_constraint` accepts the same `args:` block on each `expect_tools` entry, so you can require both *which* tool ran and *how* it was called in a single grader:
 
@@ -658,7 +665,7 @@ Supported matcher kinds:
     expect_tools:
       - tool: edit
         args:
-          path: { kind: regex, regex: "^src/" }
+          path: { regex: "^src/" }
       - tool: bash
     reject_tools:
       - tool: bash

--- a/site/src/content/docs/guides/graders.mdx
+++ b/site/src/content/docs/guides/graders.mdx
@@ -621,6 +621,52 @@ At least one constraint must be configured. When both `min_calls` and `max_calls
     min_calls: 3
 ```
 
+### Argument matchers (schema 1.1+)
+
+When you need to assert *what* a tool was called with — not just which tools ran — use the `expect:` field with structured argument matchers. Each entry names a tool and a map of `args:` constraints; the grader checks every entry against the recorded `tool_events[]` for the run.
+
+```yaml
+- type: tool_calls
+  name: edit_correctness
+  config:
+    expect:
+      - tool: edit
+        args:
+          path: { kind: equals, equals: "src/auth.go" }
+          file_text: { kind: contains, contains: "func Login" }
+      - tool: bash
+        args:
+          command: { kind: regex, regex: "^go test " }
+```
+
+Supported matcher kinds:
+
+| Kind          | Field         | Matches when …                                            |
+| ------------- | ------------- | --------------------------------------------------------- |
+| `equals`      | `equals`      | the argument is deeply equal to the supplied value         |
+| `regex`       | `regex`       | the stringified argument matches the supplied RE2 pattern  |
+| `contains`    | `contains`    | the stringified argument contains the supplied substring   |
+| `range`       | `range`       | the numeric argument is within `[min, max]` (inclusive)    |
+| `json_schema` | `json_schema` | the argument validates against the supplied JSON Schema    |
+
+`tool_constraint` accepts the same `args:` block on each `expect_tools` entry, so you can require both *which* tool ran and *how* it was called in a single grader:
+
+```yaml
+- type: tool_constraint
+  name: guardrails
+  config:
+    expect_tools:
+      - tool: edit
+        args:
+          path: { kind: regex, regex: "^src/" }
+      - tool: bash
+    reject_tools:
+      - tool: bash
+        command_pattern: "^rm -rf"
+```
+
+Argument matchers apply on top of the existing required/forbidden checks — a tool must still be present (or absent) and *also* satisfy its matchers to count as a pass.
+
 ---
 
 ## Program

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -416,6 +416,21 @@ waza compare gpt4.json sonnet.json opus.json
 waza compare results-*.json --format json
 ```
 
+### Tool-use metrics (schema 1.1+)
+
+When the input files include the `tool_events[]` array (`results.json` schema 1.1 or later), `waza compare` prints an additional `TOOL USE` section with aggregate per-file metrics:
+
+| Metric | Meaning |
+|---|---|
+| `total_calls` | Total number of tool calls across every task and run |
+| `tasks_with_tools` | Tasks where at least one tool call was recorded |
+| `avg_calls_per_task` | Mean calls per task |
+| `success_rate` | Fraction of tool calls that returned `success: true` |
+| `selection_accuracy` | Fraction of tasks where the `tool_calls` grader passed (excludes tasks without a `tool_calls` grader) |
+| `call_count_histogram` | Distribution of per-task call counts in buckets `0`, `1`, `2`, `3+` |
+
+The section is suppressed when none of the compared files contain tool data, so legacy 1.0 results remain unchanged.
+
 ## waza gate
 
 Compare a current results file against a baseline and enforce regression policy. Designed for CI: emits stable exit codes and supports GitHub Actions annotations.

--- a/site/src/content/docs/reference/schema-changes.md
+++ b/site/src/content/docs/reference/schema-changes.md
@@ -20,7 +20,7 @@ Schema versions use `MAJOR.MINOR` format with no patch component.
 
 - **MINOR** changes are backward-compatible additions, usually optional fields. Readers accept same-major artifacts and warn when they see unknown fields.
 - **MAJOR** changes are breaking. Readers refuse artifacts from a different major version and point to `waza migrate <file>`.
-- Missing `schemaVersion` defaults to `1.0` for backward compatibility with eval suites authored before the field was introduced. Same-major readers continue to accept `1.0`-defaulted files unchanged.
+- Missing `schemaVersion` is interpreted as the current schema version (currently `1.1`). Same-major minor differences are accepted and any unknown fields are warned about; cross-major mismatches are rejected.
 - New artifacts should emit the current `schemaVersion` (currently `1.1`). The version is automatically populated by the writer; you only need to set it manually when authoring fixtures or schema-pinned test data.
 
 ## Migration command
@@ -40,6 +40,8 @@ For schema `1.0`, the command is a no-op because there is no prior major version
 
 - Added optional `checkpoints[]` to task YAML for per-turn graders (`after_turn`, `graders`, `on_failure`). Backward-compatible: 1.0 task files load unchanged.
 - Added optional `checkpoints[]` to `results.json` task results, recording per-turn grader outcomes.
+- Added optional `runs[].tool_events[]` array to `results.json` (issue #366). Each entry captures one tool call with `turn`, `sequence`, `tool_call_id`, `tool_name`, `args`, `result`, `success`, `error`, and `duration_ms`. The legacy `session_digest.tool_calls` field is preserved.
+- Bumped `results.json` `schemaVersion` default to `1.1`. Readers accept `1.0` and `1.1` interchangeably (same major).
 
 ### 1.0
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -97,12 +97,12 @@ version: "1.0"
 
 **Type:** string  
 **Required:** no  
-**Default:** `1.1`
+**Default:** current schema version (currently `1.1`)
 
 Schema version for the public artifact shape. It uses `MAJOR.MINOR` format with no patch component. Same-major minor additions are backward-compatible; readers ignore unknown fields and warn. Different major versions are rejected with a migration hint.
 
 ```yaml
-schemaVersion: "1.0"
+schemaVersion: "1.1"
 ```
 
 See [Schema Changes](/reference/schema-changes/) for the versioning policy and changelog.


### PR DESCRIPTION
Implements [#366](https://github.com/microsoft/waza/issues/366) — Wave 2.

## Summary

Three additive capabilities, all gated by schemaVersion **1.1** (MINOR bump per #368/#382):

### A. Structured argument matchers for `tool_calls` / `tool_constraint`

New `internal/graders/argmatcher` package with five matcher kinds:

| Kind | Field | Matches when… |
|---|---|---|
| `equals` | `equals` | argument deeply equals supplied value |
| `regex` | `regex` | stringified arg matches RE2 pattern |
| `contains` | `contains` | stringified arg contains substring |
| `range` | `range` | numeric arg is within `[min, max]` |
| `json_schema` | `json_schema` | arg validates against JSON Schema |

- `tool_calls` gains an `expect: [{tool, args}]` block — assert *which* tool ran *and* how it was called.
- `tool_constraint` gains an `args:` map on each `expect_tools` entry.
- Backward compatible: existing `required_tools` / `forbidden_tools` semantics unchanged.

### B. Normalized `tool_events[]` in `results.json`

Each `RunResult` now carries an additive `tool_events: []ToolEvent` array, built deterministically from session events:

```json
{
  "turn": 2,
  "sequence": 3,
  "tool_call_id": "call_abc",
  "tool_name": "edit",
  "args": { "path": "src/auth.go", "file_text": "…" },
  "result": "edited",
  "success": true,
  "duration_ms": 142
}
```

- OTel GenAI alignment (`gen_ai.tool.name`, `gen_ai.tool.call.id`, etc. — see `internal/telemetry`).
- Replay-friendly and stable for Wave 3 snapshot/replay (#367).
- Legacy `session_digest.tool_calls` preserved.

### C. Aggregate tool-use metrics in `waza compare`

When inputs contain tool data, `waza compare` prints a new `TOOL USE` section:

- `total_calls`, `tasks_with_tools`, `avg_calls_per_task`
- `success_rate` (fraction of calls with `success: true`)
- `selection_accuracy` (fraction of tasks where the `tool_calls` grader passed; denominator excludes tasks with no `tool_calls` grader)
- `call_count_histogram` (buckets `0` / `1` / `2` / `3+`)

Section is suppressed for legacy 1.0 results.

## Test plan

- ✅ `internal/graders/argmatcher` — all 5 matcher kinds + invalid-regex / invalid-schema construct errors
- ✅ `internal/orchestration/tool_events_test.go` — 8 builder cases (empty, pair-by-ID, turn increments, missing complete, failure path, unknown complete, malformed start, nil args)
- ✅ `internal/graders/tool_calls_grader_test.go` — 8 new `expect` cases (equals/regex/contains/range/json_schema/missing tool/extra tool/strict ordering)
- ✅ `internal/graders/tool_constraint_grader_test.go` — 4 new `args` cases incl. invalid regex
- ✅ `internal/models/outcome_schema_test.go` — ToolEvents round-trip at schemaVersion 1.1
- ✅ `cmd/waza/cmd_compare_test.go` — 5 new metric tests (no data gate, totals/success rate, histogram, selection accuracy, hasAnyToolData)
- ✅ `go build ./... && go test ./... && go vet ./... && golangci-lint run` all clean

## Docs

- `site/src/content/docs/guides/graders.mdx` — `expect:` + matcher kinds reference under tool_calls, `args:` under tool_constraint
- `site/src/content/docs/reference/schema-changes.md` — 1.1 changelog entry, table updated
- `site/src/content/docs/reference/cli.mdx` — `waza compare` TOOL USE section documented
- `README.md` — schemaVersion 1.1 mention

## Wave coordination

- Builds on #368/#382 schema versioning (uses MINOR additive policy).
- `tool_events[]` ordering is stable & deterministic so Wave 3 #367 snapshot/replay can rely on it.
- OTel attribute mapping documented inline in `internal/models/tool_event.go` to stay consistent with #362 / `internal/telemetry`.

Closes #366