### PR TITLE
refactor: decouple execution events from Copilot SDK

### DIFF
--- a/cmd/waza/cmd_run_suggest.go
+++ b/cmd/waza/cmd_run_suggest.go
@@ -13,9 +13,7 @@ import (
 	"strings"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
 	waza "github.com/microsoft/waza"
-	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/dataset"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/models"
@@ -113,7 +111,7 @@ func buildNoSuggestionsError(res *execution.ExecutionResponse) error {
 	return fmt.Errorf("no suggestions from Copilot. Session transcript:\n- %s", strings.Join(trace, "\n- "))
 }
 
-func summarizeSessionEventTypes(events []copilot.SessionEvent) []string {
+func summarizeSessionEventTypes(events []models.SessionEvent) []string {
 	if len(events) == 0 {
 		return nil
 	}
@@ -628,74 +626,73 @@ func extractCopilotTrace(transcript []models.TranscriptEvent) []string {
 	toolNames := map[string]string{}
 	for _, evt := range transcript {
 		switch evt.Type() {
-		case copilot.SessionEventTypeAssistantMessage:
-			content, ok := copilotevents.Content(evt.SessionEvent)
-			if !ok {
+		case models.SessionEventTypeAssistantMessage:
+			if evt.Content == nil {
 				continue
 			}
-			msg := compactWhitespace(content)
+			msg := compactWhitespace(*evt.Content)
 			if msg == "" {
 				continue
 			}
 			lines = append(lines, "agent: "+truncateForPrompt(msg, maxSuggestionTraceEntryLen))
-		case copilot.SessionEventTypeSkillInvoked:
-			if skill, ok := copilotevents.SkillInvoked(evt.SessionEvent); ok {
-				msg := compactWhitespace(skill.Name)
-				if msg == "" {
-					msg = compactWhitespace(skill.Path)
-				}
-				if msg != "" {
-					lines = append(lines, "skill invoked: "+truncateForPrompt(msg, maxSuggestionTraceEntryLen))
-				}
+		case models.SessionEventTypeSkillInvoked:
+			msg := ""
+			if evt.SkillName != nil {
+				msg = compactWhitespace(*evt.SkillName)
 			}
-		case copilot.SessionEventTypeToolExecutionStart:
-			start, ok := copilotevents.ToolStart(evt.SessionEvent)
-			if !ok {
-				continue
+			if msg == "" && evt.SkillPath != nil {
+				msg = compactWhitespace(*evt.SkillPath)
 			}
-			name := start.ToolName
+			if msg != "" {
+				lines = append(lines, "skill invoked: "+truncateForPrompt(msg, maxSuggestionTraceEntryLen))
+			}
+		case models.SessionEventTypeToolExecutionStart:
+			name := ""
+			if evt.ToolName != nil {
+				name = *evt.ToolName
+			}
 			if name == "" {
 				name = "<unknown>"
 			}
-			if start.ToolCallID != "" {
-				toolNames[start.ToolCallID] = name
+			if evt.ToolCallID != nil && *evt.ToolCallID != "" {
+				toolNames[*evt.ToolCallID] = name
 			}
-			args := marshalForPrompt(start.Arguments, maxSuggestionToolSummaryLen)
+			args := marshalForPrompt(evt.Arguments, maxSuggestionToolSummaryLen)
 			if args == "" {
 				lines = append(lines, fmt.Sprintf("tool start: %s", name))
 				continue
 			}
 			lines = append(lines, fmt.Sprintf("tool start: %s args=%s", name, args))
-		case copilot.SessionEventTypeToolExecutionComplete:
-			complete, ok := copilotevents.ToolComplete(evt.SessionEvent)
-			if !ok {
-				continue
-			}
+		case models.SessionEventTypeToolExecutionComplete:
 			parts := []string{"tool result:"}
-			if name := toolNames[complete.ToolCallID]; name != "" {
-				parts = append(parts, "tool="+name)
+			if evt.ToolCallID != nil {
+				if name := toolNames[*evt.ToolCallID]; name != "" {
+					parts = append(parts, "tool="+name)
+				}
 			}
-			parts = append(parts, fmt.Sprintf("success=%t", complete.Success))
-			if result := marshalForPrompt(complete.Result, maxSuggestionToolSummaryLen); result != "" {
+			success := false
+			if evt.Success != nil {
+				success = *evt.Success
+			}
+			parts = append(parts, fmt.Sprintf("success=%t", success))
+			if result := marshalForPrompt(evt.ToolResult, maxSuggestionToolSummaryLen); result != "" {
 				parts = append(parts, "result="+result)
 			}
 			lines = append(lines, strings.Join(parts, " "))
-		case copilot.SessionEventTypeToolExecutionPartialResult:
-			partial, ok := copilotevents.ToolPartial(evt.SessionEvent)
-			if !ok {
+		case models.SessionEventTypeToolExecutionPartialResult:
+			if evt.PartialOutput == nil {
 				continue
 			}
-			output := compactWhitespace(partial.PartialOutput)
+			output := compactWhitespace(*evt.PartialOutput)
 			if output == "" {
 				continue
 			}
 			lines = append(lines, "tool partial result: "+truncateForPrompt(output, maxSuggestionTraceEntryLen))
-		case copilot.SessionEventTypeToolUserRequested:
-			request, ok := copilotevents.ToolUserRequested(evt.SessionEvent)
-			if !ok {
-				continue
+		case models.SessionEventTypeToolUserRequested:
+			msg := ""
+			if evt.ToolName != nil {
+				msg = compactWhitespace(*evt.ToolName)
 			}
-			msg := compactWhitespace(request.ToolName)
 			if msg != "" {
 				lines = append(lines, "tool user request: "+truncateForPrompt(msg, maxSuggestionTraceEntryLen))
 			}

--- a/cmd/waza/cmd_run_suggest_test.go
+++ b/cmd/waza/cmd_run_suggest_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -92,26 +91,10 @@ func TestBuildNoSuggestionsError_IncludesSessionTranscript(t *testing.T) {
 	toolResultText := "matched 1 file"
 
 	err := buildNoSuggestionsError(&execution.ExecutionResponse{
-		Events: []copilot.SessionEvent{
-			{
-				Data: &copilot.AssistantMessageData{Content: msg},
-			},
-			{
-				Data: &copilot.ToolExecutionStartData{
-					ToolName:   toolName,
-					ToolCallID: toolCallID,
-					Arguments:  map[string]any{"pattern": "foo"},
-				},
-			},
-			{
-				Data: &copilot.ToolExecutionCompleteData{
-					ToolCallID: toolCallID,
-					Success:    succeeded,
-					Result: &copilot.ToolExecutionCompleteResult{
-						Content: toolResultText,
-					},
-				},
-			},
+		Events: []models.SessionEvent{
+			{EventType: models.SessionEventTypeAssistantMessage, Content: &msg},
+			{EventType: models.SessionEventTypeToolExecutionStart, ToolName: &toolName, ToolCallID: &toolCallID, Arguments: map[string]any{"pattern": "foo"}},
+			{EventType: models.SessionEventTypeToolExecutionComplete, ToolCallID: &toolCallID, Success: &succeeded, ToolResult: &models.ToolExecutionResult{Content: toolResultText}},
 		},
 	})
 
@@ -124,13 +107,13 @@ func TestBuildNoSuggestionsError_IncludesSessionTranscript(t *testing.T) {
 
 func TestBuildNoSuggestionsError_FallsBackToEventTypes(t *testing.T) {
 	err := buildNoSuggestionsError(&execution.ExecutionResponse{
-		Events: []copilot.SessionEvent{
-			{Data: &copilot.SessionIdleData{}},
+		Events: []models.SessionEvent{
+			{EventType: models.SessionEventTypeSessionIdle},
 		},
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "event[1]: "+string(copilot.SessionEventTypeSessionIdle))
+	assert.Contains(t, err.Error(), "event[1]: "+string(models.SessionEventTypeSessionIdle))
 }
 
 func TestBuildNoSuggestionsError_WithNoEvents(t *testing.T) {
@@ -185,29 +168,13 @@ func TestBuildRunSuggestionPrompt_IncludesOnlyFailureEvidence(t *testing.T) {
 					},
 					Transcript: []models.TranscriptEvent{
 						{
-							SessionEvent: copilot.SessionEvent{
-								Data: &copilot.AssistantMessageData{Content: msg},
-							},
+							SessionEvent: models.SessionEvent{EventType: models.SessionEventTypeAssistantMessage, Content: &msg},
 						},
 						{
-							SessionEvent: copilot.SessionEvent{
-								Data: &copilot.ToolExecutionStartData{
-									ToolName:   toolName,
-									ToolCallID: toolCallID,
-									Arguments:  map[string]any{"pattern": "foo"},
-								},
-							},
+							SessionEvent: models.SessionEvent{EventType: models.SessionEventTypeToolExecutionStart, ToolName: &toolName, ToolCallID: &toolCallID, Arguments: map[string]any{"pattern": "foo"}},
 						},
 						{
-							SessionEvent: copilot.SessionEvent{
-								Data: &copilot.ToolExecutionCompleteData{
-									ToolCallID: toolCallID,
-									Success:    succeeded,
-									Result: &copilot.ToolExecutionCompleteResult{
-										Content: toolResultText,
-									},
-								},
-							},
+							SessionEvent: models.SessionEvent{EventType: models.SessionEventTypeToolExecutionComplete, ToolCallID: &toolCallID, Success: &succeeded, ToolResult: &models.ToolExecutionResult{Content: toolResultText}},
 						},
 					},
 				},
@@ -388,10 +355,8 @@ func TestWriteSuggestionTranscript_WritesFile(t *testing.T) {
 		FinalOutput: "Suggestion report text",
 		Success:     true,
 		DurationMs:  1500,
-		Events: []copilot.SessionEvent{
-			{
-				Data: &copilot.AssistantMessageData{Content: msg},
-			},
+		Events: []models.SessionEvent{
+			{EventType: models.SessionEventTypeAssistantMessage, Content: &msg},
 		},
 	}
 

--- a/internal/copilotevents/events.go
+++ b/internal/copilotevents/events.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/models"
 )
 
 func Content(event copilot.SessionEvent) (string, bool) {
@@ -126,4 +127,62 @@ func RawData(eventType copilot.SessionEventType, data any) copilot.SessionEventD
 		raw = []byte("{}")
 	}
 	return &copilot.RawSessionEventData{EventType: eventType, Raw: raw}
+}
+
+func ToSessionEvent(event copilot.SessionEvent) models.SessionEvent {
+	neutral := models.SessionEvent{
+		EventType: models.SessionEventType(event.Type()),
+	}
+
+	if content, ok := Content(event); ok {
+		neutral.Content = &content
+	}
+	if content, ok := DeltaContent(event); ok {
+		neutral.DeltaContent = &content
+	}
+	if message, ok := Message(event); ok {
+		neutral.Message = &message
+	}
+	if start, ok := ToolStart(event); ok {
+		neutral.ToolCallID = stringPtr(start.ToolCallID)
+		neutral.ToolName = stringPtr(start.ToolName)
+		neutral.Arguments = start.Arguments
+	}
+	if complete, ok := ToolComplete(event); ok {
+		neutral.ToolCallID = stringPtr(complete.ToolCallID)
+		success := complete.Success
+		neutral.Success = &success
+		neutral.ToolResult = ToToolExecutionResult(complete.Result)
+	}
+	if partial, ok := ToolPartial(event); ok {
+		neutral.ToolCallID = stringPtr(partial.ToolCallID)
+		neutral.PartialOutput = stringPtr(partial.PartialOutput)
+	}
+	if progress, ok := ToolProgress(event); ok {
+		neutral.ToolCallID = stringPtr(progress.ToolCallID)
+	}
+	if request, ok := ToolUserRequested(event); ok {
+		neutral.ToolCallID = stringPtr(request.ToolCallID)
+		neutral.ToolName = stringPtr(request.ToolName)
+	}
+	if skill, ok := SkillInvoked(event); ok {
+		neutral.SkillName = stringPtr(skill.Name)
+		neutral.SkillPath = stringPtr(skill.Path)
+	}
+
+	return neutral
+}
+
+func ToToolExecutionResult(result *copilot.ToolExecutionCompleteResult) *models.ToolExecutionResult {
+	if result == nil {
+		return nil
+	}
+	return &models.ToolExecutionResult{
+		Content:         result.Content,
+		DetailedContent: result.DetailedContent,
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
-	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -132,7 +131,7 @@ type SkillInvocation struct {
 // ExecutionResponse represents the result of an execution
 type ExecutionResponse struct {
 	FinalOutput      string
-	Events           []copilot.SessionEvent
+	Events           []models.SessionEvent
 	ModelID          string
 	SkillInvocations []SkillInvocation
 	DurationMs       int64
@@ -149,10 +148,8 @@ type ExecutionResponse struct {
 func (r *ExecutionResponse) ExtractMessages() []string {
 	var messages []string
 	for _, evt := range r.Events {
-		if evt.Type() == copilot.SessionEventTypeAssistantMessage {
-			if content, ok := copilotevents.Content(evt); ok && content != "" {
-				messages = append(messages, content)
-			}
+		if evt.Type() == models.SessionEventTypeAssistantMessage && evt.Content != nil && *evt.Content != "" {
+			messages = append(messages, *evt.Content)
 		}
 	}
 	return messages

--- a/internal/execution/engine_response_test.go
+++ b/internal/execution/engine_response_test.go
@@ -3,7 +3,7 @@ package execution
 import (
 	"testing"
 
-	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,15 +13,19 @@ func TestExecutionResponse_ExtractMessages(t *testing.T) {
 	ignoredDelta := "delta"
 
 	resp := &ExecutionResponse{
-		Events: []copilot.SessionEvent{
-			{Data: &copilot.AssistantMessageData{Content: hello}},
-			{Data: &copilot.AssistantMessageData{}},
-			{Data: &copilot.AssistantMessageDeltaData{DeltaContent: ignoredDelta}},
-			{Data: &copilot.AssistantMessageData{Content: world}},
+		Events: []models.SessionEvent{
+			{EventType: models.SessionEventTypeAssistantMessage, Content: &hello},
+			{EventType: models.SessionEventTypeAssistantMessage, Content: ptrString("")},
+			{EventType: models.SessionEventTypeAssistantMessageDelta, DeltaContent: &ignoredDelta},
+			{EventType: models.SessionEventTypeAssistantMessage, Content: &world},
 		},
 	}
 
 	assert.Equal(t, []string{"hello", "world"}, resp.ExtractMessages())
+}
+
+func ptrString(value string) *string {
+	return &value
 }
 
 func TestExecutionResponse_ContainsText(t *testing.T) {

--- a/internal/execution/mock.go
+++ b/internal/execution/mock.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -142,7 +141,7 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 
 	resp := &ExecutionResponse{
 		FinalOutput:    output,
-		Events:         []copilot.SessionEvent{},
+		Events:         []models.SessionEvent{},
 		ModelID:        m.modelID,
 		DurationMs:     time.Since(start).Milliseconds(),
 		ToolCalls:      []models.ToolCall{},

--- a/internal/execution/session_events_collector.go
+++ b/internal/execution/session_events_collector.go
@@ -16,7 +16,7 @@ type SessionEventsCollector struct {
 	// SkillInvocations is a chronological list of skills invoked during the session
 	SkillInvocations []SkillInvocation
 
-	sessionEvents  []copilot.SessionEvent
+	sessionEvents  []models.SessionEvent
 	outputParts    []string
 	errorMsg       string
 	done           chan struct{}
@@ -36,7 +36,7 @@ func NewSessionEventsCollector() *SessionEventsCollector {
 }
 
 // SessionEvents returns the collected session events.
-func (coll *SessionEventsCollector) SessionEvents() []copilot.SessionEvent {
+func (coll *SessionEventsCollector) SessionEvents() []models.SessionEvent {
 	return coll.sessionEvents
 }
 
@@ -146,7 +146,7 @@ func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
 		}
 	}
 
-	coll.sessionEvents = append(coll.sessionEvents, event)
+	coll.sessionEvents = append(coll.sessionEvents, copilotevents.ToSessionEvent(event))
 }
 
 // ToolCalls goes through the list of session events and correlates tool starts

--- a/internal/execution/session_events_collector_test.go
+++ b/internal/execution/session_events_collector_test.go
@@ -55,7 +55,7 @@ func TestNewSessionEventsCollector(t *testing.T) {
 				Skill: "example",
 			},
 			Success: true,
-			Result: &copilot.ToolExecutionCompleteResult{
+			Result: &models.ToolExecutionResult{
 				Content:         "Skill \"example\" loaded successfully. Follow the instructions in the skill context.",
 				DetailedContent: utils.Ptr("Skill loaded successfully ✅\n\n---\nname: example\ndescription: \"Checks to see if skills are enabled - if you use this skill it prints out yes\"\n---\n"),
 			},

--- a/internal/graders/inline_script_grader.go
+++ b/internal/graders/inline_script_grader.go
@@ -13,7 +13,6 @@ import (
 
 	_ "embed"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -191,7 +190,7 @@ func (isg *InlineScriptGrader) runScript(ctx context.Context, gradingContext *Co
 }
 
 func getStdinTextForScript(gradingContext *Context, assertions []string) ([]byte, error) {
-	var sessionEvents []copilot.SessionEvent
+	var sessionEvents []models.SessionEvent
 
 	for _, te := range gradingContext.Transcript {
 		sessionEvents = append(sessionEvents, te.SessionEvent)

--- a/internal/graders/inline_script_grader_test.go
+++ b/internal/graders/inline_script_grader_test.go
@@ -298,7 +298,7 @@ func TestUnsupportedLanguage(t *testing.T) {
 	require.Contains(t, err.Error(), "language 'ruby' is not yet supported")
 }
 
-func loadSampleEvents(t *testing.T) []copilot.SessionEvent {
+func loadSampleEvents(t *testing.T) []models.SessionEvent {
 	reader, err := os.Open(filepath.Join("..", "testdata", "copilot_events_using_skill.json"))
 	require.NoError(t, err)
 
@@ -325,7 +325,7 @@ func loadSampleEvents(t *testing.T) []copilot.SessionEvent {
 	return sessionEventCollector.SessionEvents()
 }
 
-func convertToTranscriptEvents(sessionEvents []copilot.SessionEvent) []models.TranscriptEvent {
+func convertToTranscriptEvents(sessionEvents []models.SessionEvent) []models.TranscriptEvent {
 	var transcript []models.TranscriptEvent
 
 	for _, evt := range sessionEvents {

--- a/internal/models/events.go
+++ b/internal/models/events.go
@@ -4,21 +4,55 @@ import (
 	"encoding/json"
 	"log/slog"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/go-viper/mapstructure/v2"
-	"github.com/microsoft/waza/internal/copilotevents"
 )
 
-// ToolCall represents a tool invocation
+// SessionEventType identifies an engine event in a provider-neutral form.
+type SessionEventType string
+
+const (
+	SessionEventTypeUserMessage                SessionEventType = "user.message"
+	SessionEventTypeSystemMessage              SessionEventType = "system.message"
+	SessionEventTypeAssistantMessage           SessionEventType = "assistant.message"
+	SessionEventTypeAssistantMessageDelta      SessionEventType = "assistant.message_delta"
+	SessionEventTypeAssistantReasoning         SessionEventType = "assistant.reasoning"
+	SessionEventTypeAssistantTurnStart         SessionEventType = "assistant.turn_start"
+	SessionEventTypeAssistantTurnEnd           SessionEventType = "assistant.turn_end"
+	SessionEventTypeAssistantUsage             SessionEventType = "assistant.usage"
+	SessionEventTypeToolExecutionStart         SessionEventType = "tool.execution_start"
+	SessionEventTypeToolExecutionComplete      SessionEventType = "tool.execution_complete"
+	SessionEventTypeToolExecutionPartialResult SessionEventType = "tool.execution_partial_result"
+	SessionEventTypeToolExecutionProgress      SessionEventType = "tool.execution_progress"
+	SessionEventTypeToolUserRequested          SessionEventType = "tool.user_requested"
+	SessionEventTypeSkillInvoked               SessionEventType = "skill.invoked"
+	SessionEventTypeSessionStart               SessionEventType = "session.start"
+	SessionEventTypeSessionIdle                SessionEventType = "session.idle"
+	SessionEventTypeSessionError               SessionEventType = "session.error"
+	SessionEventTypeSessionInfo                SessionEventType = "session.info"
+	SessionEventTypeSessionUsageInfo           SessionEventType = "session.usage_info"
+	SessionEventTypeSessionWarning             SessionEventType = "session.warning"
+	SessionEventTypeSessionShutdown            SessionEventType = "session.shutdown"
+	SessionEventTypePendingMessagesModified    SessionEventType = "pending_messages.modified"
+	SessionEventTypeHookStart                  SessionEventType = "hook.start"
+	SessionEventTypeHookEnd                    SessionEventType = "hook.end"
+)
+
+// ToolExecutionResult is the provider-neutral representation of a tool result.
+type ToolExecutionResult struct {
+	Content         string  `json:"content,omitempty"`
+	DetailedContent *string `json:"detailedContent,omitempty"`
+}
+
+// ToolCall represents a tool invocation.
 type ToolCall struct {
 	// ID is the engine-assigned identifier for this call (e.g. the
 	// Copilot SDK's ToolCallID). Used to correlate tool invocations in
 	// observability backends.
-	ID        string                               `json:"id,omitempty"`
-	Name      string                               `json:"name"`
-	Arguments ToolCallArgs                         `json:"arguments,omitempty"`
-	Result    *copilot.ToolExecutionCompleteResult `json:"result,omitempty"`
-	Success   bool                                 `json:"success"`
+	ID        string               `json:"id,omitempty"`
+	Name      string               `json:"name"`
+	Arguments ToolCallArgs         `json:"arguments,omitempty"`
+	Result    *ToolExecutionResult `json:"result,omitempty"`
+	Success   bool                 `json:"success"`
 }
 
 type ToolCallArgs struct {
@@ -34,165 +68,122 @@ type ToolCallArgs struct {
 	Skill string `json:"skill" mapstructure:"skill"`
 }
 
+// SessionEvent is the provider-neutral event model exposed by execution engines.
+type SessionEvent struct {
+	EventType SessionEventType `json:"type"`
+
+	Content      *string `json:"content,omitempty"`
+	DeltaContent *string `json:"-"`
+	Message      *string `json:"message,omitempty"`
+
+	// tool call fields
+	Arguments     any                  `json:"arguments,omitempty"`
+	Success       *bool                `json:"success,omitempty"`
+	ToolCallID    *string              `json:"tool_call_id,omitempty"`
+	ToolName      *string              `json:"tool_name,omitempty"`
+	ToolResult    *ToolExecutionResult `json:"tool_result,omitempty"`
+	PartialOutput *string              `json:"-"`
+
+	// skill invocation fields are kept in-memory for behavior, but are omitted
+	// from transcript JSON to preserve the existing output contract.
+	SkillName *string `json:"-"`
+	SkillPath *string `json:"-"`
+}
+
+// Type returns the event kind while preserving the old call pattern used by
+// transcript and test code.
+func (e SessionEvent) Type() SessionEventType {
+	return e.EventType
+}
+
 type TranscriptEvent struct {
-	copilot.SessionEvent `json:"-"`
+	SessionEvent `json:"-"`
 }
 
 func (te TranscriptEvent) MarshalJSON() ([]byte, error) {
-	v := struct {
-		Content *string                  `json:"content,omitempty"`
-		Type    copilot.SessionEventType `json:"type"`
-
-		Message *string `json:"message,omitempty"`
-
-		// tool call fields
-		Arguments  any                                  `json:"arguments,omitempty"`
-		Success    *bool                                `json:"success,omitempty"`
-		ToolCallID *string                              `json:"tool_call_id,omitempty"`
-		ToolName   *string                              `json:"tool_name,omitempty"`
-		ToolResult *copilot.ToolExecutionCompleteResult `json:"tool_result,omitempty"`
-	}{
-		Type: te.Type(),
-	}
-
-	if content, ok := copilotevents.Content(te.SessionEvent); ok {
-		v.Content = &content
-	}
-	if message, ok := copilotevents.Message(te.SessionEvent); ok {
-		v.Message = &message
-	}
-	if start, ok := copilotevents.ToolStart(te.SessionEvent); ok {
-		v.ToolCallID = &start.ToolCallID
-		v.ToolName = &start.ToolName
-		v.Arguments = start.Arguments
-	}
-	if complete, ok := copilotevents.ToolComplete(te.SessionEvent); ok {
-		v.ToolCallID = &complete.ToolCallID
-		v.ToolResult = complete.Result
-		v.Success = &complete.Success
-	}
-	if partial, ok := copilotevents.ToolPartial(te.SessionEvent); ok {
-		v.ToolCallID = &partial.ToolCallID
-	}
-
-	return json.Marshal(v)
+	return json.Marshal(transcriptEventJSON{
+		Content:    te.Content,
+		Type:       te.Type(),
+		Message:    te.Message,
+		Arguments:  te.Arguments,
+		Success:    te.Success,
+		ToolCallID: te.ToolCallID,
+		ToolName:   te.ToolName,
+		ToolResult: te.ToolResult,
+	})
 }
 
 func (te *TranscriptEvent) UnmarshalJSON(data []byte) error {
-	var v struct {
-		Content    *string                              `json:"content,omitempty"`
-		Type       copilot.SessionEventType             `json:"type"`
-		Message    *string                              `json:"message,omitempty"`
-		Arguments  any                                  `json:"arguments,omitempty"`
-		Success    *bool                                `json:"success,omitempty"`
-		ToolCallID *string                              `json:"tool_call_id,omitempty"`
-		ToolName   *string                              `json:"tool_name,omitempty"`
-		ToolResult *copilot.ToolExecutionCompleteResult `json:"tool_result,omitempty"`
-	}
-
+	var v transcriptEventJSON
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	te.Data = transcriptData(v.Type, v.Content, v.Message, v.ToolCallID, v.ToolName, v.Arguments, v.ToolResult, v.Success)
+	te.SessionEvent = SessionEvent{
+		EventType:  v.Type,
+		Content:    v.Content,
+		Message:    v.Message,
+		Arguments:  v.Arguments,
+		Success:    v.Success,
+		ToolCallID: v.ToolCallID,
+		ToolName:   v.ToolName,
+		ToolResult: v.ToolResult,
+	}
 
 	return nil
 }
 
-func transcriptData(
-	eventType copilot.SessionEventType,
-	content *string,
-	message *string,
-	toolCallID *string,
-	toolName *string,
-	arguments any,
-	toolResult *copilot.ToolExecutionCompleteResult,
-	success *bool,
-) copilot.SessionEventData {
-	switch eventType {
-	case copilot.SessionEventTypeUserMessage:
-		return &copilot.UserMessageData{Content: derefString(content)}
-	case copilot.SessionEventTypeAssistantMessage:
-		return &copilot.AssistantMessageData{Content: derefString(content)}
-	case copilot.SessionEventTypeAssistantMessageDelta:
-		return &copilot.AssistantMessageDeltaData{DeltaContent: derefString(content)}
-	case copilot.SessionEventTypeToolExecutionStart:
-		return &copilot.ToolExecutionStartData{
-			Arguments:  arguments,
-			ToolCallID: derefString(toolCallID),
-			ToolName:   derefString(toolName),
-		}
-	case copilot.SessionEventTypeToolExecutionComplete:
-		return &copilot.ToolExecutionCompleteData{
-			Result:     toolResult,
-			Success:    derefBool(success),
-			ToolCallID: derefString(toolCallID),
-		}
-	case copilot.SessionEventTypeToolExecutionPartialResult:
-		return &copilot.ToolExecutionPartialResultData{ToolCallID: derefString(toolCallID)}
-	case copilot.SessionEventTypeSessionError:
-		return &copilot.SessionErrorData{Message: derefString(message)}
-	default:
-		return copilotevents.RawData(eventType, map[string]any{
-			"content":      content,
-			"message":      message,
-			"arguments":    arguments,
-			"success":      success,
-			"tool_call_id": toolCallID,
-			"tool_name":    toolName,
-			"tool_result":  toolResult,
-		})
-	}
-}
+type transcriptEventJSON struct {
+	Content *string          `json:"content,omitempty"`
+	Type    SessionEventType `json:"type"`
 
-func derefString(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return *value
-}
+	Message *string `json:"message,omitempty"`
 
-func derefBool(value *bool) bool {
-	return value != nil && *value
+	// tool call fields
+	Arguments  any                  `json:"arguments,omitempty"`
+	Success    *bool                `json:"success,omitempty"`
+	ToolCallID *string              `json:"tool_call_id,omitempty"`
+	ToolName   *string              `json:"tool_name,omitempty"`
+	ToolResult *ToolExecutionResult `json:"tool_result,omitempty"`
 }
 
 // FilterToolCalls goes through the list of session events and correlates tool starts
 // with Success.
-func FilterToolCalls(sessionEvents []copilot.SessionEvent) []ToolCall {
+func FilterToolCalls(sessionEvents []SessionEvent) []ToolCall {
 	toolCallsMap := map[string]*ToolCall{}
 	var toolCallIDs []string // preserve the start order of the events.
 
 	for _, evt := range sessionEvents {
 		switch evt.Type() {
-		case copilot.SessionEventTypeToolExecutionStart:
-			start, ok := copilotevents.ToolStart(evt)
-			if !ok || start.ToolName == "" || start.ToolCallID == "" {
+		case SessionEventTypeToolExecutionStart:
+			if evt.ToolName == nil || *evt.ToolName == "" || evt.ToolCallID == nil || *evt.ToolCallID == "" {
 				continue
 			}
 
 			tc := &ToolCall{
-				ID:   start.ToolCallID,
-				Name: start.ToolName,
+				ID:   *evt.ToolCallID,
+				Name: *evt.ToolName,
 			}
 
-			if err := mapstructure.Decode(start.Arguments, &tc.Arguments); err != nil {
-				slog.Warn("tool argument format wasn't recognized", "error", err, "name", start.ToolName, "args", start.Arguments)
+			if err := mapstructure.Decode(evt.Arguments, &tc.Arguments); err != nil {
+				slog.Warn("tool argument format wasn't recognized", "error", err, "name", *evt.ToolName, "args", evt.Arguments)
 			}
 
-			toolCallsMap[start.ToolCallID] = tc
-			toolCallIDs = append(toolCallIDs, start.ToolCallID)
-		case copilot.SessionEventTypeToolExecutionComplete:
-			complete, ok := copilotevents.ToolComplete(evt)
-			if !ok || complete.ToolCallID == "" {
+			toolCallsMap[*evt.ToolCallID] = tc
+			toolCallIDs = append(toolCallIDs, *evt.ToolCallID)
+		case SessionEventTypeToolExecutionComplete:
+			if evt.ToolCallID == nil || *evt.ToolCallID == "" {
 				continue
 			}
-			tc := toolCallsMap[complete.ToolCallID]
+			tc := toolCallsMap[*evt.ToolCallID]
 			if tc == nil {
 				continue
 			}
 
-			tc.Success = complete.Success
-			tc.Result = complete.Result
+			if evt.Success != nil {
+				tc.Success = *evt.Success
+			}
+			tc.Result = evt.ToolResult
 		}
 	}
 

--- a/internal/models/events_test.go
+++ b/internal/models/events_test.go
@@ -4,87 +4,61 @@ import (
 	"encoding/json"
 	"testing"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTranscriptEventRoundTrip(t *testing.T) {
-	content := "hello world"
-	message := "some message"
 	toolCallID := "call-123"
-	toolName := "bash"
 	success := true
 
 	original := TranscriptEvent{
-		SessionEvent: copilot.SessionEvent{
-			Data: &copilot.ToolExecutionCompleteData{
-				ToolCallID: toolCallID,
-				Result: &copilot.ToolExecutionCompleteResult{
-					Content: "file1.go",
-				},
-				Success: success,
+		SessionEvent: SessionEvent{
+			EventType:  SessionEventTypeToolExecutionComplete,
+			ToolCallID: &toolCallID,
+			ToolResult: &ToolExecutionResult{
+				Content: "file1.go",
 			},
+			Success: &success,
 		},
 	}
-	_ = content
-	_ = message
-	_ = toolName
 
 	data, err := json.Marshal(original)
-	if err != nil {
-		t.Fatalf("MarshalJSON failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	var restored TranscriptEvent
-	if err := json.Unmarshal(data, &restored); err != nil {
-		t.Fatalf("UnmarshalJSON failed: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(data, &restored))
 
-	if restored.Type() != original.Type() {
-		t.Errorf("Type: got %v, want %v", restored.Type(), original.Type())
-	}
-	restoredData, ok := restored.Data.(*copilot.ToolExecutionCompleteData)
-	require.True(t, ok)
-	require.Equal(t, toolCallID, restoredData.ToolCallID)
-	require.Equal(t, success, restoredData.Success)
-	if restoredData.Result == nil {
-		t.Fatal("Result is nil after round-trip")
-	}
-
-	require.Equal(t, "file1.go", restoredData.Result.Content)
+	require.Equal(t, original.Type(), restored.Type())
+	require.NotNil(t, restored.ToolCallID)
+	require.Equal(t, toolCallID, *restored.ToolCallID)
+	require.NotNil(t, restored.Success)
+	require.Equal(t, success, *restored.Success)
+	require.NotNil(t, restored.ToolResult)
+	require.Equal(t, "file1.go", restored.ToolResult.Content)
 }
 
 func TestTranscriptEventUnmarshalMinimal(t *testing.T) {
 	input := `{"type":"tool.execution_start"}`
 
 	var te TranscriptEvent
-	if err := json.Unmarshal([]byte(input), &te); err != nil {
-		t.Fatalf("UnmarshalJSON failed: %v", err)
-	}
-	if te.Type() != copilot.SessionEventTypeToolExecutionStart {
-		t.Errorf("Type: got %v, want %v", te.Type(), copilot.SessionEventTypeToolExecutionStart)
-	}
-	_, ok := te.Data.(*copilot.ToolExecutionStartData)
-	require.True(t, ok)
+	require.NoError(t, json.Unmarshal([]byte(input), &te))
+	require.Equal(t, SessionEventTypeToolExecutionStart, te.Type())
 }
 
 // TestTranscriptEventRoundTripPreservesUncoveredType guards against losing the
-// event type for kinds without a dedicated transcriptData mapping (for example
-// session.idle, session.shutdown, assistant.usage). These fall to the
-// RawSessionEventData default case, which only reports the right Type() if its
-// EventType field is set. mapTranscriptEvents in the web API relies on Type().
+// event type for kinds without dedicated payload fields (for example
+// session.idle, session.shutdown, assistant.usage).
 func TestTranscriptEventRoundTripPreservesUncoveredType(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
-		eventType copilot.SessionEventType
-		data      copilot.SessionEventData
+		eventType SessionEventType
 	}{
-		{"idle", copilot.SessionEventTypeSessionIdle, &copilot.SessionIdleData{}},
-		{"shutdown", copilot.SessionEventTypeSessionShutdown, &copilot.SessionShutdownData{}},
-		{"assistant_usage", copilot.SessionEventTypeAssistantUsage, &copilot.AssistantUsageData{}},
+		{"idle", SessionEventTypeSessionIdle},
+		{"shutdown", SessionEventTypeSessionShutdown},
+		{"assistant_usage", SessionEventTypeAssistantUsage},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			original := TranscriptEvent{SessionEvent: copilot.SessionEvent{Data: tc.data}}
+			original := TranscriptEvent{SessionEvent: SessionEvent{EventType: tc.eventType}}
 			require.Equal(t, tc.eventType, original.Type())
 
 			data, err := json.Marshal(original)

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/cache"
 	"github.com/microsoft/waza/internal/config"
 	"github.com/microsoft/waza/internal/execution"
@@ -386,8 +385,8 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 		},
 		ToolCalls: []models.ToolCall{{Name: "bash"}, {Name: "view"}},
 		Usage:     &models.UsageStats{Turns: 1},
-		Events: []copilot.SessionEvent{
-			{Data: &copilot.UserMessageData{Content: content}},
+		Events: []models.SessionEvent{
+			{EventType: models.SessionEventTypeUserMessage, Content: &content},
 		},
 	}
 
@@ -408,7 +407,7 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 
 	transcript := runner.buildTranscript(resp)
 	require.Len(t, transcript, 1)
-	assert.Equal(t, copilot.SessionEventTypeUserMessage, transcript[0].Type())
+	assert.Equal(t, models.SessionEventTypeUserMessage, transcript[0].Type())
 }
 
 func TestComputeTestStats_FlakinessPercent(t *testing.T) {

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -52,9 +51,9 @@ func Write(dir string, t *models.TaskTranscript) (string, error) {
 	return path, nil
 }
 
-// BuildFromSessionEvents converts a slice of Copilot session events
+// BuildFromSessionEvents converts a slice of provider-neutral session events
 // into TranscriptEvents.
-func BuildFromSessionEvents(events []copilot.SessionEvent) []models.TranscriptEvent {
+func BuildFromSessionEvents(events []models.SessionEvent) []models.TranscriptEvent {
 	entries := make([]models.TranscriptEvent, 0, len(events))
 	for _, evt := range events {
 		entries = append(entries, models.TranscriptEvent{SessionEvent: evt})

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/require"
 )
@@ -60,14 +59,10 @@ func TestWrite(t *testing.T) {
 		FinalOutput: "This function does X",
 		Transcript: []models.TranscriptEvent{
 			{
-				SessionEvent: copilot.SessionEvent{
-					Data: &copilot.UserMessageData{Content: "Explain this function"},
-				},
+				SessionEvent: models.SessionEvent{EventType: models.SessionEventTypeUserMessage, Content: testStringPtr("Explain this function")},
 			},
 			{
-				SessionEvent: copilot.SessionEvent{
-					Data: &copilot.AssistantMessageData{Content: "This function does X"},
-				},
+				SessionEvent: models.SessionEvent{EventType: models.SessionEventTypeAssistantMessage, Content: testStringPtr("This function does X")},
 			},
 		},
 		Validations: map[string]models.GraderResults{
@@ -175,8 +170,8 @@ func TestBuildTaskTranscript(t *testing.T) {
 				Status:     models.StatusPassed,
 				DurationMs: 500,
 				Transcript: []models.TranscriptEvent{
-					{SessionEvent: copilot.SessionEvent{Data: &copilot.UserMessageData{Content: "Explain this code"}}},
-					{SessionEvent: copilot.SessionEvent{Data: &copilot.AssistantMessageData{Content: "Sure, this code..."}}},
+					{SessionEvent: models.SessionEvent{EventType: models.SessionEventTypeUserMessage, Content: testStringPtr("Explain this code")}},
+					{SessionEvent: models.SessionEvent{EventType: models.SessionEventTypeAssistantMessage, Content: testStringPtr("Sure, this code...")}},
 				},
 				Validations: map[string]models.GraderResults{
 					"check": {Name: "check", Score: 1.0, Passed: true},
@@ -211,4 +206,8 @@ func TestBuildTaskTranscript(t *testing.T) {
 	if result.FinalOutput != "Sure, this code..." {
 		t.Errorf("FinalOutput = %q, want %q", result.FinalOutput, "Sure, this code...")
 	}
+}
+
+func testStringPtr(value string) *string {
+	return &value
 }

--- a/internal/webapi/additional_test.go
+++ b/internal/webapi/additional_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/statistics"
 )
@@ -237,14 +236,11 @@ func TestOutcomeToDetailMapsStatsTranscriptAndDigest(t *testing.T) {
 						},
 						Transcript: []models.TranscriptEvent{
 							{
-								SessionEvent: copilot.SessionEvent{
-									Data: &copilot.ToolExecutionCompleteData{
-										ToolCallID: toolCallID,
-										Result: &copilot.ToolExecutionCompleteResult{
-											Content: "hi",
-										},
-										Success: success,
-									},
+								SessionEvent: models.SessionEvent{
+									EventType:  models.SessionEventTypeToolExecutionComplete,
+									ToolCallID: &toolCallID,
+									ToolResult: &models.ToolExecutionResult{Content: "hi"},
+									Success:    &success,
 								},
 							},
 						},

--- a/internal/webapi/store.go
+++ b/internal/webapi/store.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/pricing"
 )
@@ -338,25 +337,23 @@ func mapTranscriptEvents(events []models.TranscriptEvent) []TranscriptEventRespo
 		r := TranscriptEventResponse{
 			Type: string(e.Type()),
 		}
-		if content, ok := copilotevents.Content(e.SessionEvent); ok {
-			r.Content = content
+		if e.Content != nil {
+			r.Content = *e.Content
 		}
-		if message, ok := copilotevents.Message(e.SessionEvent); ok {
-			r.Message = message
+		if e.Message != nil {
+			r.Message = *e.Message
 		}
-		if start, ok := copilotevents.ToolStart(e.SessionEvent); ok {
-			r.ToolCallID = start.ToolCallID
-			r.ToolName = start.ToolName
-			r.Arguments = start.Arguments
+		if e.ToolCallID != nil {
+			r.ToolCallID = *e.ToolCallID
 		}
-		if complete, ok := copilotevents.ToolComplete(e.SessionEvent); ok {
-			r.ToolCallID = complete.ToolCallID
-			r.Success = &complete.Success
-			r.ToolResult = complete.Result
+		if e.ToolName != nil {
+			r.ToolName = *e.ToolName
 		}
-		if partial, ok := copilotevents.ToolPartial(e.SessionEvent); ok {
-			r.ToolCallID = partial.ToolCallID
-			r.Message = partial.PartialOutput
+		r.Arguments = e.Arguments
+		r.Success = e.Success
+		r.ToolResult = e.ToolResult
+		if e.PartialOutput != nil {
+			r.Message = *e.PartialOutput
 		}
 		resp = append(resp, r)
 	}


### PR DESCRIPTION
## Summary
- Introduce provider-neutral `models.SessionEvent` and `models.ToolExecutionResult` types.
- Change `execution.ExecutionResponse.Events` and transcript/tool-call consumers to use neutral events instead of `copilot.SessionEvent`.
- Keep Copilot SDK event handling at the adapter boundary by converting SDK events inside `internal/copilotevents` / `SessionEventsCollector`.
- Update tests to cover neutral transcript/event behavior while preserving current JSON output shape.

Closes #10

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Scope
Phase 1 only: this does not add Phase 2 engine implementations.

## Validation
- `go test ./...` (fails on pre-existing baseline: `internal/models TestLoadEvalSpec_MCPMocksRequireSchemaVersion11`, reproduced before changes)
- `go test ./internal/models -run 'TestTranscriptEvent'`
- `go test $(go list ./... | grep -v '/internal/models$')`
- `make lint` (after `golangci-lint cache clean` to clear stale worktree paths)
- `make build`