### PR TITLE
feat: snapshot/replay for deterministic eval reproduction (closes #367)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,6 @@ waza replay ./snapshots/a.json --bisect ./snapshots/b.json --json
 | `--bisect <file>` | Path to second snapshot to bisect against the primary |
 | `--json` | Emit machine-readable JSON instead of human summary |
 | `--strict` | Re-check final status and grader outcome consistency (default true) |
-| `--redact <path>` | Custom YAML redaction policy |
 
 Exit codes: `0` match, `1` divergence, `2` load/parse error.
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ waza grade eval.yaml --results results.json
 # Compare results across models
 waza compare results-gpt4.json results-sonnet.json
 
+# Capture snapshots during a run and replay them later for determinism checks
+waza run eval.yaml --snapshot ./snapshots/
+waza replay ./snapshots/my-task-run1.json
+
 # Check whether a schema artifact needs migration
 waza migrate eval.yaml
 
@@ -343,6 +347,9 @@ Run an evaluation benchmark from a spec file.
 | `--otel-headers` | | Comma-separated `key=value` OTLP headers (e.g. for auth) |
 | `--otel-file` | | File path for span JSON when `--otel-exporter=file` |
 | `--otel-include-payloads` | | Include prompt/tool-arg/tool-result/completion content in spans (default: redacted to `sha256`+length) |
+| `--snapshot <dir>` | | Capture self-contained `snapshot.json` per task for later [`waza replay`](#waza-replay-snapshotjson). |
+| `--snapshot-env-allow <patterns>` | | Allow-list of env var name patterns embedded in snapshots (default-deny; supports `WAZA_*` wildcards). |
+| `--redact <path>` | | YAML redaction policy applied to snapshot output (merged with built-in defaults). |
 
 **Result Caching**
 
@@ -411,6 +418,31 @@ Compare results from multiple evaluation runs side by side — per-task score de
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--format <fmt>` | `-f` | Output format: `table` or `json` (default: `table`) |
+
+### `waza replay <snapshot.json>`
+
+Replay a task snapshot to verify deterministic reproduction. Snapshots are produced by `waza run --snapshot <dir>` and capture the prompt, fixture digests, ordered tool events, environment allow-list, and redacted grader outcomes.
+
+```bash
+# Capture during a run
+waza run eval.yaml --snapshot ./snapshots/
+
+# Re-check internal consistency (offline, fast)
+waza replay ./snapshots/my-task-run1.json
+
+# Bisect two snapshots and find first divergent turn
+waza replay ./snapshots/a.json --bisect ./snapshots/b.json --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--mode <mode>` | Replay mode: `model-replay` (default, offline consistency check) or `live` (planned) |
+| `--bisect <file>` | Path to second snapshot to bisect against the primary |
+| `--json` | Emit machine-readable JSON instead of human summary |
+| `--strict` | Re-check final status and grader outcome consistency (default true) |
+| `--redact <path>` | Custom YAML redaction policy |
+
+Exit codes: `0` match, `1` divergence, `2` load/parse error.
 
 ### `waza migrate <file>`
 

--- a/cmd/waza/cmd_migrate_test.go
+++ b/cmd/waza/cmd_migrate_test.go
@@ -18,7 +18,7 @@ func TestMigrateCommandNoOpForCurrentMajor(t *testing.T) {
 	err := runMigrate(&out, path)
 
 	require.NoError(t, err)
-	require.Contains(t, out.String(), "compatible with waza schemaVersion 1.1")
+	require.Contains(t, out.String(), "compatible with waza schemaVersion 1.2")
 }
 
 func TestMigrateCommandRejectsIncompatibleMajor(t *testing.T) {
@@ -43,7 +43,7 @@ func TestMigrateCommandDefaultsMissingSchemaVersion(t *testing.T) {
 	err := runMigrate(&out, path)
 
 	require.NoError(t, err)
-	require.Contains(t, out.String(), "already compatible with schemaVersion 1.1")
+	require.Contains(t, out.String(), "already compatible with schemaVersion 1.2")
 }
 
 func TestMigrateCommandRejectsUnknownJSONShape(t *testing.T) {

--- a/cmd/waza/cmd_replay.go
+++ b/cmd/waza/cmd_replay.go
@@ -17,7 +17,6 @@ func newReplayCommand() *cobra.Command {
 		bisectArg string
 		jsonOut   bool
 		strict    bool
-		redact    string
 	)
 	cmd := &cobra.Command{
 		Use:   "replay <snapshot.json>",
@@ -49,13 +48,6 @@ Exit codes:
 			if err != nil {
 				return exitErr(2, err)
 			}
-			if redact != "" {
-				// Reserved for future modes that re-redact captured output.
-				_, err := snapshot.LoadPolicy(redact)
-				if err != nil {
-					return exitErr(2, fmt.Errorf("load redaction policy: %w", err))
-				}
-			}
 
 			if bisectArg != "" {
 				other, err := snapshot.LoadSnapshotFile(bisectArg)
@@ -82,7 +74,6 @@ Exit codes:
 	cmd.Flags().StringVar(&bisectArg, "bisect", "", "Path to a second snapshot to bisect against the primary")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit machine-readable JSON to stdout instead of a human summary")
 	cmd.Flags().BoolVar(&strict, "strict", true, "In model-replay mode, also re-check final status and grader outcomes")
-	cmd.Flags().StringVar(&redact, "redact", "", "Optional path to a custom redaction policy YAML")
 	return cmd
 }
 

--- a/cmd/waza/cmd_replay.go
+++ b/cmd/waza/cmd_replay.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/waza/internal/snapshot"
+	"github.com/spf13/cobra"
+)
+
+func newReplayCommand() *cobra.Command {
+	var (
+		mode      string
+		bisectArg string
+		jsonOut   bool
+		strict    bool
+		redact    string
+	)
+	cmd := &cobra.Command{
+		Use:   "replay <snapshot.json>",
+		Short: "Replay a snapshot to verify deterministic reproduction",
+		Long: `Replay a self-contained task snapshot to verify that the eval is
+reproducible from the captured tool_events tape.
+
+Modes:
+  model-replay  (default) Re-check grader outcomes against the snapshot's
+                tool_events without contacting the engine; exits 0 when the
+                snapshot is internally consistent.
+  live          (planned) Re-run the task against the real engine and
+                compare the resulting tool_events to the snapshot's. The
+                comparison ignores durations and raw output text, focusing
+                on the ordered tool name/args fingerprint.
+
+Bisect:
+  --bisect <other.json> compares two snapshots and reports the first
+  divergent turn (or event sequence when turn boundaries are not tracked).
+
+Exit codes:
+  0  snapshots match / replay succeeded
+  1  divergence detected (kind/value rendered to stderr or --json output)
+  2  load / parse / IO error`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			snapPath := args[0]
+			snap, err := snapshot.LoadSnapshotFile(snapPath)
+			if err != nil {
+				return exitErr(2, err)
+			}
+			if redact != "" {
+				// Reserved for future modes that re-redact captured output.
+				_, err := snapshot.LoadPolicy(redact)
+				if err != nil {
+					return exitErr(2, fmt.Errorf("load redaction policy: %w", err))
+				}
+			}
+
+			if bisectArg != "" {
+				other, err := snapshot.LoadSnapshotFile(bisectArg)
+				if err != nil {
+					return exitErr(2, err)
+				}
+				turn, result := snapshot.Bisect(snap, other)
+				result.BaselinePath = snapPath
+				result.ReplayedPath = bisectArg
+				return renderReplayResult(cmd, result, jsonOut, turn)
+			}
+
+			switch snapshot.Mode(strings.ToLower(mode)) {
+			case "", snapshot.ModeModelReplay:
+				return runModelReplay(cmd, snap, snapPath, jsonOut, strict)
+			case snapshot.ModeLive:
+				return exitErr(2, fmt.Errorf("live mode is not implemented yet; use --mode model-replay or open a tracking issue"))
+			default:
+				return exitErr(2, fmt.Errorf("unknown --mode %q (expected model-replay or live)", mode))
+			}
+		},
+	}
+	cmd.Flags().StringVar(&mode, "mode", string(snapshot.ModeModelReplay), "Replay mode: model-replay (default) or live")
+	cmd.Flags().StringVar(&bisectArg, "bisect", "", "Path to a second snapshot to bisect against the primary")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit machine-readable JSON to stdout instead of a human summary")
+	cmd.Flags().BoolVar(&strict, "strict", true, "In model-replay mode, also re-check final status and grader outcomes")
+	cmd.Flags().StringVar(&redact, "redact", "", "Optional path to a custom redaction policy YAML")
+	return cmd
+}
+
+// runModelReplay re-checks the snapshot's grader results without re-running
+// the engine. It compares the snapshot's stored validations against the
+// tool_events tape to surface internal inconsistencies (e.g. a snapshot
+// claims a tool_calls grader passed but no matching tool_event exists).
+func runModelReplay(cmd *cobra.Command, snap *snapshot.Snapshot, source string, jsonOut, strict bool) error {
+	report := buildModelReplayReport(snap, strict)
+	report.SourcePath = source
+	if jsonOut {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return exitErr(2, err)
+		}
+	} else {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), renderModelReplayHuman(report))
+	}
+	if !report.Pass {
+		return exitErr(1, fmt.Errorf("replay diverged: %d issue(s)", len(report.Issues)))
+	}
+	return nil
+}
+
+// renderReplayResult prints a CompareResult (used by bisect / live).
+func renderReplayResult(cmd *cobra.Command, result snapshot.CompareResult, jsonOut bool, firstDivergentTurn int) error {
+	if jsonOut {
+		payload := struct {
+			snapshot.CompareResult
+			FirstDivergentTurn int `json:"first_divergent_turn,omitempty"`
+		}{
+			CompareResult:      result,
+			FirstDivergentTurn: firstDivergentTurn,
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(payload); err != nil {
+			return exitErr(2, err)
+		}
+	} else {
+		var sb strings.Builder
+		if result.Match {
+			fmt.Fprintln(&sb, "OK snapshots match")
+		} else {
+			fmt.Fprintln(&sb, "DIVERGENCE detected")
+			if firstDivergentTurn > 0 {
+				fmt.Fprintf(&sb, "first divergent turn: %d\n", firstDivergentTurn)
+			}
+			fmt.Fprintln(&sb, snapshot.SummariseDivergences(result))
+		}
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), sb.String())
+	}
+	if !result.Match {
+		return exitErr(1, fmt.Errorf("snapshots diverge"))
+	}
+	return nil
+}
+
+// ModelReplayReport is the JSON/console payload for a model-replay run.
+type ModelReplayReport struct {
+	SourcePath string             `json:"source"`
+	Mode       snapshot.Mode      `json:"mode"`
+	Pass       bool               `json:"pass"`
+	Status     string             `json:"status"`
+	Issues     []ModelReplayIssue `json:"issues,omitempty"`
+	ToolEvents int                `json:"tool_events"`
+	Graders    int                `json:"graders"`
+}
+
+// ModelReplayIssue describes a single inconsistency found by model-replay.
+type ModelReplayIssue struct {
+	Kind    string `json:"kind"`
+	Grader  string `json:"grader,omitempty"`
+	Message string `json:"message"`
+}
+
+func buildModelReplayReport(snap *snapshot.Snapshot, strict bool) ModelReplayReport {
+	r := ModelReplayReport{
+		Mode:       snapshot.ModeModelReplay,
+		Status:     string(snap.Result.Status),
+		ToolEvents: len(snap.ToolEvents),
+		Graders:    len(snap.Result.Validations),
+		Pass:       true,
+	}
+
+	// Internal consistency: sequence numbers should be 1..N, strictly
+	// monotonic. Anything else indicates the tape was edited or corrupted.
+	if len(snap.ToolEvents) > 0 {
+		// Sort a copy by Sequence to detect duplicates / gaps without
+		// mutating the snapshot in memory.
+		seqs := make([]int, len(snap.ToolEvents))
+		for i, ev := range snap.ToolEvents {
+			seqs[i] = ev.Sequence
+		}
+		sort.Ints(seqs)
+		for i, s := range seqs {
+			if s != i+1 {
+				r.Pass = false
+				r.Issues = append(r.Issues, ModelReplayIssue{
+					Kind:    "sequence_gap",
+					Message: fmt.Sprintf("tool_events.sequence is not 1..N (saw %d at position %d)", s, i+1),
+				})
+				break
+			}
+		}
+	}
+
+	// Strict mode: every grader entry must agree with itself — passed=true
+	// with score 0 (and non-zero weight) is a clear inconsistency.
+	if strict {
+		for name, g := range snap.Result.Validations {
+			if g.Passed && g.Weight > 0 && g.Score == 0 {
+				r.Pass = false
+				r.Issues = append(r.Issues, ModelReplayIssue{
+					Kind:    "validation_inconsistency",
+					Grader:  name,
+					Message: "grader claims passed=true but score is 0",
+				})
+			}
+		}
+	}
+
+	return r
+}
+
+func renderModelReplayHuman(r ModelReplayReport) string {
+	var sb strings.Builder
+	if r.Pass {
+		fmt.Fprintf(&sb, "OK model-replay: %s (%d tool_events, %d graders)\n", r.Status, r.ToolEvents, r.Graders)
+	} else {
+		fmt.Fprintf(&sb, "FAIL model-replay: %d issue(s)\n", len(r.Issues))
+		for _, iss := range r.Issues {
+			grader := iss.Grader
+			if grader != "" {
+				grader = " [" + grader + "]"
+			}
+			fmt.Fprintf(&sb, "  - %s%s: %s\n", iss.Kind, grader, iss.Message)
+		}
+	}
+	if r.SourcePath != "" {
+		fmt.Fprintf(&sb, "  source: %s\n", filepath.Clean(r.SourcePath))
+	}
+	return sb.String()
+}
+
+// exitErr wraps an error so the cobra wrapper exits with the requested
+// code. main.go's run loop honors ExitCodeError and prints its message.
+func exitErr(code int, err error) error {
+	if err == nil {
+		err = fmt.Errorf("exit %d", code)
+	}
+	return &ExitCodeError{Code: code, Err: err}
+}

--- a/cmd/waza/cmd_replay_test.go
+++ b/cmd/waza/cmd_replay_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/microsoft/waza/internal/snapshot"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSnapshot(t *testing.T, dir, name string, snap snapshot.Snapshot) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	b, err := json.MarshalIndent(snap, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, b, 0o644))
+	return path
+}
+
+// makeSnap returns a minimal-but-valid 1.0 snapshot for testing.
+func makeSnap(status models.Status, withInconsistentGrader bool, events ...models.ToolEvent) snapshot.Snapshot {
+	s := snapshot.Snapshot{
+		SchemaVersion: snapshot.CurrentSchemaVersion,
+		Kind:          snapshot.Kind,
+		WazaVersion:   "test",
+		CreatedAt:     time.Now().UTC(),
+		Task:          snapshot.SnapshotTask{TestID: "demo"},
+		ToolEvents:    events,
+		Result: snapshot.SnapshotResult{
+			Status:      status,
+			Validations: map[string]models.GraderResults{},
+		},
+		Env: snapshot.SnapshotEnv{AllowList: []string{}, Captured: map[string]string{}},
+	}
+	if withInconsistentGrader {
+		s.Result.Validations["bad"] = models.GraderResults{
+			Passed: true, Score: 0, Weight: 1,
+		}
+	} else {
+		s.Result.Validations["good"] = models.GraderResults{
+			Passed: true, Score: 1, Weight: 1,
+		}
+	}
+	return s
+}
+
+func TestReplayModelReplayPasses(t *testing.T) {
+	dir := t.TempDir()
+	snap := makeSnap(models.StatusPassed, false,
+		models.ToolEvent{Sequence: 1, Turn: 1, ToolName: "read_file"},
+		models.ToolEvent{Sequence: 2, Turn: 1, ToolName: "write_file"},
+	)
+	path := writeSnapshot(t, dir, "snap.json", snap)
+
+	cmd := newReplayCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{path})
+
+	require.NoError(t, cmd.Execute())
+	require.Contains(t, out.String(), "OK model-replay")
+}
+
+func TestReplayModelReplayDetectsInconsistency(t *testing.T) {
+	dir := t.TempDir()
+	snap := makeSnap(models.StatusPassed, true,
+		models.ToolEvent{Sequence: 1, Turn: 1, ToolName: "x"},
+	)
+	path := writeSnapshot(t, dir, "snap.json", snap)
+
+	cmd := newReplayCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	var exit *ExitCodeError
+	require.True(t, errors.As(err, &exit))
+	require.Equal(t, 1, exit.Code)
+}
+
+func TestReplayJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	snap := makeSnap(models.StatusPassed, false,
+		models.ToolEvent{Sequence: 1, Turn: 1, ToolName: "x"},
+	)
+	path := writeSnapshot(t, dir, "snap.json", snap)
+
+	cmd := newReplayCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--json", path})
+	require.NoError(t, cmd.Execute())
+
+	var report ModelReplayReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.True(t, report.Pass)
+	require.Equal(t, 1, report.ToolEvents)
+	require.Equal(t, snapshot.ModeModelReplay, report.Mode)
+}
+
+func TestReplayBisectDetectsDivergence(t *testing.T) {
+	dir := t.TempDir()
+	a := makeSnap(models.StatusPassed, false,
+		models.ToolEvent{Sequence: 1, Turn: 1, ToolName: "x"},
+		models.ToolEvent{Sequence: 2, Turn: 1, ToolName: "y"},
+	)
+	b := makeSnap(models.StatusPassed, false,
+		models.ToolEvent{Sequence: 1, Turn: 1, ToolName: "x"},
+		models.ToolEvent{Sequence: 2, Turn: 1, ToolName: "z"},
+	)
+	pa := writeSnapshot(t, dir, "a.json", a)
+	pb := writeSnapshot(t, dir, "b.json", b)
+
+	cmd := newReplayCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--bisect", pb, pa})
+	err := cmd.Execute()
+	require.Error(t, err)
+	var exit *ExitCodeError
+	require.True(t, errors.As(err, &exit))
+	require.Equal(t, 1, exit.Code)
+	require.Contains(t, out.String(), "DIVERGENCE")
+}
+
+func TestReplayBisectMatch(t *testing.T) {
+	dir := t.TempDir()
+	a := makeSnap(models.StatusPassed, false,
+		models.ToolEvent{Sequence: 1, Turn: 1, ToolName: "x"},
+	)
+	pa := writeSnapshot(t, dir, "a.json", a)
+	pb := writeSnapshot(t, dir, "b.json", a)
+
+	cmd := newReplayCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--bisect", pb, pa})
+	require.NoError(t, cmd.Execute())
+	require.Contains(t, out.String(), "OK snapshots match")
+}
+
+func TestReplayRejectsIncompatibleMajor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snap.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":"2.0","kind":"waza.snapshot.task"}`), 0o644))
+
+	cmd := newReplayCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{path})
+	err := cmd.Execute()
+	require.Error(t, err)
+	var exit *ExitCodeError
+	require.True(t, errors.As(err, &exit))
+	require.Equal(t, 2, exit.Code)
+}
+
+func TestReplayLiveModeNotImplemented(t *testing.T) {
+	dir := t.TempDir()
+	snap := makeSnap(models.StatusPassed, false)
+	path := writeSnapshot(t, dir, "snap.json", snap)
+
+	cmd := newReplayCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--mode", "live", path})
+	err := cmd.Execute()
+	require.Error(t, err)
+	var exit *ExitCodeError
+	require.True(t, errors.As(err, &exit))
+	require.Equal(t, 2, exit.Code)
+}

--- a/cmd/waza/cmd_replay_test.go
+++ b/cmd/waza/cmd_replay_test.go
@@ -155,7 +155,7 @@ func TestReplayBisectMatch(t *testing.T) {
 func TestReplayRejectsIncompatibleMajor(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "snap.json")
-	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":"2.0","kind":"waza.snapshot.task"}`), 0o644))
+	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":"2.0","kind":"task-snapshot"}`), 0o644))
 
 	cmd := newReplayCommand()
 	var out bytes.Buffer

--- a/cmd/waza/cmd_run.go
+++ b/cmd/waza/cmd_run.go
@@ -36,6 +36,7 @@ import (
 	"github.com/microsoft/waza/internal/recommend"
 	"github.com/microsoft/waza/internal/reporting"
 	"github.com/microsoft/waza/internal/session"
+	"github.com/microsoft/waza/internal/snapshot"
 	"github.com/microsoft/waza/internal/storage"
 	"github.com/microsoft/waza/internal/telemetry"
 	"github.com/microsoft/waza/internal/trigger"
@@ -82,6 +83,10 @@ var (
 	otelHeaders         string
 	otelFile            string
 	otelIncludePayloads bool
+
+	snapshotDir        string
+	snapshotEnvAllow   []string
+	snapshotRedactPath string
 
 	// runTelemetry holds the configured OpenTelemetry provider for the
 	// current `waza run` invocation. It is initialized in runCommandE and
@@ -176,6 +181,10 @@ You can also specify a skill name to run its eval:
 	cmd.Flags().StringVar(&otelHeaders, "otel-headers", "", "Comma-separated key=value OTLP headers (e.g. for auth)")
 	cmd.Flags().StringVar(&otelFile, "otel-file", "", "File path for span JSON when --otel-exporter=file")
 	cmd.Flags().BoolVar(&otelIncludePayloads, "otel-include-payloads", false, "Include prompt/tool-arg/tool-result/completion content in spans (default: redacted, only sha256+length emitted)")
+
+	cmd.Flags().StringVar(&snapshotDir, "snapshot", "", "Write per-task snapshot.json files to this directory for deterministic replay (see `waza replay`)")
+	cmd.Flags().StringArrayVar(&snapshotEnvAllow, "snapshot-env-allow", nil, "Environment variables to capture in snapshots (supports trailing-* wildcards). Default-deny.")
+	cmd.Flags().StringVar(&snapshotRedactPath, "redact", "", "Optional path to a custom redaction policy YAML applied during snapshot capture")
 
 	return cmd
 }
@@ -773,6 +782,21 @@ func runSingleModel(cmd *cobra.Command, spec *models.EvalSpec, specPath string, 
 	}
 	if runTelemetry != nil && runTelemetry.Enabled() {
 		runnerOpts = append(runnerOpts, orchestration.WithTelemetry(runTelemetry))
+	}
+	if snapshotDir != "" {
+		writer := snapshot.NewWriter(snapshotDir)
+		runnerOpts = append(runnerOpts, orchestration.WithSnapshotWriter(writer))
+		runnerOpts = append(runnerOpts, orchestration.WithWazaVersion(version))
+		if len(snapshotEnvAllow) > 0 {
+			runnerOpts = append(runnerOpts, orchestration.WithSnapshotEnvAllow(snapshotEnvAllow))
+		}
+		if snapshotRedactPath != "" {
+			policy, perr := snapshot.LoadPolicy(snapshotRedactPath)
+			if perr != nil {
+				return nil, fmt.Errorf("load redaction policy: %w", perr)
+			}
+			runnerOpts = append(runnerOpts, orchestration.WithRedactionPolicy(policy))
+		}
 	}
 	runner := newBenchmarkRunner(cfg, engine, runnerOpts...)
 

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -72,6 +72,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newSpecCommand())
 	cmd.AddCommand(newMigrateCommand())
 	cmd.AddCommand(newMCPMockCommand())
+	cmd.AddCommand(newReplayCommand())
 
 	return cmd
 }

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -203,8 +203,13 @@ type RunResult struct {
 	// backward compatibility; new consumers should prefer ToolEvents.
 	ToolEvents []ToolEvent `json:"tool_events,omitempty"`
 
-	// SnapshotPath is the path (relative to results.json's directory) of
-	// the self-contained snapshot.json artifact for this run. Empty when
+	// SnapshotPath is the on-disk path of the self-contained snapshot.json
+	// artifact for this run, as returned by snapshot.Writer.Write. It is
+	// rooted at the --snapshot directory the user passed to `waza run` (so
+	// it may be absolute, or relative to the working directory at run time,
+	// depending on what the user supplied). Consumers that need a
+	// results.json-relative path should compute it themselves with
+	// filepath.Rel against the results.json directory. Empty when
 	// `waza run --snapshot` was not used. Added in schema version 1.2 as
 	// an additive field (see issue #367).
 	SnapshotPath string `json:"snapshot_path,omitempty"`

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -202,6 +202,12 @@ type RunResult struct {
 	// (see issue #366). The legacy SessionDigest.ToolCalls is preserved for
 	// backward compatibility; new consumers should prefer ToolEvents.
 	ToolEvents []ToolEvent `json:"tool_events,omitempty"`
+
+	// SnapshotPath is the path (relative to results.json's directory) of
+	// the self-contained snapshot.json artifact for this run. Empty when
+	// `waza run --snapshot` was not used. Added in schema version 1.2 as
+	// an additive field (see issue #367).
+	SnapshotPath string `json:"snapshot_path,omitempty"`
 }
 
 // CheckpointOutcome captures the results of a single TestCase.Checkpoint that

--- a/internal/models/schema_version.go
+++ b/internal/models/schema_version.go
@@ -20,7 +20,11 @@ const (
 	// 1.1 — additive: per-turn checkpoints (TestCase.Checkpoints / RunResult.Checkpoints, #358)
 	//       and RunResult.tool_events[] for per-task tool metrics (#366). Purely additive
 	//       over 1.0, so 1.0 artifacts continue to load without migration.
-	CurrentSchemaVersion = "1.1"
+	// 1.2 — additive: RunResult.snapshot_path pointer to a self-contained
+	//       snapshot.json artifact (#367). Optional and omitted when
+	//       snapshot capture is not enabled, so 1.0 and 1.1 artifacts
+	//       continue to load without migration.
+	CurrentSchemaVersion = "1.2"
 )
 
 func defaultSchemaVersion(version string) string {

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -89,6 +89,10 @@ type EvalRunner struct {
 	snapshotEnvAllow []string
 	redactionPolicy  *snapshot.Policy
 	wazaVersion      string
+	// evalRunID echoes EvaluationOutcome.RunID so per-run snapshots can be
+	// correlated back to their parent results.json. Set at the start of a
+	// benchmark run; empty for code paths that bypass the orchestrator.
+	evalRunID string
 }
 
 // ProgressListener receives progress updates
@@ -269,6 +273,12 @@ func (r *EvalRunner) RunBenchmark(ctx context.Context) (*models.EvaluationOutcom
 
 	spec := r.cfg.Spec()
 
+	// Compute the run ID once so the same value flows into both the
+	// telemetry root span and per-run snapshots (via r.evalRunID), and so
+	// runNormalBenchmark reuses it when building the EvaluationOutcome.
+	runID := fmt.Sprintf("run-%d", time.Now().Unix())
+	r.evalRunID = runID
+
 	// Open the root telemetry span for the whole eval. The span is a no-op
 	// when telemetry is disabled, so this call is always safe.
 	evalCtx, evalSpan := telemetry.StartEvalSpan(ctx, r.telemetry, telemetry.EvalInfo{
@@ -276,7 +286,7 @@ func (r *EvalRunner) RunBenchmark(ctx context.Context) (*models.EvaluationOutcom
 		Skill:  spec.SkillName,
 		Engine: spec.Config.EngineType,
 		Model:  spec.Config.ModelID,
-		RunID:  fmt.Sprintf("run-%d", time.Now().Unix()),
+		RunID:  runID,
 	})
 	defer evalSpan.End()
 
@@ -363,8 +373,16 @@ func (r *EvalRunner) runNormalBenchmark(ctx context.Context) (*models.Evaluation
 
 	// Compute statistics
 	digest := BuildDigest(testOutcomes, time.Since(startTime).Milliseconds(), spec.Config.TrialsPerTask)
+	// Reuse RunBenchmark's evalRunID when set so snapshots written during
+	// per-run execution correlate with this outcome's RunID; fall back to
+	// a fresh timestamp otherwise (e.g., when runNormalBenchmark is called
+	// from test code or alternative code paths that bypass RunBenchmark).
+	outcomeRunID := r.evalRunID
+	if outcomeRunID == "" {
+		outcomeRunID = fmt.Sprintf("run-%d", time.Now().Unix())
+	}
 	outcome := &models.EvaluationOutcome{
-		RunID:       fmt.Sprintf("run-%d", time.Now().Unix()),
+		RunID:       outcomeRunID,
 		SkillTested: spec.SkillName,
 		BenchName:   spec.Name,
 		Timestamp:   startTime,
@@ -1332,14 +1350,12 @@ func (r *EvalRunner) captureSnapshot(tc *models.TestCase, req *execution.Executi
 		return
 	}
 	spec := r.cfg.Spec()
-	evalID := ""
+	evalID := r.evalRunID
 	evalName := ""
 	skillName := ""
 	if spec != nil {
 		evalName = spec.Name
-		if len(spec.Config.SkillPaths) > 0 {
-			skillName = spec.Config.SkillPaths[0]
-		}
+		skillName = spec.SkillName
 	}
 	in := snapshot.CaptureInput{
 		EvalID:       evalID,
@@ -1352,6 +1368,7 @@ func (r *EvalRunner) captureSnapshot(tc *models.TestCase, req *execution.Executi
 		EnvAllowList: r.snapshotEnvAllow,
 		Policy:       r.redactionPolicy,
 		FixturesRoot: r.fixturesRoot(tc),
+		SkipDirs:     r.snapshotSkipDirs(tc),
 	}
 	snap, err := snapshot.Capture(in)
 	if err != nil {
@@ -1390,6 +1407,37 @@ func (r *EvalRunner) fixturesRoot(tc *models.TestCase) string {
 		return resolve(tc.ContextRoot)
 	}
 	return r.cfg.SpecDir()
+}
+
+// snapshotSkipDirs returns the absolute paths under fixturesRoot whose
+// contents should be excluded from fixture digesting. The snapshot output
+// directory must be skipped: otherwise re-running an eval to compare
+// snapshots would change the fixture hash whenever the user writes
+// snapshots inside the fixtures tree.
+func (r *EvalRunner) snapshotSkipDirs(tc *models.TestCase) []string {
+	if r == nil || r.snapshotWriter == nil {
+		return nil
+	}
+	root := r.snapshotWriter.Root()
+	if root == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		abs = root
+	}
+	fixRoot := r.fixturesRoot(tc)
+	if fixRoot != "" {
+		if absFix, err := filepath.Abs(fixRoot); err == nil {
+			fixRoot = absFix
+		}
+	}
+	// Only need to skip when the snapshot directory is inside the
+	// fixtures root; otherwise WalkDir never visits it.
+	if fixRoot != "" && !strings.HasPrefix(abs+string(os.PathSeparator), fixRoot+string(os.PathSeparator)) && abs != fixRoot {
+		return nil
+	}
+	return []string{abs}
 }
 
 func (r *EvalRunner) captureFailureArtifacts(run *models.RunResult) {

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/microsoft/waza/internal/hooks"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/responder"
+	"github.com/microsoft/waza/internal/snapshot"
 	"github.com/microsoft/waza/internal/telemetry"
 	"github.com/microsoft/waza/internal/template"
 	"github.com/microsoft/waza/internal/transcript"
@@ -78,6 +79,16 @@ type EvalRunner struct {
 	// spans. Nil means tracing is off; the helpers in internal/telemetry
 	// degrade to no-op tracers in that case.
 	telemetry *telemetry.Provider
+
+	// Snapshot capture (issue #367). When snapshotWriter is non-nil, every
+	// completed run is serialized to disk as a self-contained snapshot.json
+	// after grading completes; the resulting path is recorded on
+	// RunResult.SnapshotPath. Capture is best-effort: write failures log a
+	// warning but do not fail the run.
+	snapshotWriter   *snapshot.Writer
+	snapshotEnvAllow []string
+	redactionPolicy  *snapshot.Policy
+	wazaVersion      string
 }
 
 // ProgressListener receives progress updates
@@ -158,6 +169,42 @@ func WithSkipGraders() RunnerOption {
 func WithTelemetry(p *telemetry.Provider) RunnerOption {
 	return func(r *EvalRunner) {
 		r.telemetry = p
+	}
+}
+
+// WithSnapshotWriter enables snapshot capture for every completed run. The
+// resulting snapshot.json file path is recorded on RunResult.SnapshotPath
+// so consumers of results.json can correlate runs to their snapshots.
+//
+// Snapshot capture is best-effort: write failures are logged but never
+// fail the run.
+func WithSnapshotWriter(w *snapshot.Writer) RunnerOption {
+	return func(r *EvalRunner) {
+		r.snapshotWriter = w
+	}
+}
+
+// WithSnapshotEnvAllow sets the env-var allow-list captured in each
+// snapshot's env block. Default is empty (default-deny).
+func WithSnapshotEnvAllow(keys []string) RunnerOption {
+	return func(r *EvalRunner) {
+		r.snapshotEnvAllow = append([]string(nil), keys...)
+	}
+}
+
+// WithRedactionPolicy overrides the default snapshot redaction policy.
+// Pass nil to use snapshot.DefaultPolicy().
+func WithRedactionPolicy(p *snapshot.Policy) RunnerOption {
+	return func(r *EvalRunner) {
+		r.redactionPolicy = p
+	}
+}
+
+// WithWazaVersion records the waza binary version on each snapshot for
+// diagnostics. Defaults to empty (no version stamping).
+func WithWazaVersion(v string) RunnerOption {
+	return func(r *EvalRunner) {
+		r.wazaVersion = v
 	}
 }
 
@@ -1257,7 +1304,7 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		skillInvocations[i] = models.SkillInvocation{Name: si.Name, Path: si.Path}
 	}
 
-	return returnWithArtifacts(models.RunResult{
+	run := models.RunResult{
 		RunNumber:        runNum,
 		Status:           status,
 		DurationMs:       resp.DurationMs,
@@ -1271,7 +1318,78 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		Responder:        responderInfo,
 		Checkpoints:      checkpointOutcomes,
 		ToolEvents:       buildToolEvents(resp.Events),
-	})
+	}
+	r.captureSnapshot(tc, req, resp, &run)
+	return returnWithArtifacts(run)
+}
+
+// captureSnapshot writes a self-contained snapshot.json for the given run
+// when a writer has been configured. Failures are logged but do not fail
+// the run; missing fields default to their zero values so partial captures
+// (e.g. after an early-exit error) remain valid.
+func (r *EvalRunner) captureSnapshot(tc *models.TestCase, req *execution.ExecutionRequest, _ *execution.ExecutionResponse, run *models.RunResult) {
+	if r == nil || r.snapshotWriter == nil || run == nil {
+		return
+	}
+	spec := r.cfg.Spec()
+	evalID := ""
+	evalName := ""
+	skillName := ""
+	if spec != nil {
+		evalName = spec.Name
+		if len(spec.Config.SkillPaths) > 0 {
+			skillName = spec.Config.SkillPaths[0]
+		}
+	}
+	in := snapshot.CaptureInput{
+		EvalID:       evalID,
+		EvalName:     evalName,
+		Skill:        skillName,
+		WazaVersion:  r.wazaVersion,
+		Task:         tc,
+		Request:      req,
+		Run:          run,
+		EnvAllowList: r.snapshotEnvAllow,
+		Policy:       r.redactionPolicy,
+		FixturesRoot: r.fixturesRoot(tc),
+	}
+	snap, err := snapshot.Capture(in)
+	if err != nil {
+		slog.Warn("snapshot capture failed", "test", tc.TestID, "run", run.RunNumber, "err", err)
+		return
+	}
+	path, err := r.snapshotWriter.Write(snap)
+	if err != nil {
+		slog.Warn("snapshot write failed", "test", tc.TestID, "run", run.RunNumber, "err", err)
+		return
+	}
+	run.SnapshotPath = path
+}
+
+// fixturesRoot returns the absolute directory that fixture digests should be
+// hashed from. Falls back to the spec directory when the task does not pin
+// an explicit context directory.
+func (r *EvalRunner) fixturesRoot(tc *models.TestCase) string {
+	if r == nil || r.cfg == nil {
+		return ""
+	}
+	resolve := func(p string) string {
+		if filepath.IsAbs(p) {
+			return p
+		}
+		base := r.cfg.SpecDir()
+		if base == "" {
+			return p
+		}
+		return filepath.Join(base, p)
+	}
+	if tc != nil && tc.Stimulus.WorkDir != "" {
+		return resolve(tc.Stimulus.WorkDir)
+	}
+	if tc != nil && tc.ContextRoot != "" {
+		return resolve(tc.ContextRoot)
+	}
+	return r.cfg.SpecDir()
 }
 
 func (r *EvalRunner) captureFailureArtifacts(run *models.RunResult) {

--- a/internal/snapshot/capture.go
+++ b/internal/snapshot/capture.go
@@ -1,0 +1,237 @@
+package snapshot
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/microsoft/waza/internal/execution"
+	"github.com/microsoft/waza/internal/models"
+)
+
+// CaptureInput is everything Capture needs to build a Snapshot. It is
+// assembled by the runner inside executeRun once the RunResult is finalized.
+type CaptureInput struct {
+	WazaVersion string
+	EvalID      string
+	EvalName    string
+	Skill       string
+
+	Task    *models.TestCase
+	Request *execution.ExecutionRequest
+	Run     *models.RunResult
+
+	Engine       SnapshotEngine
+	FixturesRoot string
+	EnvAllowList []string
+	Policy       *Policy
+}
+
+// Capture builds a Snapshot from input. The returned snapshot's redaction
+// counters reflect everything scrubbed during this call; the caller may
+// inspect input.Policy.MatchCount() / MatchedRules() after.
+//
+// Capture does NOT write to disk; see Writer.Write for that.
+func Capture(in CaptureInput) (*Snapshot, error) {
+	if in.Task == nil {
+		return nil, fmt.Errorf("snapshot: capture requires Task")
+	}
+	if in.Run == nil {
+		return nil, fmt.Errorf("snapshot: capture requires Run")
+	}
+	policy := in.Policy
+	if policy == nil {
+		policy = DefaultPolicy()
+	}
+	policy.ResetCounters()
+
+	// Reset matched-rule statistics so this snapshot reports only its own
+	// matches, not the running totals across previous captures.
+
+	snap := &Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		Kind:          Kind,
+		WazaVersion:   in.WazaVersion,
+		CreatedAt:     time.Now().UTC(),
+		EvalID:        in.EvalID,
+		EvalName:      in.EvalName,
+		Skill:         in.Skill,
+		Task: SnapshotTask{
+			TestID:      in.Task.TestID,
+			DisplayName: in.Task.DisplayName,
+			Golden:      in.Task.Golden,
+			Tags:        append([]string(nil), in.Task.Tags...),
+			RunNumber:   in.Run.RunNumber,
+		},
+		Engine: in.Engine,
+	}
+
+	// Prompt: copy with redaction. Context values may contain user-supplied
+	// strings (e.g., interpolated tokens), so route through RedactAny.
+	if in.Request != nil {
+		snap.Prompt.Message = policy.RedactString(in.Request.Message)
+		if len(in.Request.Context) > 0 {
+			redactedCtx := policy.RedactAny(in.Request.Context)
+			if m, ok := redactedCtx.(map[string]any); ok {
+				snap.Prompt.Context = m
+			}
+		}
+		if len(in.Request.Instructions) > 0 {
+			snap.Prompt.Instructions = make([]InstructionEntry, len(in.Request.Instructions))
+			for i, instr := range in.Request.Instructions {
+				snap.Prompt.Instructions[i] = InstructionEntry{
+					Path:   filepath.ToSlash(instr.Path),
+					SHA256: shaBytes(instr.Content),
+				}
+			}
+		}
+	}
+	if len(in.Task.Stimulus.FollowUps) > 0 {
+		// Follow-ups are stored on the task's stimulus before execution;
+		// capture the static list as configured. Live multi-turn responder
+		// traffic is recoverable from ToolEvents.Turn fields below.
+		snap.Prompt.FollowUps = policy.RedactStringSlice(in.Task.Stimulus.FollowUps)
+	}
+
+	// Tool events: redact strings inside Args/Result/Error map structures.
+	if len(in.Run.ToolEvents) > 0 {
+		snap.ToolEvents = make([]models.ToolEvent, len(in.Run.ToolEvents))
+		for i, ev := range in.Run.ToolEvents {
+			snap.ToolEvents[i] = redactToolEvent(ev, policy)
+		}
+	}
+
+	// Fixtures
+	if in.FixturesRoot != "" {
+		digests, err := HashFixtures(in.FixturesRoot)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot: hash fixtures: %w", err)
+		}
+		snap.Fixtures = digests
+	}
+
+	// Env capture: default-deny allow-list with redaction. Always populate
+	// AllowList so consumers know whether capture was intentionally empty
+	// vs. configured-with-no-matches.
+	snap.Env = CaptureEnv(in.EnvAllowList, policy)
+
+	// Redaction summary — always present so users can confirm rules ran.
+	snap.Redaction = SnapshotRedaction{
+		Policy:         policy.Label(),
+		AppliedRules:   policy.MatchedRules(),
+		RedactionCount: policy.MatchCount(),
+	}
+
+	// Result subset
+	snap.Result = SnapshotResult{
+		Status:      in.Run.Status,
+		FinalOutput: policy.RedactString(in.Run.FinalOutput),
+		ErrorMsg:    policy.RedactString(in.Run.ErrorMsg),
+		DurationMs:  in.Run.DurationMs,
+		Validations: in.Run.Validations,
+	}
+
+	// Final-pass: recompute the redaction summary because RedactString
+	// calls in the Result/Prompt sections may have added more matches
+	// after the Env phase.
+	snap.Redaction.AppliedRules = policy.MatchedRules()
+	snap.Redaction.RedactionCount = policy.MatchCount()
+	return snap, nil
+}
+
+// redactToolEvent returns a copy of ev with every captured string value
+// passed through the policy. The tool_call_id, tool_name, turn, sequence,
+// success, and duration_ms fields are preserved verbatim because they are
+// required keys for replay correlation; only the user-controlled args /
+// result payload and error message are scrubbed.
+func redactToolEvent(ev models.ToolEvent, policy *Policy) models.ToolEvent {
+	out := ev
+	out.Args = policy.RedactAny(ev.Args)
+	out.Result = policy.RedactAny(ev.Result)
+	out.Error = policy.RedactString(ev.Error)
+	return out
+}
+
+func shaBytes(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// Writer writes captured snapshots to <root>/<test_id>-run<N>.json. Writer
+// is concurrency-safe: callers may invoke Write from multiple goroutines.
+type Writer struct {
+	root string
+}
+
+// NewWriter constructs a Writer rooted at dir. Write creates dir on demand,
+// so the caller does not need to pre-create it.
+func NewWriter(dir string) *Writer {
+	return &Writer{root: dir}
+}
+
+// Root returns the directory the writer writes to.
+func (w *Writer) Root() string {
+	if w == nil {
+		return ""
+	}
+	return w.root
+}
+
+// Write serializes snap to <root>/<test_id>-run<N>.json and returns the
+// path written. The path is suitable for embedding in a results.json
+// `runs[].snapshot_path` field.
+func (w *Writer) Write(snap *Snapshot) (string, error) {
+	if w == nil {
+		return "", fmt.Errorf("snapshot: nil writer")
+	}
+	if snap == nil {
+		return "", fmt.Errorf("snapshot: nil snapshot")
+	}
+	if err := os.MkdirAll(w.root, 0o755); err != nil {
+		return "", fmt.Errorf("snapshot: create dir %s: %w", w.root, err)
+	}
+	name := snapshotFilename(snap.Task.TestID, snap.Task.RunNumber)
+	path := filepath.Join(w.root, name)
+
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("snapshot: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("snapshot: write %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// snapshotFilename produces a stable filename for the snapshot of a single
+// task-run. Test IDs are sanitized to a filesystem-safe slug.
+func snapshotFilename(testID string, run int) string {
+	slug := sanitizeSlug(testID)
+	if slug == "" {
+		slug = "task"
+	}
+	return fmt.Sprintf("%s-run%d.json", slug, run)
+}
+
+func sanitizeSlug(s string) string {
+	if s == "" {
+		return ""
+	}
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-' || r == '_' || r == '.':
+			out = append(out, r)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}

--- a/internal/snapshot/capture.go
+++ b/internal/snapshot/capture.go
@@ -27,6 +27,12 @@ type CaptureInput struct {
 
 	Engine       SnapshotEngine
 	FixturesRoot string
+	// SkipDirs is an optional list of absolute directories under
+	// FixturesRoot whose contents will be omitted from the captured
+	// fixture digests. The runner uses this to exclude the configured
+	// snapshot output directory, which prevents previously-emitted
+	// snapshots from perturbing the fixture hash on re-runs.
+	SkipDirs     []string
 	EnvAllowList []string
 	Policy       *Policy
 }
@@ -107,7 +113,7 @@ func Capture(in CaptureInput) (*Snapshot, error) {
 
 	// Fixtures
 	if in.FixturesRoot != "" {
-		digests, err := HashFixtures(in.FixturesRoot)
+		digests, err := HashFixturesExcluding(in.FixturesRoot, in.SkipDirs)
 		if err != nil {
 			return nil, fmt.Errorf("snapshot: hash fixtures: %w", err)
 		}

--- a/internal/snapshot/env.go
+++ b/internal/snapshot/env.go
@@ -1,0 +1,96 @@
+package snapshot
+
+import (
+	"os"
+	"sort"
+	"strings"
+)
+
+// CaptureEnv returns the captured-env section of a snapshot under the
+// default-deny / allow-list policy described in the issue.
+//
+// Rules:
+//   - When allowList is empty, no env values are captured. DeniedKeys still
+//     lists every name in the process environment so a snapshot is at least
+//     auditable.
+//   - When allowList contains a name, that variable's value is captured.
+//     If the policy marks the key as sensitive (IsSensitiveKey), the value
+//     is replaced with RedactionPlaceholder; otherwise the value is run
+//     through the redaction policy's regex rules.
+//   - allowList entries may end with `*` to match prefixes (e.g. `WAZA_*`).
+//
+// The returned SnapshotEnv is always non-nil; absent fields are nil/empty.
+func CaptureEnv(allowList []string, policy *Policy) SnapshotEnv {
+	return captureEnvFrom(os.Environ(), allowList, policy)
+}
+
+func captureEnvFrom(environ []string, allowList []string, policy *Policy) SnapshotEnv {
+	allow := normaliseAllowList(allowList)
+	captured := map[string]string{}
+	var denied []string
+
+	for _, e := range environ {
+		idx := strings.IndexByte(e, '=')
+		if idx <= 0 {
+			continue
+		}
+		key, val := e[:idx], e[idx+1:]
+		if !allowList_match(allow, key) {
+			denied = append(denied, key)
+			continue
+		}
+		switch {
+		case policy.IsSensitiveKey(key):
+			captured[key] = RedactionPlaceholder
+		default:
+			captured[key] = policy.RedactString(val)
+		}
+	}
+	sort.Strings(denied)
+
+	out := SnapshotEnv{
+		AllowList: append([]string(nil), allowList...),
+	}
+	if len(captured) > 0 {
+		out.Captured = captured
+	}
+	if len(denied) > 0 {
+		out.DeniedKeys = denied
+	}
+	return out
+}
+
+type allowEntry struct {
+	exact  string
+	prefix string // empty if exact
+}
+
+func normaliseAllowList(in []string) []allowEntry {
+	out := make([]allowEntry, 0, len(in))
+	for _, e := range in {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		if strings.HasSuffix(e, "*") {
+			out = append(out, allowEntry{prefix: strings.TrimSuffix(e, "*")})
+		} else {
+			out = append(out, allowEntry{exact: e})
+		}
+	}
+	return out
+}
+
+// allowList_match (snake_case to avoid clashing with the AllowList field
+// name in SnapshotEnv when reading code grep-style).
+func allowList_match(entries []allowEntry, key string) bool {
+	for _, e := range entries {
+		if e.exact != "" && e.exact == key {
+			return true
+		}
+		if e.prefix != "" && strings.HasPrefix(key, e.prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/snapshot/env.go
+++ b/internal/snapshot/env.go
@@ -10,9 +10,13 @@ import (
 // default-deny / allow-list policy described in the issue.
 //
 // Rules:
-//   - When allowList is empty, no env values are captured. DeniedKeys still
-//     lists every name in the process environment so a snapshot is at least
-//     auditable.
+//   - When allowList is empty, no env values are captured and DeniedKeys
+//     is left empty so the snapshot does not leak the full set of
+//     environment variable names from the host (which can be large,
+//     unstable across machines, and occasionally sensitive on its own).
+//   - When allowList is non-empty, variables that do not match are added
+//     to DeniedKeys for auditing. This makes the allow-list explicit
+//     without enumerating every unrelated key from the host.
 //   - When allowList contains a name, that variable's value is captured.
 //     If the policy marks the key as sensitive (IsSensitiveKey), the value
 //     is replaced with RedactionPlaceholder; otherwise the value is run
@@ -28,6 +32,7 @@ func captureEnvFrom(environ []string, allowList []string, policy *Policy) Snapsh
 	allow := normaliseAllowList(allowList)
 	captured := map[string]string{}
 	var denied []string
+	recordDenied := len(allow) > 0
 
 	for _, e := range environ {
 		idx := strings.IndexByte(e, '=')
@@ -36,7 +41,9 @@ func captureEnvFrom(environ []string, allowList []string, policy *Policy) Snapsh
 		}
 		key, val := e[:idx], e[idx+1:]
 		if !allowList_match(allow, key) {
-			denied = append(denied, key)
+			if recordDenied {
+				denied = append(denied, key)
+			}
 			continue
 		}
 		switch {

--- a/internal/snapshot/fixtures.go
+++ b/internal/snapshot/fixtures.go
@@ -1,0 +1,104 @@
+package snapshot
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// HashFixtures walks root and returns one FixtureDigest per regular file
+// found, with paths recorded relative to root. Symlinks are followed only
+// when they resolve to a regular file. Dot-prefixed directories are
+// skipped (matches the runner's loadInstructions behavior for `.git`,
+// `.vscode`, etc.).
+//
+// The returned slice is sorted by Path for deterministic snapshots.
+func HashFixtures(root string) ([]FixtureDigest, error) {
+	if root == "" {
+		return nil, nil
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat fixtures root %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("fixtures root %s: not a directory", root)
+	}
+
+	var digests []FixtureDigest
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != root && strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			// Try to follow a symlink if it resolves to a regular file.
+			if d.Type()&fs.ModeSymlink == 0 {
+				return nil
+			}
+			si, err := os.Stat(path)
+			if err != nil || !si.Mode().IsRegular() {
+				return nil
+			}
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		// Skip emitted snapshot artifacts; otherwise running the eval twice
+		// to compare snapshots would change the fixture hash.
+		if strings.HasPrefix(rel, "snapshots"+string(os.PathSeparator)) {
+			return nil
+		}
+		sum, size, err := hashFile(path)
+		if err != nil {
+			return fmt.Errorf("hash %s: %w", rel, err)
+		}
+		digests = append(digests, FixtureDigest{
+			Path:   filepath.ToSlash(rel),
+			Size:   size,
+			SHA256: sum,
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	sort.Slice(digests, func(i, j int) bool {
+		return digests[i].Path < digests[j].Path
+	})
+	return digests, nil
+}
+
+// hashFile streams the file at path and returns its sha256 hex digest and
+// size in bytes. Using a streamed hash keeps memory bounded for large
+// binaries (e.g., golden screenshots).
+func hashFile(path string) (string, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	n, err := copyTo(h, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
+}

--- a/internal/snapshot/fixtures.go
+++ b/internal/snapshot/fixtures.go
@@ -19,6 +19,15 @@ import (
 //
 // The returned slice is sorted by Path for deterministic snapshots.
 func HashFixtures(root string) ([]FixtureDigest, error) {
+	return HashFixturesExcluding(root, nil)
+}
+
+// HashFixturesExcluding is HashFixtures but also skips any directories
+// (and their contents) whose absolute path matches an entry in skipDirs.
+// This is used by the orchestrator to exclude the configured snapshot
+// output directory so freshly-written snapshots do not perturb the fixture
+// hash on subsequent runs.
+func HashFixturesExcluding(root string, skipDirs []string) ([]FixtureDigest, error) {
 	if root == "" {
 		return nil, nil
 	}
@@ -33,6 +42,8 @@ func HashFixtures(root string) ([]FixtureDigest, error) {
 		return nil, fmt.Errorf("fixtures root %s: not a directory", root)
 	}
 
+	skip := normaliseSkipDirs(skipDirs)
+
 	var digests []FixtureDigest
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -42,6 +53,13 @@ func HashFixtures(root string) ([]FixtureDigest, error) {
 			name := d.Name()
 			if path != root && strings.HasPrefix(name, ".") {
 				return filepath.SkipDir
+			}
+			if absPath, absErr := filepath.Abs(path); absErr == nil {
+				for _, s := range skip {
+					if absPath == s {
+						return filepath.SkipDir
+					}
+				}
 			}
 			return nil
 		}
@@ -59,11 +77,6 @@ func HashFixtures(root string) ([]FixtureDigest, error) {
 		rel, err := filepath.Rel(root, path)
 		if err != nil {
 			return err
-		}
-		// Skip emitted snapshot artifacts; otherwise running the eval twice
-		// to compare snapshots would change the fixture hash.
-		if strings.HasPrefix(rel, "snapshots"+string(os.PathSeparator)) {
-			return nil
 		}
 		sum, size, err := hashFile(path)
 		if err != nil {
@@ -83,6 +96,24 @@ func HashFixtures(root string) ([]FixtureDigest, error) {
 		return digests[i].Path < digests[j].Path
 	})
 	return digests, nil
+}
+
+func normaliseSkipDirs(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		abs, err := filepath.Abs(s)
+		if err != nil {
+			abs = s
+		}
+		out = append(out, abs)
+	}
+	return out
 }
 
 // hashFile streams the file at path and returns its sha256 hex digest and

--- a/internal/snapshot/io.go
+++ b/internal/snapshot/io.go
@@ -1,0 +1,11 @@
+package snapshot
+
+import (
+	"io"
+)
+
+// copyTo is io.Copy with a small wrapper so fixtures.go does not need an
+// extra import. Returns the number of bytes copied.
+func copyTo(dst io.Writer, src io.Reader) (int64, error) {
+	return io.Copy(dst, src)
+}

--- a/internal/snapshot/redaction.go
+++ b/internal/snapshot/redaction.go
@@ -1,0 +1,281 @@
+package snapshot
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RedactionPlaceholder is what we write in place of a redacted value.
+// Stable, easy to grep for, distinguishable from any plausible credential.
+const RedactionPlaceholder = "[REDACTED]"
+
+// RedactionRule is a single named regex that matches a secret-like string.
+// Rule names appear in Snapshot.Redaction.AppliedRules so users can audit
+// which rule fired without seeing the secret.
+type RedactionRule struct {
+	Name     string         `yaml:"name" json:"name"`
+	Pattern  string         `yaml:"pattern" json:"pattern"`
+	compiled *regexp.Regexp `yaml:"-" json:"-"`
+}
+
+// Policy is the redaction configuration used when capturing a snapshot.
+// A nil *Policy means redaction is disabled — capture verbatim. This is
+// useful for tests but the CLI never produces a nil policy in production.
+type Policy struct {
+	// Rules is the ordered list of redaction rules applied to every captured
+	// string. Order matters: later rules see strings that earlier rules
+	// have already partially redacted.
+	Rules []RedactionRule `yaml:"rules" json:"rules"`
+
+	// EnvKeyDenyList is a list of env-var name *substrings* (case-insensitive)
+	// that mark an env var as sensitive even if its value does not match any
+	// regex. Shipped defaults cover SECRET/TOKEN/PASSWORD/KEY/CREDENTIAL.
+	EnvKeyDenyList []string `yaml:"envKeyDenyList" json:"envKeyDenyList"`
+
+	// label is "default", "custom", or "default+custom", recorded in
+	// Snapshot.Redaction.Policy.
+	label string `yaml:"-" json:"-"`
+
+	matchCount   int             `yaml:"-" json:"-"`
+	matchedRules map[string]bool `yaml:"-" json:"-"`
+}
+
+// DefaultPolicy returns the shipped redaction policy. The rules target the
+// most common secret formats so a snapshot is safe to share by default:
+// GitHub PATs, OpenAI/Azure keys, generic 32+ hex/base64 tokens, JWT-shaped
+// strings, AWS access keys, basic-auth headers, and email addresses.
+func DefaultPolicy() *Policy {
+	p := &Policy{
+		Rules: []RedactionRule{
+			{Name: "github_pat", Pattern: `gh[pousr]_[A-Za-z0-9_]{36,}`},
+			{Name: "openai_key", Pattern: `sk-(?:proj-)?[A-Za-z0-9_-]{20,}`},
+			{Name: "azure_openai_key", Pattern: `(?i)\b[a-f0-9]{32,64}\b`},
+			{Name: "aws_access_key", Pattern: `AKIA[0-9A-Z]{16}`},
+			{Name: "aws_secret_key", Pattern: `(?i)aws[_-]?secret[_-]?(?:access[_-]?)?key["'\s:=]+[A-Za-z0-9/+]{40}`},
+			{Name: "jwt", Pattern: `eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`},
+			{Name: "bearer_header", Pattern: `(?i)bearer\s+[A-Za-z0-9._\-+/=]{16,}`},
+			{Name: "basic_auth_header", Pattern: `(?i)basic\s+[A-Za-z0-9+/=]{16,}`},
+			{Name: "private_key_pem", Pattern: `-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`},
+			{Name: "email", Pattern: `\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`},
+		},
+		EnvKeyDenyList: []string{
+			"SECRET", "TOKEN", "PASSWORD", "PASSWD", "PWD",
+			"KEY", "CREDENTIAL", "API_KEY", "AUTH",
+		},
+		label: "default",
+	}
+	if err := p.compile(); err != nil {
+		// Shipped defaults must compile; a panic here is a programmer error
+		// caught by tests.
+		panic(fmt.Sprintf("default redaction policy failed to compile: %v", err))
+	}
+	return p
+}
+
+// LoadPolicy reads a YAML file that may either replace or extend the shipped
+// defaults. The on-disk format:
+//
+//	# extend: when true, defaults are prepended; otherwise the file's rules
+//	# replace the defaults entirely.
+//	extend: true
+//	rules:
+//	  - name: internal_token
+//	    pattern: "INT-[A-Z0-9]{20}"
+//	envKeyDenyList:
+//	  - CUSTOM_SECRET
+func LoadPolicy(path string) (*Policy, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read redaction policy %s: %w", path, err)
+	}
+	var doc struct {
+		Extend         bool            `yaml:"extend"`
+		Rules          []RedactionRule `yaml:"rules"`
+		EnvKeyDenyList []string        `yaml:"envKeyDenyList"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse redaction policy %s: %w", path, err)
+	}
+
+	var p *Policy
+	switch {
+	case doc.Extend:
+		p = DefaultPolicy()
+		p.Rules = append(p.Rules, doc.Rules...)
+		p.EnvKeyDenyList = append(p.EnvKeyDenyList, doc.EnvKeyDenyList...)
+		p.label = "default+custom"
+	default:
+		p = &Policy{
+			Rules:          doc.Rules,
+			EnvKeyDenyList: doc.EnvKeyDenyList,
+			label:          "custom",
+		}
+	}
+	if err := p.compile(); err != nil {
+		return nil, fmt.Errorf("compile redaction policy %s: %w", path, err)
+	}
+	return p, nil
+}
+
+func (p *Policy) compile() error {
+	for i := range p.Rules {
+		re, err := regexp.Compile(p.Rules[i].Pattern)
+		if err != nil {
+			return fmt.Errorf("rule %q: %w", p.Rules[i].Name, err)
+		}
+		p.Rules[i].compiled = re
+	}
+	return nil
+}
+
+// Label returns the policy label ("default", "custom", "default+custom").
+func (p *Policy) Label() string {
+	if p == nil {
+		return "disabled"
+	}
+	return p.label
+}
+
+// MatchCount returns the number of replacements performed across this
+// policy's lifetime. Reset to zero by ResetCounters.
+func (p *Policy) MatchCount() int {
+	if p == nil {
+		return 0
+	}
+	return p.matchCount
+}
+
+// MatchedRules returns the sorted set of rule names that matched at least
+// once.
+func (p *Policy) MatchedRules() []string {
+	if p == nil || len(p.matchedRules) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(p.matchedRules))
+	for name := range p.matchedRules {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ResetCounters clears the per-capture statistics.
+func (p *Policy) ResetCounters() {
+	if p == nil {
+		return
+	}
+	p.matchCount = 0
+	p.matchedRules = nil
+}
+
+// RedactString applies every rule in order to s and returns the redacted
+// string. Match counters are updated on Policy.
+func (p *Policy) RedactString(s string) string {
+	if p == nil || s == "" {
+		return s
+	}
+	for _, r := range p.Rules {
+		if r.compiled == nil {
+			continue
+		}
+		// Count matches so callers can report rule names + total count.
+		matches := r.compiled.FindAllStringIndex(s, -1)
+		if len(matches) == 0 {
+			continue
+		}
+		if p.matchedRules == nil {
+			p.matchedRules = map[string]bool{}
+		}
+		p.matchedRules[r.Name] = true
+		p.matchCount += len(matches)
+		s = r.compiled.ReplaceAllString(s, RedactionPlaceholder)
+	}
+	return s
+}
+
+// IsSensitiveKey reports whether the env-var name should be treated as
+// secret-bearing regardless of value. Allow-listed keys that match the deny
+// list are captured with their value redacted, NOT entirely dropped, so the
+// snapshot still records that the variable was present.
+func (p *Policy) IsSensitiveKey(name string) bool {
+	if p == nil || name == "" {
+		return false
+	}
+	upper := strings.ToUpper(name)
+	for _, frag := range p.EnvKeyDenyList {
+		if strings.Contains(upper, strings.ToUpper(frag)) {
+			return true
+		}
+	}
+	return false
+}
+
+// RedactStringSlice applies redaction to every element. Returns a fresh
+// slice; the input is not mutated.
+func (p *Policy) RedactStringSlice(in []string) []string {
+	if p == nil || len(in) == 0 {
+		return in
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = p.RedactString(s)
+	}
+	return out
+}
+
+// RedactStringMap applies redaction to every value in the map. Returns a
+// fresh map; the input is not mutated.
+func (p *Policy) RedactStringMap(in map[string]string) map[string]string {
+	if p == nil || len(in) == 0 {
+		return in
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if p.IsSensitiveKey(k) {
+			out[k] = RedactionPlaceholder
+			continue
+		}
+		out[k] = p.RedactString(v)
+	}
+	return out
+}
+
+// RedactAny walks a JSON-like value (string / []any / map[string]any /
+// map[string]string / and pointers thereof) and applies redaction to every
+// string it finds. Other types are returned as-is.
+func (p *Policy) RedactAny(v any) any {
+	if p == nil || v == nil {
+		return v
+	}
+	switch x := v.(type) {
+	case string:
+		return p.RedactString(x)
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, val := range x {
+			if p.IsSensitiveKey(k) {
+				out[k] = RedactionPlaceholder
+				continue
+			}
+			out[k] = p.RedactAny(val)
+		}
+		return out
+	case map[string]string:
+		return p.RedactStringMap(x)
+	case []any:
+		out := make([]any, len(x))
+		for i, val := range x {
+			out[i] = p.RedactAny(val)
+		}
+		return out
+	case []string:
+		return p.RedactStringSlice(x)
+	default:
+		return v
+	}
+}

--- a/internal/snapshot/replay.go
+++ b/internal/snapshot/replay.go
@@ -202,8 +202,13 @@ func Compare(baseline, replayed *Snapshot, strictResult bool) CompareResult {
 //
 // Bisect prefers tool_events.Turn when populated (engines that track turn
 // boundaries); when Turn is 0 it falls back to the event sequence index.
+//
+// Bisect runs Compare in non-strict mode: it ignores tool result payloads
+// and compares only the ordered (name, args) sequence so the reported
+// "first divergent turn" reflects where the agent took a different action,
+// not where downstream side effects differed.
 func Bisect(baseline, failing *Snapshot) (turn int, result CompareResult) {
-	result = Compare(baseline, failing, true)
+	result = Compare(baseline, failing, false)
 	if result.Match || len(result.Divergences) == 0 {
 		return 0, result
 	}

--- a/internal/snapshot/replay.go
+++ b/internal/snapshot/replay.go
@@ -1,0 +1,283 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+// Mode controls how `waza replay` re-runs a snapshot.
+type Mode string
+
+const (
+	// ModeModelReplay is the default mode: replay the captured tool_events
+	// without any LLM/engine call. Graders that consume tool_events
+	// (tool_calls, tool_constraint, etc.) verify byte-for-byte against the
+	// snapshot, and the snapshot's grader results are re-checked against
+	// the saved status. No tokens are spent. Diverges only if the snapshot
+	// is internally inconsistent.
+	ModeModelReplay Mode = "model-replay"
+
+	// ModeLive re-runs the task against the real engine using the same
+	// prompt + fixtures, then compares the resulting tool_events to the
+	// snapshot's. Live mode is intentionally fuzzy: non-deterministic
+	// fields (durations, raw model output text) are ignored; only the
+	// ordered tool name + args fingerprint is compared.
+	ModeLive Mode = "live"
+)
+
+// DivergenceKind classifies a single discrepancy reported by Compare.
+type DivergenceKind string
+
+const (
+	DivLengthMismatch DivergenceKind = "length_mismatch"
+	DivToolName       DivergenceKind = "tool_name"
+	DivToolArgs       DivergenceKind = "tool_args"
+	DivToolSuccess    DivergenceKind = "tool_success"
+	DivToolResult     DivergenceKind = "tool_result"
+	DivFinalStatus    DivergenceKind = "final_status"
+	DivValidation     DivergenceKind = "validation"
+)
+
+// Divergence is a single discrepancy between two snapshots (or between a
+// snapshot and a freshly-captured run in live mode). FirstDivergentIndex is
+// the 0-based position in the tool_events slice; for non-tool-event
+// divergences it is -1.
+type Divergence struct {
+	Kind                DivergenceKind `json:"kind"`
+	FirstDivergentIndex int            `json:"first_divergent_index"`
+	BaselineValue       string         `json:"baseline_value,omitempty"`
+	ReplayedValue       string         `json:"replayed_value,omitempty"`
+	Description         string         `json:"description"`
+}
+
+// CompareResult is the full report from Compare.
+type CompareResult struct {
+	Match        bool         `json:"match"`
+	Divergences  []Divergence `json:"divergences"`
+	BaselinePath string       `json:"baseline,omitempty"`
+	ReplayedPath string       `json:"replayed,omitempty"`
+}
+
+// LoadSnapshotFile reads and parses a snapshot from disk.
+func LoadSnapshotFile(path string) (*Snapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read snapshot %s: %w", path, err)
+	}
+	return ParseSnapshot(data, path)
+}
+
+// Compare returns the divergence report between baseline and replay. When
+// strictResult is true, baseline.Result.Status and validations are also
+// compared; live mode generally wants false because the new run produces
+// its own grader results that should not be expected to match byte-for-byte.
+//
+// The comparison walks tool events by index (0..min(len(a),len(b))). Args
+// and Result are compared via deep-equal of the canonical JSON form so
+// `map[string]any{"a":1}` matches `map[string]any{"a":1.0}` after a JSON
+// round-trip (no false positives on numeric kinding).
+func Compare(baseline, replayed *Snapshot, strictResult bool) CompareResult {
+	res := CompareResult{Match: true}
+	if baseline == nil || replayed == nil {
+		res.Match = false
+		res.Divergences = append(res.Divergences, Divergence{
+			Kind:                DivLengthMismatch,
+			FirstDivergentIndex: -1,
+			Description:         "one snapshot is nil",
+		})
+		return res
+	}
+
+	a, b := baseline.ToolEvents, replayed.ToolEvents
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i].ToolName != b[i].ToolName {
+			res.Match = false
+			res.Divergences = append(res.Divergences, Divergence{
+				Kind:                DivToolName,
+				FirstDivergentIndex: i,
+				BaselineValue:       a[i].ToolName,
+				ReplayedValue:       b[i].ToolName,
+				Description:         fmt.Sprintf("tool name diverges at index %d", i),
+			})
+			return res
+		}
+		if !canonicalEqual(a[i].Args, b[i].Args) {
+			res.Match = false
+			res.Divergences = append(res.Divergences, Divergence{
+				Kind:                DivToolArgs,
+				FirstDivergentIndex: i,
+				BaselineValue:       canonicalJSON(a[i].Args),
+				ReplayedValue:       canonicalJSON(b[i].Args),
+				Description:         fmt.Sprintf("tool args diverge at index %d (tool=%s)", i, a[i].ToolName),
+			})
+			return res
+		}
+		if strictResult {
+			if a[i].Success != b[i].Success {
+				res.Match = false
+				res.Divergences = append(res.Divergences, Divergence{
+					Kind:                DivToolSuccess,
+					FirstDivergentIndex: i,
+					BaselineValue:       fmt.Sprintf("%t", a[i].Success),
+					ReplayedValue:       fmt.Sprintf("%t", b[i].Success),
+					Description:         fmt.Sprintf("tool success diverges at index %d", i),
+				})
+				return res
+			}
+			if !canonicalEqual(a[i].Result, b[i].Result) {
+				res.Match = false
+				res.Divergences = append(res.Divergences, Divergence{
+					Kind:                DivToolResult,
+					FirstDivergentIndex: i,
+					BaselineValue:       canonicalJSON(a[i].Result),
+					ReplayedValue:       canonicalJSON(b[i].Result),
+					Description:         fmt.Sprintf("tool result diverges at index %d", i),
+				})
+				return res
+			}
+		}
+	}
+	if len(a) != len(b) {
+		res.Match = false
+		res.Divergences = append(res.Divergences, Divergence{
+			Kind:                DivLengthMismatch,
+			FirstDivergentIndex: n,
+			BaselineValue:       fmt.Sprintf("%d events", len(a)),
+			ReplayedValue:       fmt.Sprintf("%d events", len(b)),
+			Description:         "snapshots have different tool_event counts",
+		})
+		return res
+	}
+
+	if strictResult {
+		if baseline.Result.Status != replayed.Result.Status {
+			res.Match = false
+			res.Divergences = append(res.Divergences, Divergence{
+				Kind:                DivFinalStatus,
+				FirstDivergentIndex: -1,
+				BaselineValue:       string(baseline.Result.Status),
+				ReplayedValue:       string(replayed.Result.Status),
+				Description:         "final run status diverges",
+			})
+		}
+		for name, ag := range baseline.Result.Validations {
+			bg, ok := replayed.Result.Validations[name]
+			if !ok {
+				res.Match = false
+				res.Divergences = append(res.Divergences, Divergence{
+					Kind:                DivValidation,
+					FirstDivergentIndex: -1,
+					BaselineValue:       fmt.Sprintf("passed=%t", ag.Passed),
+					ReplayedValue:       "missing",
+					Description:         fmt.Sprintf("grader %q missing in replay", name),
+				})
+				continue
+			}
+			if ag.Passed != bg.Passed {
+				res.Match = false
+				res.Divergences = append(res.Divergences, Divergence{
+					Kind:                DivValidation,
+					FirstDivergentIndex: -1,
+					BaselineValue:       fmt.Sprintf("passed=%t", ag.Passed),
+					ReplayedValue:       fmt.Sprintf("passed=%t", bg.Passed),
+					Description:         fmt.Sprintf("grader %q outcome diverges", name),
+				})
+			}
+		}
+	}
+	return res
+}
+
+// Bisect identifies the first divergent turn between baseline and failing.
+// Returns the 1-based turn number of the first event that diverges, or 0
+// when the snapshots match. The same Divergence slice that Compare emits
+// is returned so callers can render details.
+//
+// Bisect prefers tool_events.Turn when populated (engines that track turn
+// boundaries); when Turn is 0 it falls back to the event sequence index.
+func Bisect(baseline, failing *Snapshot) (turn int, result CompareResult) {
+	result = Compare(baseline, failing, true)
+	if result.Match || len(result.Divergences) == 0 {
+		return 0, result
+	}
+	first := result.Divergences[0]
+	idx := first.FirstDivergentIndex
+	switch {
+	case idx < 0:
+		return 0, result
+	case idx < len(baseline.ToolEvents) && baseline.ToolEvents[idx].Turn > 0:
+		return baseline.ToolEvents[idx].Turn, result
+	default:
+		return idx + 1, result
+	}
+}
+
+// canonicalEqual reports whether two JSON-like values are equivalent after a
+// JSON round-trip. Avoids false negatives on int vs float64 representations
+// that arise from JSON unmarshalling.
+func canonicalEqual(a, b any) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	ca, errA := json.Marshal(a)
+	cb, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return reflect.DeepEqual(a, b)
+	}
+	var oa, ob any
+	if err := json.Unmarshal(ca, &oa); err != nil {
+		return reflect.DeepEqual(a, b)
+	}
+	if err := json.Unmarshal(cb, &ob); err != nil {
+		return reflect.DeepEqual(a, b)
+	}
+	return reflect.DeepEqual(oa, ob)
+}
+
+func canonicalJSON(v any) string {
+	if v == nil {
+		return ""
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	// Keep error messages from running wider than a terminal.
+	s := string(data)
+	const max = 200
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}
+
+// SummariseDivergences returns a short, human-friendly summary of a
+// CompareResult. The summary is intended for CLI output, not analytics.
+func SummariseDivergences(r CompareResult) string {
+	if r.Match {
+		return "snapshots match"
+	}
+	if len(r.Divergences) == 0 {
+		return "snapshots do not match (no divergence details)"
+	}
+	d := r.Divergences[0]
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "first divergence: %s", d.Kind)
+	if d.FirstDivergentIndex >= 0 {
+		fmt.Fprintf(&sb, " at event #%d", d.FirstDivergentIndex+1)
+	}
+	if d.BaselineValue != "" || d.ReplayedValue != "" {
+		fmt.Fprintf(&sb, "\n  baseline: %s\n  replayed: %s", d.BaselineValue, d.ReplayedValue)
+	}
+	if d.Description != "" {
+		fmt.Fprintf(&sb, "\n  %s", d.Description)
+	}
+	return sb.String()
+}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -1,0 +1,307 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/microsoft/waza/internal/models"
+)
+
+func TestParseSnapshotRejectsMajorMismatch(t *testing.T) {
+	doc := map[string]any{
+		"schemaVersion": "9.0",
+		"kind":          Kind,
+	}
+	b, _ := json.Marshal(doc)
+	if _, err := ParseSnapshot(b, "test"); err == nil {
+		t.Fatalf("expected major-version mismatch error, got nil")
+	}
+}
+
+func TestParseSnapshotAcceptsHigherMinor(t *testing.T) {
+	curMajor, _, _ := parseVersion(CurrentSchemaVersion)
+	higher := strings.Replace(CurrentSchemaVersion, ".0", ".99", 1)
+	if higher == CurrentSchemaVersion {
+		// Pick a high minor regardless of the current MINOR.
+		higher = ""
+		_ = curMajor
+	}
+	if higher == "" {
+		higher = "1.99"
+	}
+	doc := map[string]any{
+		"schemaVersion": higher,
+		"kind":          Kind,
+	}
+	b, _ := json.Marshal(doc)
+	snap, err := ParseSnapshot(b, "test")
+	if err != nil {
+		t.Fatalf("expected higher-minor acceptance, got %v", err)
+	}
+	if snap.SchemaVersion != higher {
+		t.Fatalf("schemaVersion = %q want %q", snap.SchemaVersion, higher)
+	}
+}
+
+func TestParseSnapshotRejectsWrongKind(t *testing.T) {
+	doc := map[string]any{
+		"schemaVersion": CurrentSchemaVersion,
+		"kind":          "results",
+	}
+	b, _ := json.Marshal(doc)
+	if _, err := ParseSnapshot(b, "test"); err == nil {
+		t.Fatalf("expected kind mismatch error, got nil")
+	}
+}
+
+func TestDefaultPolicyRedactsKnownSecrets(t *testing.T) {
+	p := DefaultPolicy()
+	cases := map[string]string{
+		"GitHub PAT":    "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"OpenAI Key":    "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		"AWS Access":    "AKIAIOSFODNN7EXAMPLE",
+		"Bearer Header": "Authorization: Bearer abc123def456ghi789jklmnop",
+		"Email":         "user@example.com",
+	}
+	for label, in := range cases {
+		out := p.RedactString(in)
+		if out == in {
+			t.Errorf("%s: expected redaction of %q, got identical output", label, in)
+		}
+		if !strings.Contains(out, RedactionPlaceholder) {
+			t.Errorf("%s: expected placeholder in output, got %q", label, out)
+		}
+	}
+}
+
+func TestPolicyIsSensitiveKey(t *testing.T) {
+	p := DefaultPolicy()
+	want := map[string]bool{
+		"GITHUB_TOKEN":   true,
+		"OPENAI_API_KEY": true,
+		"PATH":           false,
+		"USER":           false,
+	}
+	for k, exp := range want {
+		got := p.IsSensitiveKey(k)
+		if got != exp {
+			t.Errorf("IsSensitiveKey(%q) = %v, want %v", k, got, exp)
+		}
+	}
+}
+
+func TestCaptureEnvDefaultDeny(t *testing.T) {
+	env := captureEnvFrom([]string{"FOO=bar", "BAZ=qux"}, nil, DefaultPolicy())
+	if len(env.Captured) != 0 {
+		t.Fatalf("default-deny should capture nothing, got %v", env.Captured)
+	}
+	if len(env.DeniedKeys) != 2 {
+		t.Fatalf("expected 2 denied keys, got %v", env.DeniedKeys)
+	}
+}
+
+func TestCaptureEnvAllowList(t *testing.T) {
+	env := captureEnvFrom([]string{"WAZA_RUN_ID=abc", "WAZA_TRACE=on", "SECRET_TOKEN=ghp_xxxx"}, []string{"WAZA_*"}, DefaultPolicy())
+	if _, ok := env.Captured["WAZA_RUN_ID"]; !ok {
+		t.Fatalf("expected WAZA_RUN_ID captured, got %v", env.Captured)
+	}
+	if _, ok := env.Captured["SECRET_TOKEN"]; ok {
+		t.Fatalf("SECRET_TOKEN should be denied, got %v", env.Captured)
+	}
+}
+
+func TestCaptureEnvSensitiveKeyRedacted(t *testing.T) {
+	env := captureEnvFrom([]string{"MY_TOKEN=ghp_real_token_value"}, []string{"MY_TOKEN"}, DefaultPolicy())
+	val, ok := env.Captured["MY_TOKEN"]
+	if !ok {
+		t.Fatalf("expected MY_TOKEN to be captured (allow-listed), got %v", env.Captured)
+	}
+	if val != RedactionPlaceholder {
+		t.Fatalf("expected redaction placeholder, got %q", val)
+	}
+}
+
+func TestHashFixtures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "b.txt"), []byte("world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digests, err := HashFixtures(root)
+	if err != nil {
+		t.Fatalf("HashFixtures: %v", err)
+	}
+	if len(digests) != 2 {
+		t.Fatalf("expected 2 digests, got %d", len(digests))
+	}
+	for _, d := range digests {
+		if d.SHA256 == "" {
+			t.Errorf("digest missing for %s", d.Path)
+		}
+	}
+}
+
+func TestCaptureRoundtrip(t *testing.T) {
+	tc := &models.TestCase{
+		TestID: "demo",
+		Stimulus: models.TaskStimulus{
+			Message:   "hello",
+			FollowUps: []string{"follow"},
+		},
+	}
+	run := &models.RunResult{
+		Status:     models.StatusPassed,
+		DurationMs: 12,
+		ToolEvents: []models.ToolEvent{
+			{Sequence: 1, ToolName: "read_file", Args: map[string]any{"path": "a.txt"}, Result: "ok"},
+		},
+	}
+	in := CaptureInput{
+		WazaVersion: "test",
+		EvalName:    "demo-eval",
+		Skill:       "demo-skill",
+		Task:        tc,
+		Run:         run,
+		Policy:      DefaultPolicy(),
+	}
+	snap, err := Capture(in)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if snap.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("schemaVersion = %q want %q", snap.SchemaVersion, CurrentSchemaVersion)
+	}
+	if snap.Kind != Kind {
+		t.Errorf("kind = %q want %q", snap.Kind, Kind)
+	}
+	if snap.Task.TestID != "demo" {
+		t.Errorf("task.testId = %q", snap.Task.TestID)
+	}
+	if len(snap.ToolEvents) != 1 {
+		t.Errorf("toolEvents = %d want 1", len(snap.ToolEvents))
+	}
+
+	// Write to disk, read back, ensure it parses.
+	dir := t.TempDir()
+	w := NewWriter(dir)
+	path, err := w.Write(snap)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	loaded, err := LoadSnapshotFile(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshotFile: %v", err)
+	}
+	if loaded.Task.TestID != "demo" {
+		t.Errorf("loaded task.testId = %q", loaded.Task.TestID)
+	}
+}
+
+func TestCompareIdentical(t *testing.T) {
+	snap := makeSnapshot(t, []models.ToolEvent{
+		{Sequence: 1, ToolName: "a", Args: map[string]any{"k": "v"}},
+	})
+	r := Compare(snap, snap, true)
+	if !r.Match {
+		t.Fatalf("expected match, got divergences %+v", r.Divergences)
+	}
+}
+
+func TestCompareDivergentArgs(t *testing.T) {
+	a := makeSnapshot(t, []models.ToolEvent{
+		{Sequence: 1, ToolName: "tool", Args: map[string]any{"k": "v"}},
+	})
+	b := makeSnapshot(t, []models.ToolEvent{
+		{Sequence: 1, ToolName: "tool", Args: map[string]any{"k": "other"}},
+	})
+	r := Compare(a, b, false)
+	if r.Match {
+		t.Fatalf("expected mismatch")
+	}
+	if len(r.Divergences) == 0 {
+		t.Fatalf("expected at least one divergence")
+	}
+}
+
+func TestBisectReportsFirstDivergence(t *testing.T) {
+	a := makeSnapshot(t, []models.ToolEvent{
+		{Sequence: 1, Turn: 1, ToolName: "x"},
+		{Sequence: 2, Turn: 2, ToolName: "y"},
+		{Sequence: 3, Turn: 3, ToolName: "z"},
+	})
+	b := makeSnapshot(t, []models.ToolEvent{
+		{Sequence: 1, Turn: 1, ToolName: "x"},
+		{Sequence: 2, Turn: 2, ToolName: "different"},
+		{Sequence: 3, Turn: 3, ToolName: "z"},
+	})
+	turn, r := Bisect(a, b)
+	if r.Match {
+		t.Fatalf("expected mismatch")
+	}
+	if turn != 2 {
+		t.Fatalf("expected turn 2, got %d", turn)
+	}
+}
+
+func TestRedactAnyMapWithSecrets(t *testing.T) {
+	p := DefaultPolicy()
+	in := map[string]any{
+		"prompt": "Use this token: ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"nested": map[string]any{
+			"email": "alice@example.com",
+		},
+	}
+	out, _ := p.RedactAny(in).(map[string]any)
+	prompt, _ := out["prompt"].(string)
+	if !strings.Contains(prompt, RedactionPlaceholder) {
+		t.Errorf("prompt not redacted: %v", out["prompt"])
+	}
+	nested, _ := out["nested"].(map[string]any)
+	email, _ := nested["email"].(string)
+	if !strings.Contains(email, RedactionPlaceholder) {
+		t.Errorf("email not redacted: %v", nested["email"])
+	}
+}
+
+func TestSnapshotMarshalSetsHeader(t *testing.T) {
+	s := Snapshot{
+		CreatedAt: time.Now().UTC(),
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"schemaVersion":"1.0"`) {
+		t.Errorf("schemaVersion not set: %s", b)
+	}
+	if !strings.Contains(string(b), `"kind":"task-snapshot"`) {
+		t.Errorf("kind not set: %s", b)
+	}
+}
+
+// makeSnapshot is a small helper that builds a minimal Snapshot fixture
+// for compare/bisect tests.
+func makeSnapshot(t *testing.T, events []models.ToolEvent) *Snapshot {
+	t.Helper()
+	return &Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		Kind:          Kind,
+		CreatedAt:     time.Now().UTC(),
+		Task:          SnapshotTask{TestID: "t"},
+		Engine:        SnapshotEngine{Type: "mock", ModelID: "m1"},
+		Prompt:        SnapshotPrompt{Message: "hi"},
+		ToolEvents:    events,
+		Env:           SnapshotEnv{},
+		Redaction:     SnapshotRedaction{Policy: "default"},
+		Result:        SnapshotResult{Status: models.StatusPassed},
+	}
+}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -99,8 +99,10 @@ func TestCaptureEnvDefaultDeny(t *testing.T) {
 	if len(env.Captured) != 0 {
 		t.Fatalf("default-deny should capture nothing, got %v", env.Captured)
 	}
-	if len(env.DeniedKeys) != 2 {
-		t.Fatalf("expected 2 denied keys, got %v", env.DeniedKeys)
+	// With an empty allow-list we should NOT leak the full host env name
+	// list into the snapshot's DeniedKeys field.
+	if len(env.DeniedKeys) != 0 {
+		t.Fatalf("default-deny should not record DeniedKeys, got %v", env.DeniedKeys)
 	}
 }
 
@@ -147,6 +149,27 @@ func TestHashFixtures(t *testing.T) {
 		if d.SHA256 == "" {
 			t.Errorf("digest missing for %s", d.Path)
 		}
+	}
+}
+
+func TestHashFixturesExcludingSkipsCallerPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skip := filepath.Join(root, "snapshots")
+	if err := os.MkdirAll(skip, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skip, "snap.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digests, err := HashFixturesExcluding(root, []string{skip})
+	if err != nil {
+		t.Fatalf("HashFixturesExcluding: %v", err)
+	}
+	if len(digests) != 1 || digests[0].Path != "a.txt" {
+		t.Fatalf("expected only a.txt, got %#v", digests)
 	}
 }
 

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -1,0 +1,266 @@
+// Package snapshot implements waza's per-task snapshot/replay artifact.
+//
+// A snapshot is a self-contained, versioned record of one task execution:
+// prompt sequence, every tool call (name/args/result/timing), engine/model
+// config, fixture file hashes, and an env-var allow-list capture. Snapshots
+// are written under `--output-dir` when `waza run --snapshot` is passed and
+// referenced from `results.json` (additive in outcome schema 1.2).
+//
+// `waza replay <snapshot.json>` consumes snapshots to deterministically
+// re-run a task without burning LLM calls (model-replay mode), to detect
+// drift against the real engine (live mode), or to bisect divergence
+// between two snapshots.
+//
+// The snapshot wire format is its own MAJOR.MINOR schema independent of the
+// results.json schema. Additions are MINOR bumps; renames/removals are MAJOR.
+// Readers MUST refuse to load a snapshot whose MAJOR does not match
+// CurrentSchemaVersion (issue #368 policy).
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/microsoft/waza/internal/models"
+)
+
+// Kind identifies this artifact in tooling that may also handle results.json
+// or eval specs. Always "task-snapshot" for snapshots produced by `waza run`.
+const Kind = "task-snapshot"
+
+// CurrentSchemaVersion is the MAJOR.MINOR schema version of this package's
+// wire format.
+//
+// 1.0 — initial snapshot format (issue #367).
+const CurrentSchemaVersion = "1.0"
+
+// Snapshot is the on-disk record of a single task run that `waza replay` can
+// consume to either deterministically re-run graders (model-replay) or to
+// compare against a fresh live execution (live mode / bisect).
+//
+// Snapshot is intentionally self-contained: all fields needed to reproduce a
+// run are captured in the JSON document. Consumers should treat unknown
+// fields as a forward-compat signal (same MAJOR, future MINOR) and log a
+// warning rather than fail.
+type Snapshot struct {
+	// SchemaVersion is the MAJOR.MINOR version of the snapshot wire format.
+	SchemaVersion string `json:"schemaVersion"`
+
+	// Kind is always "task-snapshot" so a single tool inspecting JSON files
+	// can route by kind.
+	Kind string `json:"kind"`
+
+	// WazaVersion is the version of waza that produced this snapshot.
+	// Captured for diagnostics; not used for compatibility decisions
+	// (SchemaVersion is the source of truth).
+	WazaVersion string `json:"wazaVersion,omitempty"`
+
+	// CreatedAt is the UTC timestamp at which this snapshot was written.
+	CreatedAt time.Time `json:"createdAt"`
+
+	// EvalID, EvalName, and Skill mirror the outcome fields so a standalone
+	// snapshot can be attributed to its parent eval without re-reading
+	// results.json.
+	EvalID   string `json:"evalId,omitempty"`
+	EvalName string `json:"evalName,omitempty"`
+	Skill    string `json:"skill,omitempty"`
+
+	// Task describes the task that was executed.
+	Task SnapshotTask `json:"task"`
+
+	// Engine records the engine/model configuration so a live replay can
+	// reproduce the same request shape.
+	Engine SnapshotEngine `json:"engine"`
+
+	// Prompt holds the inputs the engine was given. FollowUps is the static
+	// follow-up list when configured; responder-driven multi-turn is
+	// captured via ToolEvents (which include turn boundaries).
+	Prompt SnapshotPrompt `json:"prompt"`
+
+	// ToolEvents is the canonical replay tape: the ordered, normalised
+	// tool-call record exactly as it appears in
+	// EvaluationOutcome.RunResult.ToolEvents (schema 1.1+). It is the
+	// deterministic input that replay model-replay mode feeds back into
+	// graders that consume tool events.
+	ToolEvents []models.ToolEvent `json:"toolEvents,omitempty"`
+
+	// Fixtures records the sha256 digest of every fixture/resource file the
+	// task started with. Replay live mode uses this to detect drift in the
+	// fixtures directory.
+	Fixtures []FixtureDigest `json:"fixtures,omitempty"`
+
+	// Env captures the env-var allow-list and (for auditing) the names of
+	// vars present in os.Environ() that were denied capture.
+	Env SnapshotEnv `json:"env"`
+
+	// Redaction documents what was scrubbed before serialization.
+	Redaction SnapshotRedaction `json:"redaction"`
+
+	// Result holds the outcome of the captured run (status / final output /
+	// grader results) so model-replay can verify graders deterministically.
+	Result SnapshotResult `json:"result"`
+}
+
+// SnapshotTask carries identifying task metadata.
+type SnapshotTask struct {
+	TestID      string   `json:"testId"`
+	DisplayName string   `json:"displayName,omitempty"`
+	Group       string   `json:"group,omitempty"`
+	Golden      bool     `json:"golden,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	RunNumber   int      `json:"runNumber"`
+}
+
+// SnapshotEngine records engine/model configuration. Fields that the engine
+// does not surface (e.g., seed for the Copilot SDK) are simply left empty —
+// the issue calls them out as best-effort metadata.
+type SnapshotEngine struct {
+	Type        string   `json:"type"`
+	ModelID     string   `json:"modelId"`
+	JudgeModel  string   `json:"judgeModel,omitempty"`
+	TimeoutSec  int      `json:"timeoutSec,omitempty"`
+	Temperature *float64 `json:"temperature,omitempty"`
+	TopP        *float64 `json:"topP,omitempty"`
+	Seed        *int64   `json:"seed,omitempty"`
+}
+
+// SnapshotPrompt is the input side of the run.
+type SnapshotPrompt struct {
+	Message      string             `json:"message"`
+	FollowUps    []string           `json:"followUps,omitempty"`
+	Context      map[string]any     `json:"context,omitempty"`
+	Instructions []InstructionEntry `json:"instructions,omitempty"`
+}
+
+// InstructionEntry records an instruction file applied to the agent.
+// The body itself is NOT captured (instructions can be large and they are
+// already hashed via Fixtures when they live in the workspace); the path
+// and digest are sufficient for replay drift detection.
+type InstructionEntry struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256,omitempty"`
+}
+
+// FixtureDigest is the sha256 of a single fixture file at snapshot time.
+type FixtureDigest struct {
+	Path   string `json:"path"`
+	Size   int64  `json:"size,omitempty"`
+	SHA256 string `json:"sha256"`
+}
+
+// SnapshotEnv documents env-var capture under the default-deny / allow-list
+// policy described in the issue.
+type SnapshotEnv struct {
+	// AllowList is the configured allow-list applied at capture time.
+	// Empty means default-deny captured nothing.
+	AllowList []string `json:"allowList,omitempty"`
+
+	// Captured holds the actually-captured KEY=VALUE pairs after the
+	// allow-list and redaction were applied. Values may be redacted
+	// placeholders if a Redaction rule matched.
+	Captured map[string]string `json:"captured,omitempty"`
+
+	// DeniedKeys lists the names (NOT values) of env vars present in the
+	// process environment that were not in AllowList. Useful for auditing
+	// what would have been redacted under a stricter policy. Empty when
+	// the process environment is small (<= 0 entries) or the writer chose
+	// to omit the audit list.
+	DeniedKeys []string `json:"deniedKeys,omitempty"`
+}
+
+// SnapshotRedaction documents what was scrubbed before serialization.
+type SnapshotRedaction struct {
+	// Policy is "default", "default+custom", or "custom" depending on
+	// whether the shipped defaults were applied, augmented, or replaced.
+	Policy string `json:"policy"`
+
+	// AppliedRules lists the rule names that matched at least once during
+	// this capture, sorted for stable diffing.
+	AppliedRules []string `json:"appliedRules,omitempty"`
+
+	// RedactionCount is the total number of replacements made across the
+	// captured payload.
+	RedactionCount int `json:"redactionCount,omitempty"`
+}
+
+// SnapshotResult mirrors the relevant subset of models.RunResult so a
+// snapshot can be replayed without also loading results.json.
+type SnapshotResult struct {
+	Status      models.Status                   `json:"status"`
+	FinalOutput string                          `json:"finalOutput,omitempty"`
+	ErrorMsg    string                          `json:"errorMsg,omitempty"`
+	DurationMs  int64                           `json:"durationMs,omitempty"`
+	Validations map[string]models.GraderResults `json:"validations,omitempty"`
+}
+
+// MarshalJSON ensures SchemaVersion and Kind are always populated.
+func (s Snapshot) MarshalJSON() ([]byte, error) {
+	type alias Snapshot
+	if s.SchemaVersion == "" {
+		s.SchemaVersion = CurrentSchemaVersion
+	}
+	if s.Kind == "" {
+		s.Kind = Kind
+	}
+	return json.Marshal(alias(s))
+}
+
+// ParseSnapshot decodes a snapshot from bytes and validates its schema
+// version. The source argument is included in error messages for diagnostics.
+func ParseSnapshot(data []byte, source string) (*Snapshot, error) {
+	var header struct {
+		SchemaVersion string `json:"schemaVersion"`
+		Kind          string `json:"kind"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return nil, fmt.Errorf("snapshot %s: %w", source, err)
+	}
+	if header.Kind != "" && header.Kind != Kind {
+		return nil, fmt.Errorf("snapshot %s: kind %q is not %q", source, header.Kind, Kind)
+	}
+
+	version := header.SchemaVersion
+	if strings.TrimSpace(version) == "" {
+		version = CurrentSchemaVersion
+	}
+	major, _, err := parseVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot %s: invalid schemaVersion %q: %w", source, version, err)
+	}
+	curMajor, _, _ := parseVersion(CurrentSchemaVersion)
+	if major != curMajor {
+		return nil, fmt.Errorf("snapshot %s: schemaVersion %q (major %d) is not compatible with waza's snapshot schema major %d (current %s)",
+			source, version, major, curMajor, CurrentSchemaVersion)
+	}
+
+	var snap Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("snapshot %s: %w", source, err)
+	}
+	if snap.SchemaVersion == "" {
+		snap.SchemaVersion = version
+	}
+	if snap.Kind == "" {
+		snap.Kind = Kind
+	}
+	return &snap, nil
+}
+
+func parseVersion(v string) (major, minor int, err error) {
+	parts := strings.Split(v, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return 0, 0, fmt.Errorf("expected MAJOR.MINOR")
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil || major < 0 {
+		return 0, 0, fmt.Errorf("major must be a non-negative integer")
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil || minor < 0 {
+		return 0, 0, fmt.Errorf("minor must be a non-negative integer")
+	}
+	return major, minor, nil
+}

--- a/site/src/content/docs/guides/snapshot-replay.mdx
+++ b/site/src/content/docs/guides/snapshot-replay.mdx
@@ -1,0 +1,149 @@
+---
+title: Snapshot & Replay
+description: Capture self-contained task snapshots during `waza run` and replay them later for deterministic, offline eval reproduction.
+---
+
+`waza` can capture a **self-contained snapshot** of every task it executes, then replay those snapshots later to detect non-determinism, regressions, or environment drift — all without contacting the agent engine.
+
+This guide covers:
+
+- What a snapshot contains and what it deliberately leaves out
+- Capturing snapshots with `waza run --snapshot`
+- Replaying snapshots with `waza replay` (model-replay, bisect)
+- Redaction and environment defaults that keep snapshots safe to commit
+- Schema and forward-compatibility
+
+## Why snapshots?
+
+Agentic evals depend on far more than just `prompt → completion`. Tool calls, fixture file contents, environment variables, and grader configurations all shape the outcome. To reproduce a run faithfully — especially when investigating a flaky failure or an outcome that "won't repro on my machine" — you need to bundle all of those inputs together with the resulting tool-event tape.
+
+A waza snapshot is exactly that bundle, serialized as a single JSON file per task run.
+
+## What's in a snapshot
+
+Each `snapshot.json` (schema `1.0`) contains:
+
+- **Identity** — `waza_version`, `eval_id`, `eval_name`, `skill`, `task` (TestID, DisplayName, Golden flag, RunNumber)
+- **Prompt** — initial user message and follow-ups, plus content-addressed (`sha256`) digests of every instruction file
+- **Fixtures** — recursive content-addressed digests of every file under the task's `context_dir`
+- **Tool events** — the ordered tape from the run, preserving `tool_call_id`, `name`, `args`, `result`, `duration_ms`, `success`, and `error` for each call
+- **Engine** — the captured engine identity (model, vendor, etc.)
+- **Env** — the explicit allow-list and the redacted KEY/VALUE pairs that were captured
+- **Redaction** — the policy label, matched rule names, and a count of redactions applied
+- **Result** — final status, redacted `final_output`/`error_msg`, total duration, and the grader-level `validations` map
+
+Snapshots **do not** contain:
+
+- Raw environment variables outside the allow-list (default-deny)
+- Secrets that match the built-in or custom redaction rules (replaced with `«redacted»` placeholders)
+- Live engine outputs not present in the tool-event tape
+
+## Capturing snapshots
+
+```bash
+waza run eval.yaml --snapshot ./snapshots/
+```
+
+Each task run produces a file named `<test-id>-run<N>.json` in the directory. The path is also recorded inline in `results.json` under each `RunResult.SnapshotPath`.
+
+### Allow-listing environment variables
+
+By default, **no environment variables** are captured. Pass `--snapshot-env-allow` (repeatable) with explicit names or `*`-suffixed prefixes:
+
+```bash
+waza run eval.yaml \
+  --snapshot ./snapshots/ \
+  --snapshot-env-allow "WAZA_*" \
+  --snapshot-env-allow "MODEL"
+```
+
+Even allow-listed values are still passed through the redaction policy, so a `GITHUB_TOKEN=ghp_…` ends up as `GITHUB_TOKEN=«redacted»` if it matches a rule.
+
+### Customising redaction
+
+Provide a YAML file via `--redact <path>`:
+
+```yaml
+# my-redaction.yaml
+rules:
+  - name: internal-id
+    pattern: 'INT-[0-9]{6}'
+```
+
+The custom rules are **merged** with the built-in defaults (which already cover GitHub tokens, AWS keys, JWTs, emails, etc.). The snapshot's `redaction.policy` field records which set was used (`default`, `custom`, or `default+custom`).
+
+## Replaying snapshots
+
+### Model-replay (offline, fast)
+
+The default mode re-checks **internal consistency** without re-running the engine:
+
+- Tool-event `sequence` is strictly `1..N`
+- When `--strict` (default), a grader that reports `passed=true` with `score=0` and non-zero `weight` is surfaced as an inconsistency
+
+```bash
+waza replay ./snapshots/my-task-run1.json
+```
+
+Exit codes: `0` consistent, `1` divergent, `2` load/parse error.
+
+Use `--json` for machine-readable output suitable for CI:
+
+```bash
+waza replay ./snapshots/my-task-run1.json --json
+```
+
+```json
+{
+  "source": "./snapshots/my-task-run1.json",
+  "mode": "model-replay",
+  "pass": true,
+  "status": "passed",
+  "tool_events": 7,
+  "graders": 2
+}
+```
+
+### Bisect two snapshots
+
+Comparing two runs of the same task and locating the first divergent turn:
+
+```bash
+waza replay ./snapshots/a.json --bisect ./snapshots/b.json --json
+```
+
+The diff focuses on the **ordered tool-name/args fingerprint**, ignoring per-call durations and raw output text. This is what catches environment drift (different model versions, prompt-tweaks, fixture mutations) cleanly.
+
+### Live mode (planned, Wave 4)
+
+`--mode live` is reserved for the upcoming adversarial harness: it will re-run the task against the real engine and diff the produced tool events against the snapshot tape, surfacing non-determinism in the engine itself. Today the flag returns exit code `2` with an explanatory message.
+
+## Schema and forward compatibility
+
+The snapshot wire format starts at its own independent `1.0`, separate from `results.json` (`1.2`) and `eval.yaml` (`1.0`).
+
+- MAJOR mismatch is **rejected** at load (`exit 2`).
+- Additive MINOR fields are forward-compatible: a `1.1` snapshot can be replayed by `1.0`-aware tooling, with the extra fields preserved verbatim under the standard json round-tripping rules.
+
+When you author new graders, mocks, or harnesses that touch snapshots, prefer adding fields under the existing branches rather than introducing parallel top-level keys.
+
+## CI patterns
+
+```yaml
+# Capture every task in your nightly run
+- run: waza run eval.yaml --snapshot ./out/snapshots
+
+# In a follow-up job, replay each one and fail on divergence
+- run: |
+    for s in out/snapshots/*.json; do
+      waza replay "$s" --json >> replay-report.ndjson
+    done
+```
+
+For per-PR regression gates, capture a baseline snapshot during the release branch build and bisect each PR's snapshot against it. The bisect output's `first_divergent_turn` field tells reviewers exactly where to look.
+
+## See also
+
+- [`waza replay` CLI reference](/reference/cli/#waza-replay)
+- [`waza run` snapshot flags](/reference/cli/#flags)
+- [Schema versioning policy](/reference/schema-changes/)

--- a/site/src/content/docs/guides/snapshot-replay.mdx
+++ b/site/src/content/docs/guides/snapshot-replay.mdx
@@ -35,7 +35,7 @@ Each `snapshot.json` (schema `1.0`) contains:
 Snapshots **do not** contain:
 
 - Raw environment variables outside the allow-list (default-deny)
-- Secrets that match the built-in or custom redaction rules (replaced with `«redacted»` placeholders)
+- Secrets that match the built-in or custom redaction rules (replaced with `[REDACTED]` placeholders)
 - Live engine outputs not present in the tool-event tape
 
 ## Capturing snapshots
@@ -57,11 +57,11 @@ waza run eval.yaml \
   --snapshot-env-allow "MODEL"
 ```
 
-Even allow-listed values are still passed through the redaction policy, so a `GITHUB_TOKEN=ghp_…` ends up as `GITHUB_TOKEN=«redacted»` if it matches a rule.
+Even allow-listed values are still passed through the redaction policy, so a `GITHUB_TOKEN=ghp_…` ends up as `GITHUB_TOKEN=[REDACTED]` if it matches a rule.
 
 ### Customising redaction
 
-Provide a YAML file via `--redact <path>`:
+Provide a YAML file via `--redact <path>` on `waza run`:
 
 ```yaml
 # my-redaction.yaml

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -95,6 +95,9 @@ waza run [eval.yaml | skill-name | agent-name]
 | `--otel-headers` | | string | | Comma-separated `key=value` OTLP headers (e.g. for auth) |
 | `--otel-file` | | string | | File path for span JSON when `--otel-exporter=file` |
 | `--otel-include-payloads` | | bool | false | Include prompt/tool-arg/tool-result/completion content in spans (default: redacted to `sha256`+length) |
+| `--snapshot` | | string | | Capture a self-contained `snapshot.json` per task to the given directory for later replay. See [`waza replay`](#waza-replay). |
+| `--snapshot-env-allow` | | string[] | | Allow-list of environment variable name patterns to embed in snapshots (default-deny; supports `WAZA_*` wildcards). |
+| `--redact` | | string | | Path to a custom YAML redaction policy applied to snapshot output (merged with the built-in default rules). |
 
 ### Examples
 
@@ -430,6 +433,56 @@ When the input files include the `tool_events[]` array (`results.json` schema 1.
 | `call_count_histogram` | Distribution of per-task call counts in buckets `0`, `1`, `2`, `3+` |
 
 The section is suppressed when none of the compared files contain tool data, so legacy 1.0 results remain unchanged.
+
+## waza replay
+
+Replay a self-contained task snapshot to verify deterministic reproduction. Snapshots are produced by `waza run --snapshot <dir>` and contain the prompt, fixture digests, ordered tool events, environment allow-list, and redacted grader outcomes — everything required to re-derive the run without contacting the engine.
+
+```bash
+waza replay <snapshot.json> [flags]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<snapshot.json>` | Path to a snapshot produced by `waza run --snapshot <dir>` |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--mode` | string | `model-replay` | Replay mode. `model-replay` re-checks internal consistency without contacting the engine. `live` (planned) re-runs against the real engine. |
+| `--bisect` | string | | Path to a second snapshot to compare against the primary. Reports the first divergent turn. |
+| `--json` | bool | false | Emit machine-readable JSON to stdout instead of a human summary. |
+| `--strict` | bool | true | In `model-replay` mode, also re-check final status and grader outcome consistency. |
+| `--redact` | string | | Optional custom YAML redaction policy for re-rendering captured output. |
+
+### Modes
+
+- **`model-replay`** — Re-checks the snapshot's grader outcomes and tool-event tape for internal consistency (monotonic sequence, validation/score agreement). Fast, fully offline, ideal for CI.
+- **`live`** — _Planned for Wave 4._ Re-runs the task against the real engine and diffs the resulting tool events against the snapshot's, ignoring durations and raw text.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Snapshots match / replay succeeded |
+| `1` | Divergence detected (kind/value rendered to stderr or `--json` output) |
+| `2` | Load, parse, schema-version, or I/O error |
+
+### Examples
+
+```bash
+# Capture snapshots during a run
+waza run eval.yaml --snapshot ./snapshots/
+
+# Re-verify a single task's snapshot is internally consistent
+waza replay ./snapshots/my-task-run1.json
+
+# Diff two snapshots and find the first divergent turn (CI-friendly JSON)
+waza replay ./snapshots/run-a.json --bisect ./snapshots/run-b.json --json
+```
 
 ## waza gate
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -456,7 +456,6 @@ waza replay <snapshot.json> [flags]
 | `--bisect` | string | | Path to a second snapshot to compare against the primary. Reports the first divergent turn. |
 | `--json` | bool | false | Emit machine-readable JSON to stdout instead of a human summary. |
 | `--strict` | bool | true | In `model-replay` mode, also re-check final status and grader outcome consistency. |
-| `--redact` | string | | Optional custom YAML redaction policy for re-rendering captured output. |
 
 ### Modes
 


### PR DESCRIPTION
## Summary

Implements **snapshot / replay-from-results** (Wave 3 #367). Adds two commands to the Go CLI:

- `waza run --snapshot <dir>` — writes a self-contained `snapshot.json` per task run, capturing prompt + content-addressed instruction/fixture digests, the ordered tool-event tape from `runs[].tool_events[]`, engine identity, redacted env (default-deny + explicit allow-list), redaction metadata, and the final status + grader validations.
- `waza replay <snapshot.json>` — re-checks a snapshot offline against itself (model-replay mode, default), bisects two snapshots to find the first divergent turn (`--bisect`), or returns a clean "not implemented" stub for Wave 4's live mode (`--mode live`, exit 2).

The replay tape is deliberately designed so the upcoming **#365 adversarial harness** can swap in altered tool results without changing the wire format.

### What's in a snapshot (schema 1.0)

| Section | Contents |
|---|---|
| Identity | `waza_version`, `eval_id`, `eval_name`, `skill`, `task` (TestID, DisplayName, Golden, RunNumber) |
| Prompt | initial + follow-up messages, SHA-256 digests of instruction files |
| Fixtures | recursive SHA-256 digests of every file under `context_dir` |
| Tool events | ordered `tool_call_id`, `name`, `args`, `result`, `duration_ms`, `success`, `error` |
| Engine | model, vendor, runtime identity |
| Env | allow-list + redacted KEY/VALUE pairs (default-deny) |
| Redaction | policy label, matched rule names, redaction count |
| Result | redacted `final_output` / `error_msg`, total duration, grader validations |

Built-in redaction rules cover GitHub tokens, AWS keys, JWTs, emails, etc., and merge additively with `--redact <yaml>`. Even allow-listed env values flow through redaction.

### Other changes

- `results.json` schema **1.1 → 1.2** (additive `RunResult.SnapshotPath`). Migrate command tests updated.
- New `--snapshot`, `--snapshot-env-allow`, `--redact` flags on `waza run`.
- Reuses `cmd/waza`'s existing `*ExitCodeError` so replay propagates `0` / `1` / `2` cleanly through `main.execute()`.

## Test plan

- **Unit (`internal/snapshot`)** — 13 tests: capture, redaction (string + nested maps), env allow-list + default-deny, fixture digesting, schema MAJOR rejection, bisect divergence.
- **CLI integration (`cmd/waza`)** — 7 tests: model-replay pass/fail, `--json`, bisect divergence, bisect match, schema rejection, live-mode stub.
- `go build ./... && go vet ./... && go test ./...` — all clean.
- `golangci-lint run` — **0 issues**.

## Docs

- New `site/src/content/docs/guides/snapshot-replay.mdx` walking through capture, replay, bisect, redaction, and CI patterns.
- `waza replay` section + new flags in `site/src/content/docs/reference/cli.mdx`.
- README All Commands block + dedicated `waza replay <snapshot.json>` subsection.

Closes #367
