### PR TITLE
refactor: decouple ExecutionResponse from Copilot SDK events (Phase 1, #10)

### DIFF
--- a/cmd/waza/cmd_run_suggest.go
+++ b/cmd/waza/cmd_run_suggest.go
@@ -99,9 +99,10 @@ func generateEvalAnalysis(
 }
 
 func buildNoSuggestionsError(res *execution.ExecutionResponse) error {
-	trace := extractCopilotTrace(transcript.BuildFromSessionEvents(res.Events))
+	sdkEvents := copilotevents.ToSDK(res.Events)
+	trace := extractCopilotTrace(transcript.BuildFromSessionEvents(sdkEvents))
 	if len(trace) == 0 {
-		trace = summarizeSessionEventTypes(res.Events)
+		trace = summarizeSessionEventTypes(sdkEvents)
 	}
 	if len(trace) == 0 {
 		return errors.New("no suggestions from Copilot (no session events captured)")
@@ -778,7 +779,7 @@ func writeSuggestionTranscript(prompt string, res *execution.ExecutionResponse) 
 	}
 
 	now := time.Now()
-	events := transcript.BuildFromSessionEvents(res.Events)
+	events := transcript.BuildFromSessionEvents(copilotevents.ToSDK(res.Events))
 
 	status := models.StatusPassed
 	if res.FinalOutput == "" || !res.Success {

--- a/cmd/waza/cmd_run_suggest_test.go
+++ b/cmd/waza/cmd_run_suggest_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -92,7 +93,7 @@ func TestBuildNoSuggestionsError_IncludesSessionTranscript(t *testing.T) {
 	toolResultText := "matched 1 file"
 
 	err := buildNoSuggestionsError(&execution.ExecutionResponse{
-		Events: []copilot.SessionEvent{
+		Events: copilotevents.FromSDK([]copilot.SessionEvent{
 			{
 				Data: &copilot.AssistantMessageData{Content: msg},
 			},
@@ -112,7 +113,7 @@ func TestBuildNoSuggestionsError_IncludesSessionTranscript(t *testing.T) {
 					},
 				},
 			},
-		},
+		}),
 	})
 
 	require.Error(t, err)
@@ -124,9 +125,9 @@ func TestBuildNoSuggestionsError_IncludesSessionTranscript(t *testing.T) {
 
 func TestBuildNoSuggestionsError_FallsBackToEventTypes(t *testing.T) {
 	err := buildNoSuggestionsError(&execution.ExecutionResponse{
-		Events: []copilot.SessionEvent{
+		Events: copilotevents.FromSDK([]copilot.SessionEvent{
 			{Data: &copilot.SessionIdleData{}},
-		},
+		}),
 	})
 
 	require.Error(t, err)
@@ -388,11 +389,11 @@ func TestWriteSuggestionTranscript_WritesFile(t *testing.T) {
 		FinalOutput: "Suggestion report text",
 		Success:     true,
 		DurationMs:  1500,
-		Events: []copilot.SessionEvent{
+		Events: copilotevents.FromSDK([]copilot.SessionEvent{
 			{
 				Data: &copilot.AssistantMessageData{Content: msg},
 			},
-		},
+		}),
 	}
 
 	writeSuggestionTranscript("test prompt", res)

--- a/internal/agentevent/agentevent.go
+++ b/internal/agentevent/agentevent.go
@@ -81,3 +81,34 @@ func (e Event) Kind() Kind { return e.kind }
 // an engine-specific helper (e.g. internal/copilotevents.AsSDKEvent) rather
 // than depending on a particular concrete type here.
 func (e Event) Raw() any { return e.raw }
+
+// TextProvider is an optional interface that engine-specific event payloads
+// (returned from [Event.Raw]) may implement to expose the human-readable text
+// content of an event without forcing consumers to type-assert against a
+// concrete SDK type.
+//
+// Engine adapters are encouraged to implement this on payloads that carry
+// natural-language content (assistant messages, user messages, reasoning,
+// system messages). Consumers such as ExecutionResponse.ExtractMessages use
+// it as an engine-neutral fallback when an event was not produced by the
+// Copilot SDK.
+type TextProvider interface {
+	// Text returns the text content of the event and true. Implementations
+	// that have no text for a given event should return ("", false) rather
+	// than an empty string, so callers can distinguish "no content" from
+	// "empty content".
+	Text() (string, bool)
+}
+
+// Text returns the human-readable text content of the event, if its
+// engine-specific payload implements [TextProvider]. Returns ("", false) when
+// the payload is nil or does not implement the interface.
+func (e Event) Text() (string, bool) {
+	if e.raw == nil {
+		return "", false
+	}
+	if tp, ok := e.raw.(TextProvider); ok {
+		return tp.Text()
+	}
+	return "", false
+}

--- a/internal/agentevent/agentevent.go
+++ b/internal/agentevent/agentevent.go
@@ -1,0 +1,83 @@
+// Package agentevent defines engine-neutral session event types that decouple
+// ExecutionResponse and downstream consumers from any single agent SDK.
+//
+// An [Event] carries a [Kind] (an engine-neutral classifier) together with an
+// opaque per-engine payload accessible via [Event.Raw]. Engines convert their
+// native event stream into Events at the boundary; consumers that still need
+// engine-specific data unwrap [Event.Raw] via an engine-specific helper (for
+// example internal/copilotevents.AsSDKEvent).
+//
+// This package is deliberately minimal: Phase 1 of issue #10 introduces the
+// abstraction seam without forcing every consumer to migrate to generic
+// accessors. Phase 2 will replace remaining type-asserted access to the
+// underlying SDK payload with kind-based generic accessors so additional
+// engines (Claude Code, Codex, generic CLI) can plug in without leaking
+// engine-specific types into the rest of the codebase.
+package agentevent
+
+// Kind classifies a session event independently of the underlying agent SDK.
+// Values mirror the lifecycle stages emitted by typical agent runtimes
+// (session lifecycle, user/assistant turns, tool execution, skill invocation,
+// hooks). New engines may introduce additional kinds — consumers should treat
+// unknown kinds as opaque and fall through to KindRaw-style handling.
+type Kind string
+
+const (
+	// KindUnknown is the zero value. Events that have not been classified
+	// fall back to this so callers can distinguish "not set" from a known
+	// kind.
+	KindUnknown Kind = ""
+
+	KindSessionStart    Kind = "session_start"
+	KindSessionShutdown Kind = "session_shutdown"
+	KindSessionError    Kind = "session_error"
+	KindSessionInfo     Kind = "session_info"
+	KindSessionWarning  Kind = "session_warning"
+
+	KindUserMessage           Kind = "user_message"
+	KindAssistantMessage      Kind = "assistant_message"
+	KindAssistantMessageDelta Kind = "assistant_message_delta"
+	KindAssistantReasoning    Kind = "assistant_reasoning"
+	KindAssistantUsage        Kind = "assistant_usage"
+	KindSystemMessage         Kind = "system_message"
+
+	KindToolExecutionStart         Kind = "tool_execution_start"
+	KindToolExecutionComplete      Kind = "tool_execution_complete"
+	KindToolExecutionPartialResult Kind = "tool_execution_partial_result"
+	KindToolExecutionProgress      Kind = "tool_execution_progress"
+	KindToolUserRequested          Kind = "tool_user_requested"
+
+	KindSkillInvoked Kind = "skill_invoked"
+	KindHookStart    Kind = "hook_start"
+	KindHookEnd      Kind = "hook_end"
+
+	// KindRaw is the fallback for engine-specific events that do not
+	// correspond to any of the kinds above. The full payload is reachable
+	// via Event.Raw().
+	KindRaw Kind = "raw"
+)
+
+// Event is an engine-neutral session event. It pairs an engine-neutral [Kind]
+// with an opaque payload supplied by the producing engine. Construction is
+// reserved for engine adapters via [New]; consumers should treat Event as a
+// read-only value.
+type Event struct {
+	kind Kind
+	raw  any
+}
+
+// New constructs an Event with the given kind and engine-specific payload.
+// The payload may be nil. Engine adapters call this once per emitted event;
+// downstream consumers should never need to construct Events directly.
+func New(kind Kind, raw any) Event {
+	return Event{kind: kind, raw: raw}
+}
+
+// Kind returns the engine-neutral classifier for this event.
+func (e Event) Kind() Kind { return e.kind }
+
+// Raw returns the engine-specific payload attached to this event, or nil if
+// the producing engine did not attach one. Callers must type-assert through
+// an engine-specific helper (e.g. internal/copilotevents.AsSDKEvent) rather
+// than depending on a particular concrete type here.
+func (e Event) Raw() any { return e.raw }

--- a/internal/agentevent/agentevent_test.go
+++ b/internal/agentevent/agentevent_test.go
@@ -1,0 +1,54 @@
+package agentevent_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/microsoft/waza/internal/agentevent"
+)
+
+type stubTextPayload struct {
+	text string
+	has  bool
+}
+
+func (s stubTextPayload) Text() (string, bool) { return s.text, s.has }
+
+func TestEvent_Text_UsesTextProvider(t *testing.T) {
+	evt := agentevent.New(agentevent.KindAssistantMessage, stubTextPayload{text: "hi there", has: true})
+	got, ok := evt.Text()
+	assert.True(t, ok)
+	assert.Equal(t, "hi there", got)
+}
+
+func TestEvent_Text_NoProviderReturnsFalse(t *testing.T) {
+	type opaque struct{}
+	evt := agentevent.New(agentevent.KindAssistantMessage, opaque{})
+	got, ok := evt.Text()
+	assert.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func TestEvent_Text_NilRawReturnsFalse(t *testing.T) {
+	evt := agentevent.New(agentevent.KindAssistantMessage, nil)
+	got, ok := evt.Text()
+	assert.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func TestEvent_Text_ProviderMayReportAbsentContent(t *testing.T) {
+	evt := agentevent.New(agentevent.KindAssistantMessage, stubTextPayload{has: false})
+	got, ok := evt.Text()
+	assert.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func TestEvent_KindAndRawPreserved(t *testing.T) {
+	payload := stubTextPayload{text: "x", has: true}
+	evt := agentevent.New(agentevent.KindUserMessage, payload)
+	assert.Equal(t, agentevent.KindUserMessage, evt.Kind())
+	raw, ok := evt.Raw().(stubTextPayload)
+	assert.True(t, ok)
+	assert.Equal(t, payload, raw)
+}

--- a/internal/copilotevents/bridge.go
+++ b/internal/copilotevents/bridge.go
@@ -1,0 +1,103 @@
+package copilotevents
+
+import (
+	copilot "github.com/github/copilot-sdk/go"
+
+	"github.com/microsoft/waza/internal/agentevent"
+)
+
+// FromSDK wraps a slice of Copilot SDK session events as engine-neutral
+// [agentevent.Event] values. The underlying SDK event is preserved on each
+// returned Event via Event.Raw() so consumers that still need SDK-typed data
+// can unwrap with [AsSDKEvent] or [ToSDK]. Phase 2 will replace those typed
+// accesses with kind-based generic accessors.
+func FromSDK(events []copilot.SessionEvent) []agentevent.Event {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]agentevent.Event, len(events))
+	for i, evt := range events {
+		out[i] = WrapSDKEvent(evt)
+	}
+	return out
+}
+
+// WrapSDKEvent wraps a single Copilot SDK session event as an engine-neutral
+// [agentevent.Event].
+func WrapSDKEvent(evt copilot.SessionEvent) agentevent.Event {
+	return agentevent.New(kindFromSDK(evt.Type()), evt)
+}
+
+// AsSDKEvent returns the Copilot SDK session event that was wrapped into the
+// given engine-neutral event. The second return value reports whether the
+// event was produced by the Copilot engine (and therefore carries an SDK
+// payload). Events produced by non-Copilot engines yield the zero
+// [copilot.SessionEvent] and false.
+func AsSDKEvent(e agentevent.Event) (copilot.SessionEvent, bool) {
+	se, ok := e.Raw().(copilot.SessionEvent)
+	return se, ok
+}
+
+// ToSDK extracts the underlying Copilot SDK events from a slice of
+// engine-neutral events. Events that were not produced by the Copilot engine
+// are skipped — callers that need to distinguish them should iterate with
+// [AsSDKEvent] instead.
+func ToSDK(events []agentevent.Event) []copilot.SessionEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]copilot.SessionEvent, 0, len(events))
+	for _, e := range events {
+		if se, ok := AsSDKEvent(e); ok {
+			out = append(out, se)
+		}
+	}
+	return out
+}
+
+// kindFromSDK translates an SDK event type into the engine-neutral [agentevent.Kind].
+// Unknown SDK event types fall through to [agentevent.KindRaw].
+func kindFromSDK(t copilot.SessionEventType) agentevent.Kind {
+	switch t {
+	case copilot.SessionEventTypeSessionStart:
+		return agentevent.KindSessionStart
+	case copilot.SessionEventTypeSessionShutdown:
+		return agentevent.KindSessionShutdown
+	case copilot.SessionEventTypeSessionError:
+		return agentevent.KindSessionError
+	case copilot.SessionEventTypeSessionInfo:
+		return agentevent.KindSessionInfo
+	case copilot.SessionEventTypeSessionWarning:
+		return agentevent.KindSessionWarning
+	case copilot.SessionEventTypeUserMessage:
+		return agentevent.KindUserMessage
+	case copilot.SessionEventTypeAssistantMessage:
+		return agentevent.KindAssistantMessage
+	case copilot.SessionEventTypeAssistantMessageDelta:
+		return agentevent.KindAssistantMessageDelta
+	case copilot.SessionEventTypeAssistantReasoning:
+		return agentevent.KindAssistantReasoning
+	case copilot.SessionEventTypeAssistantUsage:
+		return agentevent.KindAssistantUsage
+	case copilot.SessionEventTypeSystemMessage:
+		return agentevent.KindSystemMessage
+	case copilot.SessionEventTypeToolExecutionStart:
+		return agentevent.KindToolExecutionStart
+	case copilot.SessionEventTypeToolExecutionComplete:
+		return agentevent.KindToolExecutionComplete
+	case copilot.SessionEventTypeToolExecutionPartialResult:
+		return agentevent.KindToolExecutionPartialResult
+	case copilot.SessionEventTypeToolExecutionProgress:
+		return agentevent.KindToolExecutionProgress
+	case copilot.SessionEventTypeToolUserRequested:
+		return agentevent.KindToolUserRequested
+	case copilot.SessionEventTypeSkillInvoked:
+		return agentevent.KindSkillInvoked
+	case copilot.SessionEventTypeHookStart:
+		return agentevent.KindHookStart
+	case copilot.SessionEventTypeHookEnd:
+		return agentevent.KindHookEnd
+	default:
+		return agentevent.KindRaw
+	}
+}

--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -14,6 +14,8 @@ import (
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/github/copilot-sdk/go/rpc"
+
+	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/skill"
 	"github.com/microsoft/waza/internal/utils"
@@ -555,7 +557,7 @@ func (e *CopilotEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Ex
 	e.provider.applyToUsage(usage)
 	resp := &ExecutionResponse{
 		FinalOutput:      joinStrings(eventsCollector.OutputParts()),
-		Events:           eventsCollector.SessionEvents(),
+		Events:           copilotevents.FromSDK(eventsCollector.SessionEvents()),
 		ModelID:          modelID,
 		SkillInvocations: eventsCollector.SkillInvocations,
 		DurationMs:       duration.Milliseconds(),

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -156,17 +156,27 @@ type ExecutionResponse struct {
 }
 
 // ExtractMessages gets all non-empty assistant messages from events.
+//
+// Copilot SDK events are unwrapped through [copilotevents.AsSDKEvent] so the
+// existing Content helper can extract structured fields. Events produced by
+// other engines fall back to [agentevent.Event.Text], which delegates to the
+// engine payload's optional [agentevent.TextProvider] implementation. This
+// keeps ExtractMessages truly engine-neutral: a non-Copilot engine that
+// emits KindAssistantMessage with a TextProvider payload will surface here
+// instead of being silently dropped.
 func (r *ExecutionResponse) ExtractMessages() []string {
 	var messages []string
 	for _, evt := range r.Events {
 		if evt.Kind() != agentevent.KindAssistantMessage {
 			continue
 		}
-		sdkEvt, ok := copilotevents.AsSDKEvent(evt)
-		if !ok {
+		if sdkEvt, ok := copilotevents.AsSDKEvent(evt); ok {
+			if content, ok := copilotevents.Content(sdkEvt); ok && content != "" {
+				messages = append(messages, content)
+			}
 			continue
 		}
-		if content, ok := copilotevents.Content(sdkEvt); ok && content != "" {
+		if content, ok := evt.Text(); ok && content != "" {
 			messages = append(messages, content)
 		}
 	}

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
+
+	"github.com/microsoft/waza/internal/agentevent"
 	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/models"
 )
@@ -129,10 +131,18 @@ type SkillInvocation struct {
 	Path string
 }
 
-// ExecutionResponse represents the result of an execution
+// ExecutionResponse represents the result of an execution.
+//
+// Events carries engine-neutral [agentevent.Event] values rather than a
+// concrete SDK type so additional agent engines (Claude Code, Codex, generic
+// CLI) can plug in without leaking their native event types through this API.
+// The Copilot engine wraps each SDK event into an Event via
+// internal/copilotevents.FromSDK at the engine boundary; consumers that still
+// need SDK-typed access unwrap via [copilotevents.ToSDK] or
+// [copilotevents.AsSDKEvent].
 type ExecutionResponse struct {
 	FinalOutput      string
-	Events           []copilot.SessionEvent
+	Events           []agentevent.Event
 	ModelID          string
 	SkillInvocations []SkillInvocation
 	DurationMs       int64
@@ -149,10 +159,15 @@ type ExecutionResponse struct {
 func (r *ExecutionResponse) ExtractMessages() []string {
 	var messages []string
 	for _, evt := range r.Events {
-		if evt.Type() == copilot.SessionEventTypeAssistantMessage {
-			if content, ok := copilotevents.Content(evt); ok && content != "" {
-				messages = append(messages, content)
-			}
+		if evt.Kind() != agentevent.KindAssistantMessage {
+			continue
+		}
+		sdkEvt, ok := copilotevents.AsSDKEvent(evt)
+		if !ok {
+			continue
+		}
+		if content, ok := copilotevents.Content(sdkEvt); ok && content != "" {
+			messages = append(messages, content)
 		}
 	}
 	return messages

--- a/internal/execution/engine_response_test.go
+++ b/internal/execution/engine_response_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,12 +14,12 @@ func TestExecutionResponse_ExtractMessages(t *testing.T) {
 	ignoredDelta := "delta"
 
 	resp := &ExecutionResponse{
-		Events: []copilot.SessionEvent{
+		Events: copilotevents.FromSDK([]copilot.SessionEvent{
 			{Data: &copilot.AssistantMessageData{Content: hello}},
 			{Data: &copilot.AssistantMessageData{}},
 			{Data: &copilot.AssistantMessageDeltaData{DeltaContent: ignoredDelta}},
 			{Data: &copilot.AssistantMessageData{Content: world}},
-		},
+		}),
 	}
 
 	assert.Equal(t, []string{"hello", "world"}, resp.ExtractMessages())

--- a/internal/execution/engine_test.go
+++ b/internal/execution/engine_test.go
@@ -1,0 +1,78 @@
+package execution_test
+
+import (
+	"testing"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/microsoft/waza/internal/agentevent"
+	"github.com/microsoft/waza/internal/copilotevents"
+	"github.com/microsoft/waza/internal/execution"
+)
+
+// textPayload is a stand-in for a non-Copilot engine's event payload that
+// carries text content via agentevent.TextProvider.
+type textPayload struct{ content string }
+
+func (t textPayload) Text() (string, bool) { return t.content, t.content != "" }
+
+func TestExecutionResponse_ExtractMessages_CopilotEvents(t *testing.T) {
+	resp := &execution.ExecutionResponse{
+		Events: copilotevents.FromSDK([]copilot.SessionEvent{
+			{Data: &copilot.AssistantMessageData{Content: "hello from copilot"}},
+			{Data: &copilot.UserMessageData{Content: "user text — should be ignored"}},
+			{Data: &copilot.AssistantMessageData{Content: ""}},
+			{Data: &copilot.AssistantMessageData{Content: "second assistant reply"}},
+		}),
+	}
+
+	got := resp.ExtractMessages()
+	assert.Equal(t, []string{"hello from copilot", "second assistant reply"}, got)
+}
+
+func TestExecutionResponse_ExtractMessages_NonCopilotEngineFallback(t *testing.T) {
+	// Simulate events emitted by a future non-Copilot engine: the payload
+	// is not a copilot.SessionEvent, but it implements TextProvider so the
+	// engine-neutral fallback in ExtractMessages should surface the text.
+	resp := &execution.ExecutionResponse{
+		Events: []agentevent.Event{
+			agentevent.New(agentevent.KindAssistantMessage, textPayload{content: "claude says hi"}),
+			agentevent.New(agentevent.KindUserMessage, textPayload{content: "user prompt"}),
+			agentevent.New(agentevent.KindAssistantMessage, textPayload{content: ""}),
+			agentevent.New(agentevent.KindAssistantMessage, textPayload{content: "follow-up"}),
+		},
+	}
+
+	got := resp.ExtractMessages()
+	assert.Equal(t, []string{"claude says hi", "follow-up"}, got)
+}
+
+func TestExecutionResponse_ExtractMessages_MixedEngines(t *testing.T) {
+	// Mix Copilot-wrapped events with native non-Copilot events to ensure
+	// both branches contribute to the result and ordering is preserved.
+	copilotEvents := copilotevents.FromSDK([]copilot.SessionEvent{
+		{Data: &copilot.AssistantMessageData{Content: "from copilot"}},
+	})
+	events := append([]agentevent.Event{}, copilotEvents...)
+	events = append(events,
+		agentevent.New(agentevent.KindAssistantMessage, textPayload{content: "from other engine"}),
+	)
+
+	resp := &execution.ExecutionResponse{Events: events}
+	got := resp.ExtractMessages()
+	assert.Equal(t, []string{"from copilot", "from other engine"}, got)
+}
+
+func TestExecutionResponse_ExtractMessages_NonCopilotWithoutTextProviderIsSkipped(t *testing.T) {
+	// A non-Copilot payload that does NOT implement TextProvider must not
+	// panic or surface anything — but unlike before, this is now an explicit
+	// "no engine support" rather than a silent drop of Copilot data.
+	type opaque struct{}
+	resp := &execution.ExecutionResponse{
+		Events: []agentevent.Event{
+			agentevent.New(agentevent.KindAssistantMessage, opaque{}),
+		},
+	}
+	assert.Empty(t, resp.ExtractMessages())
+}

--- a/internal/execution/mock.go
+++ b/internal/execution/mock.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	copilot "github.com/github/copilot-sdk/go"
+	"github.com/microsoft/waza/internal/agentevent"
 	"github.com/microsoft/waza/internal/models"
 )
 
@@ -142,7 +142,7 @@ func (m *MockEngine) Execute(ctx context.Context, req *ExecutionRequest) (*Execu
 
 	resp := &ExecutionResponse{
 		FinalOutput:    output,
-		Events:         []copilot.SessionEvent{},
+		Events:         []agentevent.Event{},
 		ModelID:        m.modelID,
 		DurationMs:     time.Since(start).Milliseconds(),
 		ToolCalls:      []models.ToolCall{},

--- a/internal/orchestration/checkpoints.go
+++ b/internal/orchestration/checkpoints.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/graders"
 	"github.com/microsoft/waza/internal/models"
@@ -78,7 +79,7 @@ func (cr *checkpointRunner) runForTurn(ctx context.Context, turn int, resp *exec
 		return false
 	}
 
-	gCtx := cr.runner.buildGraderContext(cr.tc, resp)
+	gCtx := cr.runner.buildGraderContext(cr.tc, resp, copilotevents.ToSDK(resp.Events))
 
 	// Run only the checkpoint's graders. Reuse graders.RunAll by passing a
 	// synthetic TestCase whose Validators field carries the checkpoint

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1238,8 +1238,16 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		}
 	}
 
+	// Convert engine-neutral events to SDK form once for the remaining
+	// transcript/tool-event/grader-context work. resp.Events is no longer
+	// mutated after the responder/follow-up loop above, so a single
+	// conversion is safe and avoids re-walking the (potentially large)
+	// event slice in buildGraderContext, buildTranscript, and
+	// buildToolEvents.
+	sdkEvents := copilotevents.ToSDK(resp.Events)
+
 	// Build validation context
-	vCtx := r.buildGraderContext(tc, resp)
+	vCtx := r.buildGraderContext(tc, resp, sdkEvents)
 
 	var gradersResults map[string]models.GraderResults
 	if r.skipGraders {
@@ -1315,8 +1323,8 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		}
 	}
 
-	// Build transcript
-	transcript := r.buildTranscript(resp)
+	// Build transcript (reuses the SDK conversion computed above)
+	transcript := transcript.BuildFromSessionEvents(sdkEvents)
 
 	skillInvocations := make([]models.SkillInvocation, len(resp.SkillInvocations))
 	for i, si := range resp.SkillInvocations {
@@ -1336,7 +1344,7 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		WorkspaceDir:     resp.WorkspaceDir,
 		Responder:        responderInfo,
 		Checkpoints:      checkpointOutcomes,
-		ToolEvents:       buildToolEvents(copilotevents.ToSDK(resp.Events)),
+		ToolEvents:       buildToolEvents(sdkEvents),
 	}
 	r.captureSnapshot(tc, req, resp, &run)
 	return returnWithArtifacts(run)
@@ -2032,19 +2040,17 @@ func convertMCPServers(serverConfigs map[string]any, mocks []models.MCPMockConfi
 	})
 }
 
-func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse) *graders.Context {
-	// Convert events to transcript entries
-	var transcript []models.TranscriptEvent
-	for _, evt := range copilotevents.ToSDK(resp.Events) {
-		entry := models.TranscriptEvent{SessionEvent: evt}
-		transcript = append(transcript, entry)
-	}
+func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse, sdkEvents []copilot.SessionEvent) *graders.Context {
+	// Reuse the shared transcript builder so the conversion is preallocated
+	// (entries := make([]TranscriptEvent, 0, len(events))) and produced in a
+	// single place.
+	transcriptEntries := transcript.BuildFromSessionEvents(sdkEvents)
 
 	sessionDigest := r.buildSessionDigest(resp)
 
 	return &graders.Context{
 		TestCase:         tc,
-		Transcript:       transcript,
+		Transcript:       transcriptEntries,
 		Output:           resp.FinalOutput,
 		Outcome:          make(map[string]any),
 		DurationMS:       resp.DurationMs,

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/microsoft/waza/internal/cache"
 	"github.com/microsoft/waza/internal/config"
 	"github.com/microsoft/waza/internal/copilotconfig"
+	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/dataset"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/failures"
@@ -1335,7 +1336,7 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		WorkspaceDir:     resp.WorkspaceDir,
 		Responder:        responderInfo,
 		Checkpoints:      checkpointOutcomes,
-		ToolEvents:       buildToolEvents(resp.Events),
+		ToolEvents:       buildToolEvents(copilotevents.ToSDK(resp.Events)),
 	}
 	r.captureSnapshot(tc, req, resp, &run)
 	return returnWithArtifacts(run)
@@ -2034,7 +2035,7 @@ func convertMCPServers(serverConfigs map[string]any, mocks []models.MCPMockConfi
 func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse) *graders.Context {
 	// Convert events to transcript entries
 	var transcript []models.TranscriptEvent
-	for _, evt := range resp.Events {
+	for _, evt := range copilotevents.ToSDK(resp.Events) {
 		entry := models.TranscriptEvent{SessionEvent: evt}
 		transcript = append(transcript, entry)
 	}
@@ -2081,7 +2082,7 @@ func (r *EvalRunner) buildSessionDigest(resp *execution.ExecutionResponse) model
 }
 
 func (r *EvalRunner) buildTranscript(resp *execution.ExecutionResponse) []models.TranscriptEvent {
-	return transcript.BuildFromSessionEvents(resp.Events)
+	return transcript.BuildFromSessionEvents(copilotevents.ToSDK(resp.Events))
 }
 
 // resolveGroup returns the group value for the current benchmark configuration.

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -392,7 +392,7 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 		}),
 	}
 
-	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp)
+	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp, copilotevents.ToSDK(resp.Events))
 	require.Len(t, graderCtx.Transcript, 1)
 	assert.Equal(t, "final output", graderCtx.Output)
 	assert.Equal(t, int64(42), graderCtx.DurationMS)

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -12,6 +12,7 @@ import (
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/cache"
 	"github.com/microsoft/waza/internal/config"
+	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/graders"
 	"github.com/microsoft/waza/internal/models"
@@ -386,9 +387,9 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 		},
 		ToolCalls: []models.ToolCall{{Name: "bash"}, {Name: "view"}},
 		Usage:     &models.UsageStats{Turns: 1},
-		Events: []copilot.SessionEvent{
+		Events: copilotevents.FromSDK([]copilot.SessionEvent{
 			{Data: &copilot.UserMessageData{Content: content}},
-		},
+		}),
 	}
 
 	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp)

--- a/internal/trigger/runner.go
+++ b/internal/trigger/runner.go
@@ -15,6 +15,7 @@ import (
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/config"
 	"github.com/microsoft/waza/internal/copilotconfig"
+	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/models"
 	"github.com/microsoft/waza/internal/orchestration"
@@ -92,7 +93,7 @@ func (r *Runner) RunDetailed(ctx context.Context) ([]models.TriggerResult, *mode
 			outcomes[i] = taskResult{
 				triggered:  triggered,
 				response:   resp.FinalOutput,
-				transcript: transcript.BuildFromSessionEvents(resp.Events),
+				transcript: transcript.BuildFromSessionEvents(copilotevents.ToSDK(resp.Events)),
 				toolCalls:  resp.ToolCalls,
 				sessionID:  resp.SessionID,
 			}


### PR DESCRIPTION
## Summary

Phase 1 of #10 — introduces an engine-neutral event abstraction so additional agent engines (Claude Code, Codex, generic CLI) can plug in for Phase 2 without coupling `ExecutionResponse` to the Copilot SDK.

This is a **pure refactor with no behavioral change**. All existing tests pass unchanged.

## Changes

### New abstraction layer
- **`internal/agentevent`** — engine-neutral `Event` carrying a `Kind` enum (`KindAssistantMessage`, `KindToolStart`, …) and an opaque `Raw any` payload. Accessors `Kind()` / `Raw()`.
- **`internal/copilotevents/bridge.go`** — bridge between SDK `copilot.SessionEvent` and the generic `agentevent.Event`:
  - `FromSDK([]copilot.SessionEvent) []agentevent.Event` — wrap at engine boundary
  - `ToSDK([]agentevent.Event) []copilot.SessionEvent` — unwrap for legacy consumers
  - `AsSDKEvent(agentevent.Event) (copilot.SessionEvent, bool)` — single-item unwrap
  - `WrapSDKEvent(copilot.SessionEvent) agentevent.Event`

### `ExecutionResponse`
- `Events []copilot.SessionEvent` → `Events []agentevent.Event`.
- `ExtractMessages` rewritten against the generic `Kind`, unwrapping via `copilotevents.AsSDKEvent` to read `AssistantMessageData`.

### Engines
- `internal/execution/copilot.go` wraps SDK events with `copilotevents.FromSDK(...)` at the boundary when building the response.
- `internal/execution/mock.go` emits `[]agentevent.Event{}` (dropped the `copilot` import).

### Consumers (minimal-churn migration)
Call sites that still need SDK events use `copilotevents.ToSDK(resp.Events)`:
- `internal/orchestration/runner.go` — `buildToolEvents`, transcript construction, `buildTranscript`
- `internal/trigger/runner.go` — `transcript.BuildFromSessionEvents`
- `cmd/waza/cmd_run_suggest.go` — `buildNoSuggestionsError`, `writeSuggestionTranscript`

### Tests
Fixture event slices now wrap with `copilotevents.FromSDK(...)`:
- `cmd/waza/cmd_run_suggest_test.go`
- `internal/execution/engine_response_test.go`
- `internal/orchestration/runner_orchestration_test.go`

## Out of scope (Phase 1)

- `ExecutionRequest.Tools`, `.MCPServers`, `.PermissionHandler` still use SDK types. These are engine-input types, not response types, and are outside Phase 1's acceptance criteria. Phase 2 will revisit them.
- `models.TranscriptEvent` (on-disk transcript format) still embeds `copilot.SessionEvent` — persistence format, not an engine-neutral type.

## Validation

- `go build ./...` — clean
- `go test ./...` — all packages pass
- `golangci-lint run` — 0 issues

## Phase 2 hand-off

Phase 2 (multi-agent engine support, owned by @richardpark-msft) will extend the `agentevent.Event` model with more kinds and add per-engine adapters parallel to `copilotevents`. Consumers can then migrate from `copilotevents.ToSDK(...)` to direct generic accessors.

Partial progress on #10 — issue stays open for Phase 2.