### PR TITLE
feat: Decouple ExecutionResponse from Copilot SDK event types (#10)

### DIFF
--- a/cmd/waza/cmd_run_suggest.go
+++ b/cmd/waza/cmd_run_suggest.go
@@ -13,9 +13,8 @@ import (
 	"strings"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
 	waza "github.com/microsoft/waza"
-	"github.com/microsoft/waza/internal/copilotevents"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/dataset"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/models"
@@ -113,7 +112,7 @@ func buildNoSuggestionsError(res *execution.ExecutionResponse) error {
 	return fmt.Errorf("no suggestions from Copilot. Session transcript:\n- %s", strings.Join(trace, "\n- "))
 }
 
-func summarizeSessionEventTypes(events []copilot.SessionEvent) []string {
+func summarizeSessionEventTypes(events []agentevents.Event) []string {
 	if len(events) == 0 {
 		return nil
 	}
@@ -628,8 +627,8 @@ func extractCopilotTrace(transcript []models.TranscriptEvent) []string {
 	toolNames := map[string]string{}
 	for _, evt := range transcript {
 		switch evt.Type() {
-		case copilot.SessionEventTypeAssistantMessage:
-			content, ok := copilotevents.Content(evt.SessionEvent)
+		case agentevents.EventTypeAssistantMessage:
+			content, ok := agentevents.Content(evt.Event)
 			if !ok {
 				continue
 			}
@@ -638,8 +637,8 @@ func extractCopilotTrace(transcript []models.TranscriptEvent) []string {
 				continue
 			}
 			lines = append(lines, "agent: "+truncateForPrompt(msg, maxSuggestionTraceEntryLen))
-		case copilot.SessionEventTypeSkillInvoked:
-			if skill, ok := copilotevents.SkillInvoked(evt.SessionEvent); ok {
+		case agentevents.EventTypeSkillInvoked:
+			if skill, ok := agentevents.SkillInvoked(evt.Event); ok {
 				msg := compactWhitespace(skill.Name)
 				if msg == "" {
 					msg = compactWhitespace(skill.Path)
@@ -648,8 +647,8 @@ func extractCopilotTrace(transcript []models.TranscriptEvent) []string {
 					lines = append(lines, "skill invoked: "+truncateForPrompt(msg, maxSuggestionTraceEntryLen))
 				}
 			}
-		case copilot.SessionEventTypeToolExecutionStart:
-			start, ok := copilotevents.ToolStart(evt.SessionEvent)
+		case agentevents.EventTypeToolExecutionStart:
+			start, ok := agentevents.ToolStart(evt.Event)
 			if !ok {
 				continue
 			}
@@ -666,8 +665,8 @@ func extractCopilotTrace(transcript []models.TranscriptEvent) []string {
 				continue
 			}
 			lines = append(lines, fmt.Sprintf("tool start: %s args=%s", name, args))
-		case copilot.SessionEventTypeToolExecutionComplete:
-			complete, ok := copilotevents.ToolComplete(evt.SessionEvent)
+		case agentevents.EventTypeToolExecutionComplete:
+			complete, ok := agentevents.ToolComplete(evt.Event)
 			if !ok {
 				continue
 			}
@@ -680,8 +679,8 @@ func extractCopilotTrace(transcript []models.TranscriptEvent) []string {
 				parts = append(parts, "result="+result)
 			}
 			lines = append(lines, strings.Join(parts, " "))
-		case copilot.SessionEventTypeToolExecutionPartialResult:
-			partial, ok := copilotevents.ToolPartial(evt.SessionEvent)
+		case agentevents.EventTypeToolExecutionPartialResult:
+			partial, ok := agentevents.ToolPartial(evt.Event)
 			if !ok {
 				continue
 			}
@@ -690,8 +689,8 @@ func extractCopilotTrace(transcript []models.TranscriptEvent) []string {
 				continue
 			}
 			lines = append(lines, "tool partial result: "+truncateForPrompt(output, maxSuggestionTraceEntryLen))
-		case copilot.SessionEventTypeToolUserRequested:
-			request, ok := copilotevents.ToolUserRequested(evt.SessionEvent)
+		case agentevents.EventTypeToolUserRequested:
+			request, ok := agentevents.ToolUserRequested(evt.Event)
 			if !ok {
 				continue
 			}

--- a/cmd/waza/cmd_run_suggest_test.go
+++ b/cmd/waza/cmd_run_suggest_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -92,19 +93,19 @@ func TestBuildNoSuggestionsError_IncludesSessionTranscript(t *testing.T) {
 	toolResultText := "matched 1 file"
 
 	err := buildNoSuggestionsError(&execution.ExecutionResponse{
-		Events: []copilot.SessionEvent{
+		Events: []agentevents.Event{
 			{
-				Data: &copilot.AssistantMessageData{Content: msg},
+				Data: &agentevents.AssistantMessageData{Content: msg},
 			},
 			{
-				Data: &copilot.ToolExecutionStartData{
+				Data: &agentevents.ToolExecutionStartData{
 					ToolName:   toolName,
 					ToolCallID: toolCallID,
 					Arguments:  map[string]any{"pattern": "foo"},
 				},
 			},
 			{
-				Data: &copilot.ToolExecutionCompleteData{
+				Data: &agentevents.ToolExecutionCompleteData{
 					ToolCallID: toolCallID,
 					Success:    succeeded,
 					Result: &copilot.ToolExecutionCompleteResult{
@@ -124,13 +125,13 @@ func TestBuildNoSuggestionsError_IncludesSessionTranscript(t *testing.T) {
 
 func TestBuildNoSuggestionsError_FallsBackToEventTypes(t *testing.T) {
 	err := buildNoSuggestionsError(&execution.ExecutionResponse{
-		Events: []copilot.SessionEvent{
-			{Data: &copilot.SessionIdleData{}},
+		Events: []agentevents.Event{
+			{Data: &agentevents.SessionIdleData{}},
 		},
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "event[1]: "+string(copilot.SessionEventTypeSessionIdle))
+	assert.Contains(t, err.Error(), "event[1]: "+string(agentevents.EventTypeSessionIdle))
 }
 
 func TestBuildNoSuggestionsError_WithNoEvents(t *testing.T) {
@@ -185,13 +186,13 @@ func TestBuildRunSuggestionPrompt_IncludesOnlyFailureEvidence(t *testing.T) {
 					},
 					Transcript: []models.TranscriptEvent{
 						{
-							SessionEvent: copilot.SessionEvent{
-								Data: &copilot.AssistantMessageData{Content: msg},
+							Event: agentevents.Event{
+								Data: &agentevents.AssistantMessageData{Content: msg},
 							},
 						},
 						{
-							SessionEvent: copilot.SessionEvent{
-								Data: &copilot.ToolExecutionStartData{
+							Event: agentevents.Event{
+								Data: &agentevents.ToolExecutionStartData{
 									ToolName:   toolName,
 									ToolCallID: toolCallID,
 									Arguments:  map[string]any{"pattern": "foo"},
@@ -199,8 +200,8 @@ func TestBuildRunSuggestionPrompt_IncludesOnlyFailureEvidence(t *testing.T) {
 							},
 						},
 						{
-							SessionEvent: copilot.SessionEvent{
-								Data: &copilot.ToolExecutionCompleteData{
+							Event: agentevents.Event{
+								Data: &agentevents.ToolExecutionCompleteData{
 									ToolCallID: toolCallID,
 									Success:    succeeded,
 									Result: &copilot.ToolExecutionCompleteResult{
@@ -388,9 +389,9 @@ func TestWriteSuggestionTranscript_WritesFile(t *testing.T) {
 		FinalOutput: "Suggestion report text",
 		Success:     true,
 		DurationMs:  1500,
-		Events: []copilot.SessionEvent{
+		Events: []agentevents.Event{
 			{
-				Data: &copilot.AssistantMessageData{Content: msg},
+				Data: &agentevents.AssistantMessageData{Content: msg},
 			},
 		},
 	}

--- a/internal/agentevents/events.go
+++ b/internal/agentevents/events.go
@@ -1,0 +1,340 @@
+// Package agentevents defines a provider-neutral event model that waza's
+// execution layer uses to describe agent runs. It is intentionally independent
+// of any specific agent SDK so the rest of the codebase (orchestration,
+// graders, transcripts, web API, CLI suggestion path) can consume execution
+// output without importing a particular SDK's event types.
+//
+// Engine adapters are responsible for converting SDK-native events into the
+// neutral types defined here. For the Copilot engine, see
+// internal/execution/agentevents_adapter.go.
+//
+// Phase 1 (issue #10) scope: this package intentionally retains one narrow
+// SDK reference - ToolExecutionCompleteData.Result keeps the SDK's
+// *copilot.ToolExecutionCompleteResult type so that the existing JSON wire
+// format (transcripts, dashboard payloads) is preserved bit-for-bit. Phase 2
+// will replace this with a neutral result type.
+package agentevents
+
+import (
+	"encoding/json"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+// EventType identifies the kind of an Event. Constants below use the same
+// string values as the underlying engine's event types so the JSON wire
+// format produced for transcripts is unchanged.
+type EventType string
+
+const (
+	EventTypeAssistantMessage           EventType = "assistant.message"
+	EventTypeAssistantMessageDelta      EventType = "assistant.message_delta"
+	EventTypeAssistantReasoning         EventType = "assistant.reasoning"
+	EventTypeAssistantUsage             EventType = "assistant.usage"
+	EventTypeUserMessage                EventType = "user.message"
+	EventTypeSystemMessage              EventType = "system.message"
+	EventTypeSessionStart               EventType = "session.start"
+	EventTypeSessionIdle                EventType = "session.idle"
+	EventTypeSessionError               EventType = "session.error"
+	EventTypeSessionInfo                EventType = "session.info"
+	EventTypeSessionWarning             EventType = "session.warning"
+	EventTypeSessionShutdown            EventType = "session.shutdown"
+	EventTypeSkillInvoked               EventType = "skill.invoked"
+	EventTypeToolExecutionStart         EventType = "tool.execution_start"
+	EventTypeToolExecutionComplete      EventType = "tool.execution_complete"
+	EventTypeToolExecutionProgress      EventType = "tool.execution_progress"
+	EventTypeToolExecutionPartialResult EventType = "tool.execution_partial_result"
+	EventTypeToolUserRequested          EventType = "tool.user_requested"
+	EventTypeHookStart                  EventType = "hook.start"
+	EventTypeHookEnd                    EventType = "hook.end"
+)
+
+// EventData is the payload carried by an Event. Concrete payload types
+// implement Type() to declare which EventType they represent.
+type EventData interface {
+	Type() EventType
+}
+
+// Event is a single neutral agent execution event.
+type Event struct {
+	Data EventData
+}
+
+// Type returns the EventType of e's payload. Returns "" for a zero Event.
+func (e Event) Type() EventType {
+	if e.Data == nil {
+		return ""
+	}
+	return e.Data.Type()
+}
+
+// ---------- Concrete payload types ----------
+
+type UserMessageData struct {
+	Content string
+}
+
+func (*UserMessageData) Type() EventType { return EventTypeUserMessage }
+
+type AssistantMessageData struct {
+	Content       string
+	ReasoningText *string
+}
+
+func (*AssistantMessageData) Type() EventType { return EventTypeAssistantMessage }
+
+type AssistantMessageDeltaData struct {
+	DeltaContent string
+}
+
+func (*AssistantMessageDeltaData) Type() EventType { return EventTypeAssistantMessageDelta }
+
+type AssistantReasoningData struct {
+	Content string
+}
+
+func (*AssistantReasoningData) Type() EventType { return EventTypeAssistantReasoning }
+
+type SystemMessageData struct {
+	Content string
+}
+
+func (*SystemMessageData) Type() EventType { return EventTypeSystemMessage }
+
+type AssistantUsageData struct{}
+
+func (*AssistantUsageData) Type() EventType { return EventTypeAssistantUsage }
+
+type SessionStartData struct{}
+
+func (*SessionStartData) Type() EventType { return EventTypeSessionStart }
+
+type SessionIdleData struct{}
+
+func (*SessionIdleData) Type() EventType { return EventTypeSessionIdle }
+
+type SessionShutdownData struct{}
+
+func (*SessionShutdownData) Type() EventType { return EventTypeSessionShutdown }
+
+type SessionErrorData struct {
+	Message string
+}
+
+func (*SessionErrorData) Type() EventType { return EventTypeSessionError }
+
+type SessionInfoData struct {
+	Message string
+}
+
+func (*SessionInfoData) Type() EventType { return EventTypeSessionInfo }
+
+type SessionWarningData struct {
+	Message string
+}
+
+func (*SessionWarningData) Type() EventType { return EventTypeSessionWarning }
+
+type SkillInvokedData struct {
+	Name string
+	Path string
+}
+
+func (*SkillInvokedData) Type() EventType { return EventTypeSkillInvoked }
+
+type ToolExecutionStartData struct {
+	ToolCallID string
+	ToolName   string
+	Arguments  any
+}
+
+func (*ToolExecutionStartData) Type() EventType { return EventTypeToolExecutionStart }
+
+// ToolExecutionCompleteData carries the result of a completed tool call.
+//
+// Phase 1 residual SDK coupling: Result intentionally keeps the SDK's
+// *copilot.ToolExecutionCompleteResult type so that transcript JSON output
+// and dashboard payloads remain identical to today. Replacing Result with a
+// fully neutral type is tracked as Phase 2 work for issue #10.
+type ToolExecutionCompleteData struct {
+	ToolCallID string
+	Success    bool
+	Result     *copilot.ToolExecutionCompleteResult
+}
+
+func (*ToolExecutionCompleteData) Type() EventType { return EventTypeToolExecutionComplete }
+
+type ToolExecutionPartialResultData struct {
+	ToolCallID    string
+	PartialOutput string
+}
+
+func (*ToolExecutionPartialResultData) Type() EventType {
+	return EventTypeToolExecutionPartialResult
+}
+
+type ToolExecutionProgressData struct {
+	ToolCallID string
+}
+
+func (*ToolExecutionProgressData) Type() EventType { return EventTypeToolExecutionProgress }
+
+type ToolUserRequestedData struct {
+	Arguments  any
+	ToolCallID string
+	ToolName   string
+}
+
+func (*ToolUserRequestedData) Type() EventType { return EventTypeToolUserRequested }
+
+type HookStartData struct{}
+
+func (*HookStartData) Type() EventType { return EventTypeHookStart }
+
+type HookEndData struct{}
+
+func (*HookEndData) Type() EventType { return EventTypeHookEnd }
+
+// RawData is the fallback payload for event types without a dedicated
+// neutral struct. EventType is preserved so Type() round-trips correctly.
+type RawData struct {
+	EventType EventType
+	Raw       json.RawMessage
+}
+
+func (r *RawData) Type() EventType { return r.EventType }
+
+// NewRawData builds a RawData payload by JSON-encoding arbitrary data.
+// Marshaling errors fall back to an empty object so the event type still
+// round-trips.
+func NewRawData(eventType EventType, data any) *RawData {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		raw = []byte("{}")
+	}
+	return &RawData{EventType: eventType, Raw: raw}
+}
+
+// ---------- Accessor helpers ----------
+//
+// These mirror the shape of internal/copilotevents helpers so call sites can
+// migrate with minimal churn.
+
+// Content returns the textual content for message-bearing events
+// (user/assistant/assistant-reasoning/system messages).
+func Content(e Event) (string, bool) {
+	switch d := e.Data.(type) {
+	case *UserMessageData:
+		return d.Content, true
+	case *AssistantMessageData:
+		return d.Content, true
+	case *AssistantReasoningData:
+		return d.Content, true
+	case *SystemMessageData:
+		return d.Content, true
+	}
+	return "", false
+}
+
+// DeltaContent returns the streaming delta for assistant message deltas.
+func DeltaContent(e Event) (string, bool) {
+	if d, ok := e.Data.(*AssistantMessageDeltaData); ok {
+		return d.DeltaContent, true
+	}
+	return "", false
+}
+
+// Message returns the message text for session error/info/warning events.
+func Message(e Event) (string, bool) {
+	switch d := e.Data.(type) {
+	case *SessionErrorData:
+		return d.Message, true
+	case *SessionInfoData:
+		return d.Message, true
+	case *SessionWarningData:
+		return d.Message, true
+	}
+	return "", false
+}
+
+// ReasoningText returns the assistant reasoning text pointer for assistant
+// message events, or nil when not present.
+func ReasoningText(e Event) *string {
+	if d, ok := e.Data.(*AssistantMessageData); ok {
+		return d.ReasoningText
+	}
+	return nil
+}
+
+func SessionStart(e Event) (*SessionStartData, bool) {
+	d, ok := e.Data.(*SessionStartData)
+	return d, ok
+}
+
+func Shutdown(e Event) (*SessionShutdownData, bool) {
+	d, ok := e.Data.(*SessionShutdownData)
+	return d, ok
+}
+
+func AssistantUsage(e Event) (*AssistantUsageData, bool) {
+	d, ok := e.Data.(*AssistantUsageData)
+	return d, ok
+}
+
+func SkillInvoked(e Event) (*SkillInvokedData, bool) {
+	d, ok := e.Data.(*SkillInvokedData)
+	return d, ok
+}
+
+func ToolStart(e Event) (*ToolExecutionStartData, bool) {
+	d, ok := e.Data.(*ToolExecutionStartData)
+	return d, ok
+}
+
+func ToolComplete(e Event) (*ToolExecutionCompleteData, bool) {
+	d, ok := e.Data.(*ToolExecutionCompleteData)
+	return d, ok
+}
+
+func ToolPartial(e Event) (*ToolExecutionPartialResultData, bool) {
+	d, ok := e.Data.(*ToolExecutionPartialResultData)
+	return d, ok
+}
+
+func ToolProgress(e Event) (*ToolExecutionProgressData, bool) {
+	d, ok := e.Data.(*ToolExecutionProgressData)
+	return d, ok
+}
+
+func ToolUserRequested(e Event) (*ToolUserRequestedData, bool) {
+	d, ok := e.Data.(*ToolUserRequestedData)
+	return d, ok
+}
+
+func HookStart(e Event) (*HookStartData, bool) {
+	d, ok := e.Data.(*HookStartData)
+	return d, ok
+}
+
+func HookEnd(e Event) (*HookEndData, bool) {
+	d, ok := e.Data.(*HookEndData)
+	return d, ok
+}
+
+// ToolCallID returns the tool-call identifier for any tool-related event
+// kind. The boolean is false for events without a tool call ID.
+func ToolCallID(e Event) (string, bool) {
+	switch d := e.Data.(type) {
+	case *ToolExecutionStartData:
+		return d.ToolCallID, d.ToolCallID != ""
+	case *ToolExecutionCompleteData:
+		return d.ToolCallID, d.ToolCallID != ""
+	case *ToolExecutionPartialResultData:
+		return d.ToolCallID, d.ToolCallID != ""
+	case *ToolExecutionProgressData:
+		return d.ToolCallID, d.ToolCallID != ""
+	case *ToolUserRequestedData:
+		return d.ToolCallID, d.ToolCallID != ""
+	}
+	return "", false
+}

--- a/internal/execution/agentevents_adapter.go
+++ b/internal/execution/agentevents_adapter.go
@@ -1,0 +1,85 @@
+package execution
+
+import (
+	"encoding/json"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
+)
+
+// FromCopilotEvent converts a Copilot SDK session event into the neutral
+// agentevents.Event used throughout waza. Unknown event types fall through
+// to agentevents.RawData so the kind round-trips.
+func FromCopilotEvent(e copilot.SessionEvent) agentevents.Event {
+	switch d := e.Data.(type) {
+	case *copilot.UserMessageData:
+		return agentevents.Event{Data: &agentevents.UserMessageData{Content: d.Content}}
+	case *copilot.AssistantMessageData:
+		return agentevents.Event{Data: &agentevents.AssistantMessageData{
+			Content:       d.Content,
+			ReasoningText: d.ReasoningText,
+		}}
+	case *copilot.AssistantMessageDeltaData:
+		return agentevents.Event{Data: &agentevents.AssistantMessageDeltaData{DeltaContent: d.DeltaContent}}
+	case *copilot.AssistantReasoningData:
+		return agentevents.Event{Data: &agentevents.AssistantReasoningData{Content: d.Content}}
+	case *copilot.SystemMessageData:
+		return agentevents.Event{Data: &agentevents.SystemMessageData{Content: d.Content}}
+	case *copilot.AssistantUsageData:
+		return agentevents.Event{Data: &agentevents.AssistantUsageData{}}
+	case *copilot.SessionStartData:
+		return agentevents.Event{Data: &agentevents.SessionStartData{}}
+	case *copilot.SessionIdleData:
+		return agentevents.Event{Data: &agentevents.SessionIdleData{}}
+	case *copilot.SessionShutdownData:
+		return agentevents.Event{Data: &agentevents.SessionShutdownData{}}
+	case *copilot.SessionErrorData:
+		return agentevents.Event{Data: &agentevents.SessionErrorData{Message: d.Message}}
+	case *copilot.SessionInfoData:
+		return agentevents.Event{Data: &agentevents.SessionInfoData{Message: d.Message}}
+	case *copilot.SessionWarningData:
+		return agentevents.Event{Data: &agentevents.SessionWarningData{Message: d.Message}}
+	case *copilot.SkillInvokedData:
+		return agentevents.Event{Data: &agentevents.SkillInvokedData{Name: d.Name, Path: d.Path}}
+	case *copilot.ToolExecutionStartData:
+		return agentevents.Event{Data: &agentevents.ToolExecutionStartData{
+			ToolCallID: d.ToolCallID,
+			ToolName:   d.ToolName,
+			Arguments:  d.Arguments,
+		}}
+	case *copilot.ToolExecutionCompleteData:
+		return agentevents.Event{Data: &agentevents.ToolExecutionCompleteData{
+			ToolCallID: d.ToolCallID,
+			Success:    d.Success,
+			Result:     d.Result,
+		}}
+	case *copilot.ToolExecutionPartialResultData:
+		return agentevents.Event{Data: &agentevents.ToolExecutionPartialResultData{
+			ToolCallID:    d.ToolCallID,
+			PartialOutput: d.PartialOutput,
+		}}
+	case *copilot.ToolExecutionProgressData:
+		return agentevents.Event{Data: &agentevents.ToolExecutionProgressData{ToolCallID: d.ToolCallID}}
+	case *copilot.ToolUserRequestedData:
+		return agentevents.Event{Data: &agentevents.ToolUserRequestedData{Arguments: d.Arguments, ToolCallID: d.ToolCallID, ToolName: d.ToolName}}
+	case *copilot.HookStartData:
+		return agentevents.Event{Data: &agentevents.HookStartData{}}
+	case *copilot.HookEndData:
+		return agentevents.Event{Data: &agentevents.HookEndData{}}
+	case *copilot.RawSessionEventData:
+		return agentevents.Event{Data: &agentevents.RawData{
+			EventType: agentevents.EventType(d.EventType),
+			Raw:       d.Raw,
+		}}
+	}
+	// Unrecognized SDK data type: best-effort preserve the kind string and
+	// JSON form so consumers can still see it.
+	raw, err := json.Marshal(e.Data)
+	if err != nil {
+		raw = []byte("{}")
+	}
+	return agentevents.Event{Data: &agentevents.RawData{
+		EventType: agentevents.EventType(e.Type()),
+		Raw:       raw,
+	}}
+}

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
-	"github.com/microsoft/waza/internal/copilotevents"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -132,7 +132,7 @@ type SkillInvocation struct {
 // ExecutionResponse represents the result of an execution
 type ExecutionResponse struct {
 	FinalOutput      string
-	Events           []copilot.SessionEvent
+	Events           []agentevents.Event
 	ModelID          string
 	SkillInvocations []SkillInvocation
 	DurationMs       int64
@@ -149,8 +149,8 @@ type ExecutionResponse struct {
 func (r *ExecutionResponse) ExtractMessages() []string {
 	var messages []string
 	for _, evt := range r.Events {
-		if evt.Type() == copilot.SessionEventTypeAssistantMessage {
-			if content, ok := copilotevents.Content(evt); ok && content != "" {
+		if evt.Type() == agentevents.EventTypeAssistantMessage {
+			if content, ok := agentevents.Content(evt); ok && content != "" {
 				messages = append(messages, content)
 			}
 		}

--- a/internal/execution/engine_response_test.go
+++ b/internal/execution/engine_response_test.go
@@ -3,7 +3,7 @@ package execution
 import (
 	"testing"
 
-	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,11 +13,11 @@ func TestExecutionResponse_ExtractMessages(t *testing.T) {
 	ignoredDelta := "delta"
 
 	resp := &ExecutionResponse{
-		Events: []copilot.SessionEvent{
-			{Data: &copilot.AssistantMessageData{Content: hello}},
-			{Data: &copilot.AssistantMessageData{}},
-			{Data: &copilot.AssistantMessageDeltaData{DeltaContent: ignoredDelta}},
-			{Data: &copilot.AssistantMessageData{Content: world}},
+		Events: []agentevents.Event{
+			{Data: &agentevents.AssistantMessageData{Content: hello}},
+			{Data: &agentevents.AssistantMessageData{}},
+			{Data: &agentevents.AssistantMessageDeltaData{DeltaContent: ignoredDelta}},
+			{Data: &agentevents.AssistantMessageData{Content: world}},
 		},
 	}
 

--- a/internal/execution/mock.go
+++ b/internal/execution/mock.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -142,7 +142,7 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 
 	resp := &ExecutionResponse{
 		FinalOutput:    output,
-		Events:         []copilot.SessionEvent{},
+		Events:         []agentevents.Event{},
 		ModelID:        m.modelID,
 		DurationMs:     time.Since(start).Milliseconds(),
 		ToolCalls:      []models.ToolCall{},

--- a/internal/execution/session_events_collector.go
+++ b/internal/execution/session_events_collector.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	copilot "github.com/github/copilot-sdk/go"
-	"github.com/microsoft/waza/internal/copilotevents"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -16,7 +16,7 @@ type SessionEventsCollector struct {
 	// SkillInvocations is a chronological list of skills invoked during the session
 	SkillInvocations []SkillInvocation
 
-	sessionEvents  []copilot.SessionEvent
+	sessionEvents  []agentevents.Event
 	outputParts    []string
 	errorMsg       string
 	done           chan struct{}
@@ -35,8 +35,10 @@ func NewSessionEventsCollector() *SessionEventsCollector {
 	}
 }
 
-// SessionEvents returns the collected session events.
-func (coll *SessionEventsCollector) SessionEvents() []copilot.SessionEvent {
+// SessionEvents returns the collected session events in their neutral form.
+// SDK events received via On() are converted to agentevents.Event at the
+// boundary, so consumers never see provider-specific event types.
+func (coll *SessionEventsCollector) SessionEvents() []agentevents.Event {
 	return coll.sessionEvents
 }
 
@@ -74,7 +76,9 @@ func (coll *SessionEventsCollector) SetOnSkillInvoked(fn func(SkillInvocation)) 
 }
 
 // On is a callback, intended to be passed to [copilot.Session.On] to receive
-// events in real-time.
+// events in real-time. The SDK signature requires copilot.SessionEvent on this
+// boundary; internally we immediately convert to the neutral agentevents.Event
+// representation used throughout the rest of waza.
 func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
 	// Signal first contact before anything else: ANY event proves the engine is
 	// alive and has begun the turn, which disarms the first-event watchdog. We
@@ -83,16 +87,17 @@ func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
 	// a true session-start hang emits no events at all.
 	coll.firstEventOnce.Do(func() { close(coll.firstEvent) })
 
-	switch event.Type() {
-	case copilot.SessionEventTypeAssistantMessage:
-		if content, ok := copilotevents.Content(event); ok {
+	neutral := FromCopilotEvent(event)
+
+	switch neutral.Type() {
+	case agentevents.EventTypeAssistantMessage:
+		if content, ok := agentevents.Content(neutral); ok {
 			coll.outputParts = append(coll.outputParts, content)
 		}
 
-	case copilot.SessionEventTypeSkillInvoked:
+	case agentevents.EventTypeSkillInvoked:
 		si := SkillInvocation{}
-		// these and Content (the text of the relevant SKILL.md) are the only consistently populated fields
-		if data, ok := copilotevents.SkillInvoked(event); ok {
+		if data, ok := agentevents.SkillInvoked(neutral); ok {
 			si.Name = data.Name
 			si.Path = data.Path
 		}
@@ -109,8 +114,8 @@ func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
 			}
 		}
 
-	case copilot.SessionEventTypeToolExecutionStart:
-		if data, ok := copilotevents.ToolStart(event); ok && data.ToolName == "report_intent" {
+	case agentevents.EventTypeToolExecutionStart:
+		if data, ok := agentevents.ToolStart(neutral); ok && data.ToolName == "report_intent" {
 			// report_intent always seems to be followed by the actual tool invocation,
 			// so I'm just going to skip these to save a little space.
 			if data.ToolCallID != "" {
@@ -118,21 +123,21 @@ func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
 			}
 			return
 		}
-	case copilot.SessionEventTypeToolExecutionProgress,
-		copilot.SessionEventTypeToolUserRequested:
-		if toolCallID, ok := copilotevents.ToolCallID(event); ok && coll.intentToolIDs[toolCallID] {
+	case agentevents.EventTypeToolExecutionProgress,
+		agentevents.EventTypeToolUserRequested:
+		if toolCallID, ok := agentevents.ToolCallID(neutral); ok && coll.intentToolIDs[toolCallID] {
 			return
 		}
 
-	case copilot.SessionEventTypeToolExecutionComplete, copilot.SessionEventTypeToolExecutionPartialResult:
-		if toolCallID, ok := copilotevents.ToolCallID(event); ok && coll.intentToolIDs[toolCallID] {
+	case agentevents.EventTypeToolExecutionComplete, agentevents.EventTypeToolExecutionPartialResult:
+		if toolCallID, ok := agentevents.ToolCallID(neutral); ok && coll.intentToolIDs[toolCallID] {
 			delete(coll.intentToolIDs, toolCallID)
 			return
 		}
 	// these are both termination events
-	case copilot.SessionEventTypeSessionIdle, copilot.SessionEventTypeSessionError:
-		if event.Type() == copilot.SessionEventTypeSessionError {
-			if message, ok := copilotevents.Message(event); !ok || message == "" {
+	case agentevents.EventTypeSessionIdle, agentevents.EventTypeSessionError:
+		if neutral.Type() == agentevents.EventTypeSessionError {
+			if message, ok := agentevents.Message(neutral); !ok || message == "" {
 				coll.errorMsg = sessionFailedUnknown
 			} else {
 				coll.errorMsg = message
@@ -146,7 +151,7 @@ func (coll *SessionEventsCollector) On(event copilot.SessionEvent) {
 		}
 	}
 
-	coll.sessionEvents = append(coll.sessionEvents, event)
+	coll.sessionEvents = append(coll.sessionEvents, neutral)
 }
 
 // ToolCalls goes through the list of session events and correlates tool starts

--- a/internal/graders/inline_script_grader.go
+++ b/internal/graders/inline_script_grader.go
@@ -13,7 +13,7 @@ import (
 
 	_ "embed"
 
-	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -191,10 +191,10 @@ func (isg *InlineScriptGrader) runScript(ctx context.Context, gradingContext *Co
 }
 
 func getStdinTextForScript(gradingContext *Context, assertions []string) ([]byte, error) {
-	var sessionEvents []copilot.SessionEvent
+	var events []agentevents.Event
 
 	for _, te := range gradingContext.Transcript {
-		sessionEvents = append(sessionEvents, te.SessionEvent)
+		events = append(events, te.Event)
 	}
 
 	outcome := gradingContext.Outcome
@@ -209,7 +209,7 @@ func getStdinTextForScript(gradingContext *Context, assertions []string) ([]byte
 		transcriptEvents = []models.TranscriptEvent{}
 	}
 
-	toolCalls := models.FilterToolCalls(sessionEvents)
+	toolCalls := models.FilterToolCalls(events)
 
 	if toolCalls == nil {
 		toolCalls = []models.ToolCall{}

--- a/internal/graders/inline_script_grader_test.go
+++ b/internal/graders/inline_script_grader_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/require"
@@ -298,7 +299,7 @@ func TestUnsupportedLanguage(t *testing.T) {
 	require.Contains(t, err.Error(), "language 'ruby' is not yet supported")
 }
 
-func loadSampleEvents(t *testing.T) []copilot.SessionEvent {
+func loadSampleEvents(t *testing.T) []agentevents.Event {
 	reader, err := os.Open(filepath.Join("..", "testdata", "copilot_events_using_skill.json"))
 	require.NoError(t, err)
 
@@ -325,11 +326,11 @@ func loadSampleEvents(t *testing.T) []copilot.SessionEvent {
 	return sessionEventCollector.SessionEvents()
 }
 
-func convertToTranscriptEvents(sessionEvents []copilot.SessionEvent) []models.TranscriptEvent {
+func convertToTranscriptEvents(sessionEvents []agentevents.Event) []models.TranscriptEvent {
 	var transcript []models.TranscriptEvent
 
 	for _, evt := range sessionEvents {
-		transcript = append(transcript, models.TranscriptEvent{SessionEvent: evt})
+		transcript = append(transcript, models.TranscriptEvent{Event: evt})
 	}
 
 	return transcript

--- a/internal/models/events.go
+++ b/internal/models/events.go
@@ -6,10 +6,14 @@ import (
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/go-viper/mapstructure/v2"
-	"github.com/microsoft/waza/internal/copilotevents"
+	"github.com/microsoft/waza/internal/agentevents"
 )
 
-// ToolCall represents a tool invocation
+// ToolCall represents a tool invocation.
+//
+// Phase 1 residual SDK coupling (issue #10): Result intentionally keeps the
+// SDK type so transcript and dashboard JSON output remains unchanged. A
+// neutral result type is tracked as Phase 2 work.
 type ToolCall struct {
 	// ID is the engine-assigned identifier for this call (e.g. the
 	// Copilot SDK's ToolCallID). Used to correlate tool invocations in
@@ -34,14 +38,20 @@ type ToolCallArgs struct {
 	Skill string `json:"skill" mapstructure:"skill"`
 }
 
+// TranscriptEvent wraps a neutral agent event with custom JSON marshaling that
+// preserves the transcript wire format used by dashboards and CI consumers.
+//
+// The embedded field is named `Event` so call sites construct events with
+// `TranscriptEvent{Event: ev}` and reach the underlying type via `te.Type()`
+// and `te.Data` via field promotion.
 type TranscriptEvent struct {
-	copilot.SessionEvent `json:"-"`
+	agentevents.Event `json:"-"`
 }
 
 func (te TranscriptEvent) MarshalJSON() ([]byte, error) {
 	v := struct {
-		Content *string                  `json:"content,omitempty"`
-		Type    copilot.SessionEventType `json:"type"`
+		Content *string               `json:"content,omitempty"`
+		Type    agentevents.EventType `json:"type"`
 
 		Message *string `json:"message,omitempty"`
 
@@ -55,23 +65,23 @@ func (te TranscriptEvent) MarshalJSON() ([]byte, error) {
 		Type: te.Type(),
 	}
 
-	if content, ok := copilotevents.Content(te.SessionEvent); ok {
+	if content, ok := agentevents.Content(te.Event); ok {
 		v.Content = &content
 	}
-	if message, ok := copilotevents.Message(te.SessionEvent); ok {
+	if message, ok := agentevents.Message(te.Event); ok {
 		v.Message = &message
 	}
-	if start, ok := copilotevents.ToolStart(te.SessionEvent); ok {
+	if start, ok := agentevents.ToolStart(te.Event); ok {
 		v.ToolCallID = &start.ToolCallID
 		v.ToolName = &start.ToolName
 		v.Arguments = start.Arguments
 	}
-	if complete, ok := copilotevents.ToolComplete(te.SessionEvent); ok {
+	if complete, ok := agentevents.ToolComplete(te.Event); ok {
 		v.ToolCallID = &complete.ToolCallID
 		v.ToolResult = complete.Result
 		v.Success = &complete.Success
 	}
-	if partial, ok := copilotevents.ToolPartial(te.SessionEvent); ok {
+	if partial, ok := agentevents.ToolPartial(te.Event); ok {
 		v.ToolCallID = &partial.ToolCallID
 	}
 
@@ -81,7 +91,7 @@ func (te TranscriptEvent) MarshalJSON() ([]byte, error) {
 func (te *TranscriptEvent) UnmarshalJSON(data []byte) error {
 	var v struct {
 		Content    *string                              `json:"content,omitempty"`
-		Type       copilot.SessionEventType             `json:"type"`
+		Type       agentevents.EventType                `json:"type"`
 		Message    *string                              `json:"message,omitempty"`
 		Arguments  any                                  `json:"arguments,omitempty"`
 		Success    *bool                                `json:"success,omitempty"`
@@ -94,13 +104,15 @@ func (te *TranscriptEvent) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	te.Data = transcriptData(v.Type, v.Content, v.Message, v.ToolCallID, v.ToolName, v.Arguments, v.ToolResult, v.Success)
+	te.Event = agentevents.Event{
+		Data: transcriptData(v.Type, v.Content, v.Message, v.ToolCallID, v.ToolName, v.Arguments, v.ToolResult, v.Success),
+	}
 
 	return nil
 }
 
 func transcriptData(
-	eventType copilot.SessionEventType,
+	eventType agentevents.EventType,
 	content *string,
 	message *string,
 	toolCallID *string,
@@ -108,32 +120,32 @@ func transcriptData(
 	arguments any,
 	toolResult *copilot.ToolExecutionCompleteResult,
 	success *bool,
-) copilot.SessionEventData {
+) agentevents.EventData {
 	switch eventType {
-	case copilot.SessionEventTypeUserMessage:
-		return &copilot.UserMessageData{Content: derefString(content)}
-	case copilot.SessionEventTypeAssistantMessage:
-		return &copilot.AssistantMessageData{Content: derefString(content)}
-	case copilot.SessionEventTypeAssistantMessageDelta:
-		return &copilot.AssistantMessageDeltaData{DeltaContent: derefString(content)}
-	case copilot.SessionEventTypeToolExecutionStart:
-		return &copilot.ToolExecutionStartData{
+	case agentevents.EventTypeUserMessage:
+		return &agentevents.UserMessageData{Content: derefString(content)}
+	case agentevents.EventTypeAssistantMessage:
+		return &agentevents.AssistantMessageData{Content: derefString(content)}
+	case agentevents.EventTypeAssistantMessageDelta:
+		return &agentevents.AssistantMessageDeltaData{DeltaContent: derefString(content)}
+	case agentevents.EventTypeToolExecutionStart:
+		return &agentevents.ToolExecutionStartData{
 			Arguments:  arguments,
 			ToolCallID: derefString(toolCallID),
 			ToolName:   derefString(toolName),
 		}
-	case copilot.SessionEventTypeToolExecutionComplete:
-		return &copilot.ToolExecutionCompleteData{
+	case agentevents.EventTypeToolExecutionComplete:
+		return &agentevents.ToolExecutionCompleteData{
 			Result:     toolResult,
 			Success:    derefBool(success),
 			ToolCallID: derefString(toolCallID),
 		}
-	case copilot.SessionEventTypeToolExecutionPartialResult:
-		return &copilot.ToolExecutionPartialResultData{ToolCallID: derefString(toolCallID)}
-	case copilot.SessionEventTypeSessionError:
-		return &copilot.SessionErrorData{Message: derefString(message)}
+	case agentevents.EventTypeToolExecutionPartialResult:
+		return &agentevents.ToolExecutionPartialResultData{ToolCallID: derefString(toolCallID)}
+	case agentevents.EventTypeSessionError:
+		return &agentevents.SessionErrorData{Message: derefString(message)}
 	default:
-		return copilotevents.RawData(eventType, map[string]any{
+		return agentevents.NewRawData(eventType, map[string]any{
 			"content":      content,
 			"message":      message,
 			"arguments":    arguments,
@@ -156,16 +168,16 @@ func derefBool(value *bool) bool {
 	return value != nil && *value
 }
 
-// FilterToolCalls goes through the list of session events and correlates tool starts
-// with Success.
-func FilterToolCalls(sessionEvents []copilot.SessionEvent) []ToolCall {
+// FilterToolCalls goes through the list of session events and correlates tool
+// starts with their completion Success/Result.
+func FilterToolCalls(sessionEvents []agentevents.Event) []ToolCall {
 	toolCallsMap := map[string]*ToolCall{}
 	var toolCallIDs []string // preserve the start order of the events.
 
 	for _, evt := range sessionEvents {
 		switch evt.Type() {
-		case copilot.SessionEventTypeToolExecutionStart:
-			start, ok := copilotevents.ToolStart(evt)
+		case agentevents.EventTypeToolExecutionStart:
+			start, ok := agentevents.ToolStart(evt)
 			if !ok || start.ToolName == "" || start.ToolCallID == "" {
 				continue
 			}
@@ -181,8 +193,8 @@ func FilterToolCalls(sessionEvents []copilot.SessionEvent) []ToolCall {
 
 			toolCallsMap[start.ToolCallID] = tc
 			toolCallIDs = append(toolCallIDs, start.ToolCallID)
-		case copilot.SessionEventTypeToolExecutionComplete:
-			complete, ok := copilotevents.ToolComplete(evt)
+		case agentevents.EventTypeToolExecutionComplete:
+			complete, ok := agentevents.ToolComplete(evt)
 			if !ok || complete.ToolCallID == "" {
 				continue
 			}

--- a/internal/models/events_test.go
+++ b/internal/models/events_test.go
@@ -5,19 +5,17 @@ import (
 	"testing"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTranscriptEventRoundTrip(t *testing.T) {
-	content := "hello world"
-	message := "some message"
 	toolCallID := "call-123"
-	toolName := "bash"
 	success := true
 
 	original := TranscriptEvent{
-		SessionEvent: copilot.SessionEvent{
-			Data: &copilot.ToolExecutionCompleteData{
+		Event: agentevents.Event{
+			Data: &agentevents.ToolExecutionCompleteData{
 				ToolCallID: toolCallID,
 				Result: &copilot.ToolExecutionCompleteResult{
 					Content: "file1.go",
@@ -26,9 +24,6 @@ func TestTranscriptEventRoundTrip(t *testing.T) {
 			},
 		},
 	}
-	_ = content
-	_ = message
-	_ = toolName
 
 	data, err := json.Marshal(original)
 	if err != nil {
@@ -43,7 +38,7 @@ func TestTranscriptEventRoundTrip(t *testing.T) {
 	if restored.Type() != original.Type() {
 		t.Errorf("Type: got %v, want %v", restored.Type(), original.Type())
 	}
-	restoredData, ok := restored.Data.(*copilot.ToolExecutionCompleteData)
+	restoredData, ok := restored.Data.(*agentevents.ToolExecutionCompleteData)
 	require.True(t, ok)
 	require.Equal(t, toolCallID, restoredData.ToolCallID)
 	require.Equal(t, success, restoredData.Success)
@@ -61,30 +56,30 @@ func TestTranscriptEventUnmarshalMinimal(t *testing.T) {
 	if err := json.Unmarshal([]byte(input), &te); err != nil {
 		t.Fatalf("UnmarshalJSON failed: %v", err)
 	}
-	if te.Type() != copilot.SessionEventTypeToolExecutionStart {
-		t.Errorf("Type: got %v, want %v", te.Type(), copilot.SessionEventTypeToolExecutionStart)
+	if te.Type() != agentevents.EventTypeToolExecutionStart {
+		t.Errorf("Type: got %v, want %v", te.Type(), agentevents.EventTypeToolExecutionStart)
 	}
-	_, ok := te.Data.(*copilot.ToolExecutionStartData)
+	_, ok := te.Data.(*agentevents.ToolExecutionStartData)
 	require.True(t, ok)
 }
 
 // TestTranscriptEventRoundTripPreservesUncoveredType guards against losing the
 // event type for kinds without a dedicated transcriptData mapping (for example
 // session.idle, session.shutdown, assistant.usage). These fall to the
-// RawSessionEventData default case, which only reports the right Type() if its
+// RawData default case, which only reports the right Type() if its
 // EventType field is set. mapTranscriptEvents in the web API relies on Type().
 func TestTranscriptEventRoundTripPreservesUncoveredType(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
-		eventType copilot.SessionEventType
-		data      copilot.SessionEventData
+		eventType agentevents.EventType
+		data      agentevents.EventData
 	}{
-		{"idle", copilot.SessionEventTypeSessionIdle, &copilot.SessionIdleData{}},
-		{"shutdown", copilot.SessionEventTypeSessionShutdown, &copilot.SessionShutdownData{}},
-		{"assistant_usage", copilot.SessionEventTypeAssistantUsage, &copilot.AssistantUsageData{}},
+		{"idle", agentevents.EventTypeSessionIdle, &agentevents.SessionIdleData{}},
+		{"shutdown", agentevents.EventTypeSessionShutdown, &agentevents.SessionShutdownData{}},
+		{"assistant_usage", agentevents.EventTypeAssistantUsage, &agentevents.AssistantUsageData{}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			original := TranscriptEvent{SessionEvent: copilot.SessionEvent{Data: tc.data}}
+			original := TranscriptEvent{Event: agentevents.Event{Data: tc.data}}
 			require.Equal(t, tc.eventType, original.Type())
 
 			data, err := json.Marshal(original)

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1868,7 +1868,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 	// Convert events to transcript entries
 	var transcript []models.TranscriptEvent
 	for _, evt := range resp.Events {
-		entry := models.TranscriptEvent{SessionEvent: evt}
+		entry := models.TranscriptEvent{Event: evt}
 		transcript = append(transcript, entry)
 	}
 

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/cache"
 	"github.com/microsoft/waza/internal/config"
 	"github.com/microsoft/waza/internal/execution"
@@ -386,8 +386,8 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 		},
 		ToolCalls: []models.ToolCall{{Name: "bash"}, {Name: "view"}},
 		Usage:     &models.UsageStats{Turns: 1},
-		Events: []copilot.SessionEvent{
-			{Data: &copilot.UserMessageData{Content: content}},
+		Events: []agentevents.Event{
+			{Data: &agentevents.UserMessageData{Content: content}},
 		},
 	}
 
@@ -408,7 +408,7 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 
 	transcript := runner.buildTranscript(resp)
 	require.Len(t, transcript, 1)
-	assert.Equal(t, copilot.SessionEventTypeUserMessage, transcript[0].Type())
+	assert.Equal(t, agentevents.EventTypeUserMessage, transcript[0].Type())
 }
 
 func TestComputeTestStats_FlakinessPercent(t *testing.T) {

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -52,12 +52,12 @@ func Write(dir string, t *models.TaskTranscript) (string, error) {
 	return path, nil
 }
 
-// BuildFromSessionEvents converts a slice of Copilot session events
+// BuildFromSessionEvents converts a slice of neutral agent events
 // into TranscriptEvents.
-func BuildFromSessionEvents(events []copilot.SessionEvent) []models.TranscriptEvent {
+func BuildFromSessionEvents(events []agentevents.Event) []models.TranscriptEvent {
 	entries := make([]models.TranscriptEvent, 0, len(events))
 	for _, evt := range events {
-		entries = append(entries, models.TranscriptEvent{SessionEvent: evt})
+		entries = append(entries, models.TranscriptEvent{Event: evt})
 	}
 	return entries
 }

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/require"
 )
@@ -60,13 +60,13 @@ func TestWrite(t *testing.T) {
 		FinalOutput: "This function does X",
 		Transcript: []models.TranscriptEvent{
 			{
-				SessionEvent: copilot.SessionEvent{
-					Data: &copilot.UserMessageData{Content: "Explain this function"},
+				Event: agentevents.Event{
+					Data: &agentevents.UserMessageData{Content: "Explain this function"},
 				},
 			},
 			{
-				SessionEvent: copilot.SessionEvent{
-					Data: &copilot.AssistantMessageData{Content: "This function does X"},
+				Event: agentevents.Event{
+					Data: &agentevents.AssistantMessageData{Content: "This function does X"},
 				},
 			},
 		},
@@ -175,8 +175,8 @@ func TestBuildTaskTranscript(t *testing.T) {
 				Status:     models.StatusPassed,
 				DurationMs: 500,
 				Transcript: []models.TranscriptEvent{
-					{SessionEvent: copilot.SessionEvent{Data: &copilot.UserMessageData{Content: "Explain this code"}}},
-					{SessionEvent: copilot.SessionEvent{Data: &copilot.AssistantMessageData{Content: "Sure, this code..."}}},
+					{Event: agentevents.Event{Data: &agentevents.UserMessageData{Content: "Explain this code"}}},
+					{Event: agentevents.Event{Data: &agentevents.AssistantMessageData{Content: "Sure, this code..."}}},
 				},
 				Validations: map[string]models.GraderResults{
 					"check": {Name: "check", Score: 1.0, Passed: true},

--- a/internal/webapi/additional_test.go
+++ b/internal/webapi/additional_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/statistics"
 )
@@ -237,8 +238,8 @@ func TestOutcomeToDetailMapsStatsTranscriptAndDigest(t *testing.T) {
 						},
 						Transcript: []models.TranscriptEvent{
 							{
-								SessionEvent: copilot.SessionEvent{
-									Data: &copilot.ToolExecutionCompleteData{
+								Event: agentevents.Event{
+									Data: &agentevents.ToolExecutionCompleteData{
 										ToolCallID: toolCallID,
 										Result: &copilot.ToolExecutionCompleteResult{
 											Content: "hi",

--- a/internal/webapi/store.go
+++ b/internal/webapi/store.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/microsoft/waza/internal/copilotevents"
+	"github.com/microsoft/waza/internal/agentevents"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/pricing"
 )
@@ -338,23 +338,23 @@ func mapTranscriptEvents(events []models.TranscriptEvent) []TranscriptEventRespo
 		r := TranscriptEventResponse{
 			Type: string(e.Type()),
 		}
-		if content, ok := copilotevents.Content(e.SessionEvent); ok {
+		if content, ok := agentevents.Content(e.Event); ok {
 			r.Content = content
 		}
-		if message, ok := copilotevents.Message(e.SessionEvent); ok {
+		if message, ok := agentevents.Message(e.Event); ok {
 			r.Message = message
 		}
-		if start, ok := copilotevents.ToolStart(e.SessionEvent); ok {
+		if start, ok := agentevents.ToolStart(e.Event); ok {
 			r.ToolCallID = start.ToolCallID
 			r.ToolName = start.ToolName
 			r.Arguments = start.Arguments
 		}
-		if complete, ok := copilotevents.ToolComplete(e.SessionEvent); ok {
+		if complete, ok := agentevents.ToolComplete(e.Event); ok {
 			r.ToolCallID = complete.ToolCallID
 			r.Success = &complete.Success
 			r.ToolResult = complete.Result
 		}
-		if partial, ok := copilotevents.ToolPartial(e.SessionEvent); ok {
+		if partial, ok := agentevents.ToolPartial(e.Event); ok {
 			r.ToolCallID = partial.ToolCallID
 			r.Message = partial.PartialOutput
 		}


### PR DESCRIPTION
## Summary

Phase 1 of #10. Decouples waza's execution surface from `copilot.SessionEvent` so future engines can populate `ExecutionResponse.Events` without depending on the Copilot SDK's event types. Phase 2 (multi-engine implementations, fully neutral `ToolExecutionCompleteResult`) is intentionally out of scope.

## Changes

- **New package `internal/agentevents`** — neutral `Event` struct, `EventType` constants, and 21 typed payload structs (`AssistantMessageData`, `ToolExecutionStartData`, `ToolExecutionCompleteData`, etc.) that mirror the SDK shape.
- **New adapter `internal/execution/agentevents_adapter.go`** — `FromCopilotEvent(copilot.SessionEvent) agentevents.Event` is applied inside `SessionEventsCollector.On` so the SDK callback contract is preserved at the engine boundary while everything downstream is neutral.
- **`ExecutionResponse.Events []agentevents.Event`** and `SessionEventsCollector.SessionEvents()` now return neutral events.
- **`models.TranscriptEvent`** embeds `agentevents.Event` (the embedded field was renamed `SessionEvent` → `Event`). JSON wire format is preserved: each `EventType` constant has the same string value as its `copilot.SessionEventType` counterpart (e.g. `"assistant.message"`, `"tool.execution_complete"`).
- **Consumers migrated to neutral types**: `internal/transcript`, `internal/orchestration` runner, `internal/graders/inline_script_grader`, `internal/webapi/store`, and `cmd/waza/cmd_run_suggest`.
- **Tests updated** to construct neutral events and assert against neutral `EventType` constants. SDK-boundary tests still feed `copilot.SessionEvent` into `On(...)` as that's the SDK callback contract.

## Phase 1 residual coupling (documented; Phase 2)

- `agentevents.ToolExecutionCompleteData.Result` and `models.ToolCall.Result` remain `*copilot.ToolExecutionCompleteResult` so the dashboard payload (`Content`, `DetailedContent`, `Contents`, `BinaryResultsForLlm`) is wire-compatible bit-for-bit.
- `internal/copilotevents` and `internal/utils/logging.go` keep their SDK imports — they sit on the SDK side of the boundary.

## Verification

- `go build ./...` — clean
- `go test ./...` — passes (the only failure is `internal/models/TestLoadEvalSpec_MCPMocksRequireSchemaVersion11`, which is pre-existing on `main` ec8cb620 and unrelated to this change).
- `golangci-lint run` — 0 issues.

Closes #10 (Phase 1 only)