### PR TITLE
fix: align check summary table for wide-character skill names

### DIFF
--- a/cmd/waza/cmd_check.go
+++ b/cmd/waza/cmd_check.go
@@ -248,14 +248,14 @@ func printCheckSummaryTable(w interface{ Write([]byte) (int, error) }, reports [
 	// Compute dynamic column width (in terminal display cells) from the longest
 	// skill name. Display width, rather than the rune count, is used so the
 	// column stays aligned with padRight for wide characters (CJK, emoji).
-	nameWidth := len("Skill")
+	nameWidth := runewidth.StringWidth("Skill")
 	for _, r := range reports {
 		n := r.skillName
 		if n == "" {
 			n = "unnamed"
 		}
-		if w := runewidth.StringWidth(n); w > nameWidth {
-			nameWidth = w
+		if width := runewidth.StringWidth(n); width > nameWidth {
+			nameWidth = width
 		}
 	}
 	if nameWidth > maxNameWidth {

--- a/cmd/waza/cmd_check.go
+++ b/cmd/waza/cmd_check.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/mattn/go-runewidth"
 
@@ -246,15 +245,17 @@ func printCheckSummaryTable(w interface{ Write([]byte) (int, error) }, reports [
 	const maxNameWidth = 25
 	const minNameWidth = 10
 
-	// Compute dynamic column width from the longest skill name.
+	// Compute dynamic column width (in terminal display cells) from the longest
+	// skill name. Display width, rather than the rune count, is used so the
+	// column stays aligned with padRight for wide characters (CJK, emoji).
 	nameWidth := len("Skill")
 	for _, r := range reports {
 		n := r.skillName
 		if n == "" {
 			n = "unnamed"
 		}
-		if runeLen := utf8.RuneCountInString(n); runeLen > nameWidth {
-			nameWidth = runeLen
+		if w := runewidth.StringWidth(n); w > nameWidth {
+			nameWidth = w
 		}
 	}
 	if nameWidth > maxNameWidth {
@@ -337,13 +338,15 @@ func printCheckSummaryTable(w interface{ Write([]byte) (int, error) }, reports [
 	fmt.Fprintf(w, "\n") //nolint:errcheck
 }
 
-// truncateName shortens a name to maxLen runes, replacing the last rune with "…" if needed.
+// truncateName shortens a name so that its terminal display width is at most
+// maxLen cells, appending "…" when truncation happens. Display width is used
+// (rather than the rune count) so that wide characters such as CJK and emoji
+// stay aligned with padRight in the summary table.
 func truncateName(name string, maxLen int) string {
-	runes := []rune(name)
-	if len(runes) <= maxLen {
+	if runewidth.StringWidth(name) <= maxLen {
 		return name
 	}
-	return string(runes[:maxLen-1]) + "…"
+	return runewidth.Truncate(name, maxLen, "…")
 }
 
 // padRight pads s with spaces so its terminal display width reaches width.

--- a/cmd/waza/cmd_check_test.go
+++ b/cmd/waza/cmd_check_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/microsoft/waza/cmd/waza/tokens"
 	"github.com/microsoft/waza/internal/scaffold"
 	"github.com/microsoft/waza/internal/scoring"
@@ -689,6 +690,48 @@ func TestPrintCheckSummaryTable_DynamicWidth(t *testing.T) {
 			// The line should have consistent spacing
 			assert.Contains(t, line, "Medium-High")
 		}
+	}
+}
+
+func TestPrintCheckSummaryTable_WideCharAlignment(t *testing.T) {
+	// A skill name with fullwidth (CJK) characters must not break column
+	// alignment. The table pads by terminal display width (see padRight), so the
+	// dynamic name column has to be measured by display width too; otherwise a
+	// wide name overflows its column and shifts every following column right.
+	reports := []*readinessReport{
+		{skillName: "日本語スキル", complianceLevel: "Medium-High", tokenCount: 100, tokenLimit: 500},
+		{skillName: "azure-ai", complianceLevel: "Medium-High", tokenCount: 100, tokenLimit: 500},
+	}
+	var buf bytes.Buffer
+	printCheckSummaryTable(&buf, reports)
+
+	// The display column at which the second column begins must be identical on
+	// the header row ("Compliance") and on every data row ("Medium-High").
+	displayCol := func(line, token string) (int, bool) {
+		idx := strings.Index(line, token)
+		if idx < 0 {
+			return 0, false
+		}
+		return runewidth.StringWidth(line[:idx]), true
+	}
+
+	lines := strings.Split(buf.String(), "\n")
+	var want int
+	found := false
+	for _, line := range lines {
+		if col, ok := displayCol(line, "Compliance"); ok {
+			want, found = col, true
+			break
+		}
+	}
+	require.True(t, found, "header row with the Compliance column was not found")
+
+	for _, line := range lines {
+		if !strings.Contains(line, "Medium-High") {
+			continue
+		}
+		col, _ := displayCol(line, "Medium-High")
+		assert.Equal(t, want, col, "second column misaligned for row %q", line)
 	}
 }
 

--- a/cmd/waza/cmd_check_test.go
+++ b/cmd/waza/cmd_check_test.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"unicode/utf8"
 
 	"github.com/mattn/go-runewidth"
 	"github.com/microsoft/waza/cmd/waza/tokens"
@@ -661,7 +660,7 @@ func TestTruncateName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := truncateName(tt.name, tt.maxLen)
 			assert.Equal(t, tt.want, got)
-			assert.LessOrEqual(t, utf8.RuneCountInString(got), tt.maxLen)
+			assert.LessOrEqual(t, runewidth.StringWidth(got), tt.maxLen)
 		})
 	}
 }
@@ -726,13 +725,17 @@ func TestPrintCheckSummaryTable_WideCharAlignment(t *testing.T) {
 	}
 	require.True(t, found, "header row with the Compliance column was not found")
 
+	dataFound := false
 	for _, line := range lines {
 		if !strings.Contains(line, "Medium-High") {
 			continue
 		}
-		col, _ := displayCol(line, "Medium-High")
+		col, ok := displayCol(line, "Medium-High")
+		require.True(t, ok, "data row with the Compliance column was not found")
 		assert.Equal(t, want, col, "second column misaligned for row %q", line)
+		dataFound = true
 	}
+	require.True(t, dataFound, "no data rows were checked")
 }
 
 func TestCheckCommandJSONOutput(t *testing.T) {


### PR DESCRIPTION
### What

`waza check` prints a summary table that lines its columns up by terminal display width: `padRight` pads with `runewidth.StringWidth`, and the fixed columns are commented as "display columns ... for emoji-safe alignment".

The dynamic "Skill" column does not follow that rule. Its width comes from `utf8.RuneCountInString`, and `truncateName` cuts by rune count. For ASCII one rune is one cell, so it looks fine, but a wide character (CJK, fullwidth) is one rune and two display cells. A skill named for example `日本語スキル` counts as 6 when the column width is chosen and then renders as 12 cells, so the column overflows and every column after it shifts to the right.

### Fix

Measure the column width and truncate with `runewidth.StringWidth` / `runewidth.Truncate`, the same helper `padRight` already uses. ASCII output is unchanged: `runewidth.Truncate("appinsights-instrumentation", 25, "…")` returns the same `appinsights-instrumentat…` that the existing test expects. Wide names now stay inside their column.

### Test

Added `TestPrintCheckSummaryTable_WideCharAlignment`, which asserts that the second column starts at the same display offset on the header row and on a row whose skill name is CJK. It fails before the change (offset 14 vs 12) and passes after. `go vet ./cmd/waza/` and the existing `cmd/waza` table tests stay green.
