### PR TITLE
feat: add run SSE events

### DIFF
--- a/internal/webapi/events.go
+++ b/internal/webapi/events.go
@@ -1,0 +1,191 @@
+package webapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const liveEventSchemaVersion = "1.0"
+
+// RunEventType identifies a live progress event in a run SSE stream.
+type RunEventType string
+
+const (
+	RunEventStarted       RunEventType = "run_started"
+	RunEventTaskStarted   RunEventType = "task_started"
+	RunEventStepExecuted  RunEventType = "step_executed"
+	RunEventTaskCompleted RunEventType = "task_completed"
+	RunEventCompleted     RunEventType = "run_completed"
+	RunEventFailed        RunEventType = "run_failed"
+)
+
+// RunEvent is the JSON payload sent in each Server-Sent Event.
+type RunEvent struct {
+	SchemaVersion string       `json:"schemaVersion"`
+	Sequence      int64        `json:"sequence"`
+	RunID         string       `json:"runId"`
+	Type          RunEventType `json:"type"`
+	Data          RunEventData `json:"data"`
+	Timestamp     time.Time    `json:"timestamp"`
+}
+
+// RunEventData carries event-specific progress details.
+type RunEventData struct {
+	Spec           string  `json:"spec,omitempty"`
+	Model          string  `json:"model,omitempty"`
+	TaskName       string  `json:"taskName,omitempty"`
+	Outcome        string  `json:"outcome,omitempty"`
+	Score          float64 `json:"score,omitempty"`
+	Duration       float64 `json:"duration,omitempty"`
+	GraderName     string  `json:"graderName,omitempty"`
+	GraderType     string  `json:"graderType,omitempty"`
+	Passed         *bool   `json:"passed,omitempty"`
+	Message        string  `json:"message,omitempty"`
+	TotalTasks     int     `json:"totalTasks,omitempty"`
+	CompletedTasks int     `json:"completedTasks,omitempty"`
+	PassCount      int     `json:"passCount,omitempty"`
+	FailCount      int     `json:"failCount,omitempty"`
+	Tokens         int     `json:"tokens,omitempty"`
+	Cost           float64 `json:"cost,omitempty"`
+}
+
+func runEventsFromDetail(detail *RunDetail) []RunEvent {
+	if detail == nil {
+		return nil
+	}
+
+	base := detail.Timestamp
+	if base.IsZero() {
+		base = time.Unix(0, 0).UTC()
+	}
+
+	var seq int64
+	events := make([]RunEvent, 0, 2+(len(detail.Tasks)*3))
+	appendEvent := func(t RunEventType, data RunEventData) {
+		seq++
+		events = append(events, RunEvent{
+			SchemaVersion: liveEventSchemaVersion,
+			Sequence:      seq,
+			RunID:         detail.ID,
+			Type:          t,
+			Data:          data,
+			Timestamp:     base.Add(time.Duration(seq-1) * time.Millisecond),
+		})
+	}
+
+	appendEvent(RunEventStarted, RunEventData{
+		Spec:       detail.Spec,
+		Model:      detail.Model,
+		TotalTasks: detail.TaskCount,
+		PassCount:  detail.PassCount,
+		FailCount:  detail.TaskCount - detail.PassCount,
+	})
+
+	completed := 0
+	for _, task := range detail.Tasks {
+		appendEvent(RunEventTaskStarted, RunEventData{
+			TaskName:   task.Name,
+			TotalTasks: detail.TaskCount,
+		})
+
+		graders := append([]GraderResult(nil), task.GraderResults...)
+		sort.SliceStable(graders, func(i, j int) bool {
+			return graders[i].Name < graders[j].Name
+		})
+		for _, grader := range graders {
+			passed := grader.Passed
+			appendEvent(RunEventStepExecuted, RunEventData{
+				TaskName:   task.Name,
+				GraderName: grader.Name,
+				GraderType: grader.Type,
+				Passed:     &passed,
+				Score:      grader.Score,
+				Message:    grader.Message,
+			})
+		}
+
+		completed++
+		appendEvent(RunEventTaskCompleted, RunEventData{
+			TaskName:       task.Name,
+			Outcome:        task.Outcome,
+			Score:          task.Score,
+			Duration:       task.Duration,
+			TotalTasks:     detail.TaskCount,
+			CompletedTasks: completed,
+		})
+	}
+
+	eventType := RunEventCompleted
+	if strings.HasPrefix(detail.Outcome, "fail") || strings.HasPrefix(detail.Outcome, "error") {
+		eventType = RunEventFailed
+	}
+	appendEvent(eventType, RunEventData{
+		Outcome:    detail.Outcome,
+		TotalTasks: detail.TaskCount,
+		PassCount:  detail.PassCount,
+		FailCount:  detail.TaskCount - detail.PassCount,
+		Tokens:     detail.Tokens,
+		Cost:       detail.Cost,
+		Duration:   detail.Duration,
+	})
+
+	return events
+}
+
+func filterEventsAfter(events []RunEvent, lastID int64) []RunEvent {
+	if lastID <= 0 {
+		return events
+	}
+	for i, event := range events {
+		if event.Sequence > lastID {
+			return events[i:]
+		}
+	}
+	return nil
+}
+
+func lastEventID(r *http.Request) (int64, error) {
+	raw := r.Header.Get("Last-Event-ID")
+	if queryID := r.URL.Query().Get("lastEventId"); queryID != "" {
+		raw = queryID
+	}
+	if raw == "" {
+		return 0, nil
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id < 0 {
+		return 0, fmt.Errorf("invalid Last-Event-ID %q", raw)
+	}
+	return id, nil
+}
+
+func writeSSEHeaders(w http.ResponseWriter) {
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+}
+
+func writeRunSSEEvent(w io.Writer, event RunEvent) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "id: %d\n", event.Sequence); err != nil {
+		return err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if _, err := fmt.Fprintf(w, "data: %s\n", line); err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprint(w, "\n")
+	return err
+}

--- a/internal/webapi/events.go
+++ b/internal/webapi/events.go
@@ -121,8 +121,12 @@ func runEventsFromDetail(detail *RunDetail) []RunEvent {
 		})
 	}
 
+	if !isTerminalRunDetail(detail) {
+		return events
+	}
+
 	eventType := RunEventCompleted
-	if strings.HasPrefix(detail.Outcome, "fail") || strings.HasPrefix(detail.Outcome, "error") {
+	if isFailureOutcome(detail.Outcome) {
 		eventType = RunEventFailed
 	}
 	appendEvent(eventType, RunEventData{
@@ -136,6 +140,25 @@ func runEventsFromDetail(detail *RunDetail) []RunEvent {
 	})
 
 	return events
+}
+
+func isTerminalRunDetail(detail *RunDetail) bool {
+	if detail == nil {
+		return false
+	}
+	if isFailureOutcome(detail.Outcome) {
+		return true
+	}
+	outcome := strings.ToLower(detail.Outcome)
+	if !strings.HasPrefix(outcome, "pass") {
+		return false
+	}
+	return detail.TaskCount == 0 || len(detail.Tasks) >= detail.TaskCount
+}
+
+func isFailureOutcome(outcome string) bool {
+	outcome = strings.ToLower(outcome)
+	return strings.HasPrefix(outcome, "fail") || strings.HasPrefix(outcome, "error")
 }
 
 func filterEventsAfter(events []RunEvent, lastID int64) []RunEvent {

--- a/internal/webapi/events_test.go
+++ b/internal/webapi/events_test.go
@@ -3,6 +3,7 @@ package webapi
 import (
 	"bufio"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -59,6 +60,20 @@ func TestRunEventsFromDetailMarksFailedRun(t *testing.T) {
 	}
 }
 
+func TestRunEventsFromDetailOmitsTerminalEventForRunningRun(t *testing.T) {
+	detail := sampleRun("run-live", "code-explainer", "gpt-4o", 1, 2, 1000, time.Now())
+	detail.Outcome = "running"
+
+	events := runEventsFromDetail(detail)
+	if len(events) == 0 {
+		t.Fatal("expected non-terminal events")
+	}
+	last := events[len(events)-1]
+	if last.Type == RunEventCompleted || last.Type == RunEventFailed {
+		t.Fatalf("last event type = %q, want non-terminal", last.Type)
+	}
+}
+
 func TestHandleRunEventsStreamsSSE(t *testing.T) {
 	store := newMockStore()
 	store.addRun(sampleRun("run-001", "code-explainer", "gpt-4o", 1, 1, 1000, time.Now()))
@@ -87,6 +102,13 @@ func TestHandleRunEventsStreamsSSE(t *testing.T) {
 	if events[len(events)-1].Type != RunEventCompleted {
 		t.Fatalf("last event = %q, want %q", events[len(events)-1].Type, RunEventCompleted)
 	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "retry: 1000\n\n") {
+		t.Fatal("expected SSE retry directive")
+	}
+	if !strings.Contains(body, "id: 1\n") {
+		t.Fatal("expected event-stream id framing")
+	}
 }
 
 func TestHandleRunEventsReconnectUsesLastEventID(t *testing.T) {
@@ -98,6 +120,29 @@ func TestHandleRunEventsReconnectUsesLastEventID(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/run-001/events", nil)
 	req.Header.Set("Last-Event-ID", "3")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	events := decodeSSEEvents(t, rec.Body.String())
+	if len(events) != 2 {
+		t.Fatalf("expected 2 recovered events, got %d", len(events))
+	}
+	if events[0].Sequence != 4 {
+		t.Fatalf("first recovered sequence = %d, want 4", events[0].Sequence)
+	}
+}
+
+func TestHandleRunEventsReconnectUsesLastEventIDQueryParam(t *testing.T) {
+	store := newMockStore()
+	store.addRun(sampleRun("run-001", "code-explainer", "gpt-4o", 1, 1, 1000, time.Now()))
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/run-001/events?lastEventId=3", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -125,6 +170,90 @@ func TestHandleRunEventsInvalidLastEventID(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleRunEventsRejectsMalformedFallbackPath(t *testing.T) {
+	h := NewHandlers(newMockStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	rec := httptest.NewRecorder()
+	h.HandleRunEvents(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestRunIDFromEventsPathRequiresV1RunEventsShape(t *testing.T) {
+	tests := map[string]string{
+		"/api/v1/runs/run-001/events": "run-001",
+		"/api/v1/runs//events":        "",
+		"/api/events":                 "",
+		"/api/v1/runs/run-001":        "",
+		"/api/v1/runs/a/b/events":     "",
+	}
+
+	for path, want := range tests {
+		if got := runIDFromEventsPath(path); got != want {
+			t.Fatalf("runIDFromEventsPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestHandleRunEventsStreamsNewEventsUntilTerminal(t *testing.T) {
+	oldInterval := runEventsPollInterval
+	runEventsPollInterval = 10 * time.Millisecond
+	defer func() { runEventsPollInterval = oldInterval }()
+
+	first := sampleRun("run-live", "code-explainer", "gpt-4o", 1, 2, 1000, time.Now())
+	first.Outcome = "running"
+	final := sampleRun("run-live", "code-explainer", "gpt-4o", 2, 2, 1000, first.Timestamp)
+	final.Tasks = append(final.Tasks, TaskResult{
+		Name:     "explain-factorial",
+		Outcome:  "passed",
+		Score:    1,
+		Duration: 21,
+		GraderResults: []GraderResult{
+			{
+				Name:    "code_validator",
+				Type:    "code",
+				Passed:  true,
+				Score:   1,
+				Message: "All assertions passed",
+			},
+		},
+	})
+
+	store := newLiveRunStore(first)
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, store)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		store.setRun(final)
+	}()
+
+	resp, err := http.Get(ts.URL + "/api/v1/runs/run-live/events") //nolint:gosec,noctx
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	events := readSSEEventsUntil(t, resp.Body, RunEventCompleted)
+	if len(events) != 8 {
+		t.Fatalf("expected 8 streamed events, got %d", len(events))
+	}
+	if events[4].Sequence != 5 || events[4].Data.TaskName != "explain-factorial" {
+		t.Fatalf("first live delta = sequence %d task %q, want sequence 5 explain-factorial", events[4].Sequence, events[4].Data.TaskName)
+	}
+	if events[len(events)-1].Type != RunEventCompleted {
+		t.Fatalf("last event = %q, want %q", events[len(events)-1].Type, RunEventCompleted)
 	}
 }
 
@@ -185,6 +314,40 @@ func TestHandleRunEventsConcurrentClients(t *testing.T) {
 	}
 }
 
+type liveRunStore struct {
+	mu     sync.RWMutex
+	detail *RunDetail
+}
+
+func newLiveRunStore(detail *RunDetail) *liveRunStore {
+	return &liveRunStore{detail: detail}
+}
+
+func (s *liveRunStore) setRun(detail *RunDetail) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.detail = detail
+}
+
+func (s *liveRunStore) ListRuns(_, _ string) ([]RunSummary, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return []RunSummary{s.detail.RunSummary}, nil
+}
+
+func (s *liveRunStore) GetRun(id string) (*RunDetail, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.detail == nil || s.detail.ID != id {
+		return nil, ErrRunNotFound
+	}
+	return s.detail, nil
+}
+
+func (s *liveRunStore) Summary() (*SummaryResponse, error) {
+	return &SummaryResponse{}, nil
+}
+
 type statusError struct {
 	status int
 }
@@ -225,4 +388,38 @@ func decodeSSEEvents(t *testing.T, body string) []RunEvent {
 	}
 	flush()
 	return events
+}
+
+func readSSEEventsUntil(t *testing.T, r io.Reader, want RunEventType) []RunEvent {
+	t.Helper()
+
+	var events []RunEvent
+	var dataLines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line != "" {
+			if strings.HasPrefix(line, "data: ") {
+				dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+			}
+			continue
+		}
+		if len(dataLines) == 0 {
+			continue
+		}
+		var event RunEvent
+		if err := json.Unmarshal([]byte(strings.Join(dataLines, "\n")), &event); err != nil {
+			t.Fatalf("decode SSE data: %v", err)
+		}
+		events = append(events, event)
+		dataLines = nil
+		if event.Type == want {
+			return events
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan SSE body: %v", err)
+	}
+	t.Fatalf("stream ended before %q event", want)
+	return nil
 }

--- a/internal/webapi/events_test.go
+++ b/internal/webapi/events_test.go
@@ -1,0 +1,228 @@
+package webapi
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunEventsFromDetailGeneratesSequencedLifecycle(t *testing.T) {
+	detail := sampleRun("run-001", "code-explainer", "gpt-4o", 1, 1, 1000, time.Date(2026, 6, 30, 13, 0, 0, 0, time.UTC))
+
+	events := runEventsFromDetail(detail)
+	if len(events) != 5 {
+		t.Fatalf("expected 5 events, got %d", len(events))
+	}
+
+	wantTypes := []RunEventType{
+		RunEventStarted,
+		RunEventTaskStarted,
+		RunEventStepExecuted,
+		RunEventTaskCompleted,
+		RunEventCompleted,
+	}
+	for i, want := range wantTypes {
+		if events[i].Sequence != int64(i+1) {
+			t.Fatalf("event %d sequence = %d, want %d", i, events[i].Sequence, i+1)
+		}
+		if events[i].Type != want {
+			t.Fatalf("event %d type = %q, want %q", i, events[i].Type, want)
+		}
+		if events[i].RunID != "run-001" {
+			t.Fatalf("event %d run id = %q", i, events[i].RunID)
+		}
+	}
+
+	if events[0].Data.TotalTasks != 1 {
+		t.Fatalf("run_started totalTasks = %d, want 1", events[0].Data.TotalTasks)
+	}
+	if events[2].Data.GraderName != "code_validator" {
+		t.Fatalf("step_executed graderName = %q", events[2].Data.GraderName)
+	}
+}
+
+func TestRunEventsFromDetailMarksFailedRun(t *testing.T) {
+	detail := sampleRun("run-002", "code-explainer", "gpt-4o", 0, 1, 1000, time.Now())
+
+	events := runEventsFromDetail(detail)
+	last := events[len(events)-1]
+	if last.Type != RunEventFailed {
+		t.Fatalf("last event type = %q, want %q", last.Type, RunEventFailed)
+	}
+	if last.Data.FailCount != 1 {
+		t.Fatalf("fail count = %d, want 1", last.Data.FailCount)
+	}
+}
+
+func TestHandleRunEventsStreamsSSE(t *testing.T) {
+	store := newMockStore()
+	store.addRun(sampleRun("run-001", "code-explainer", "gpt-4o", 1, 1, 1000, time.Now()))
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/run-001/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("content type = %q, want text/event-stream", got)
+	}
+
+	events := decodeSSEEvents(t, rec.Body.String())
+	if len(events) != 5 {
+		t.Fatalf("expected 5 SSE events, got %d", len(events))
+	}
+	if events[0].Type != RunEventStarted {
+		t.Fatalf("first event = %q, want %q", events[0].Type, RunEventStarted)
+	}
+	if events[len(events)-1].Type != RunEventCompleted {
+		t.Fatalf("last event = %q, want %q", events[len(events)-1].Type, RunEventCompleted)
+	}
+}
+
+func TestHandleRunEventsReconnectUsesLastEventID(t *testing.T) {
+	store := newMockStore()
+	store.addRun(sampleRun("run-001", "code-explainer", "gpt-4o", 1, 1, 1000, time.Now()))
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/run-001/events", nil)
+	req.Header.Set("Last-Event-ID", "3")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	events := decodeSSEEvents(t, rec.Body.String())
+	if len(events) != 2 {
+		t.Fatalf("expected 2 recovered events, got %d", len(events))
+	}
+	if events[0].Sequence != 4 {
+		t.Fatalf("first recovered sequence = %d, want 4", events[0].Sequence)
+	}
+}
+
+func TestHandleRunEventsInvalidLastEventID(t *testing.T) {
+	store := newMockStore()
+	store.addRun(sampleRun("run-001", "code-explainer", "gpt-4o", 1, 1, 1000, time.Now()))
+	h := NewHandlers(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/run-001/events", nil)
+	req.Header.Set("Last-Event-ID", "bad")
+	rec := httptest.NewRecorder()
+	h.HandleRunEvents(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleLatestRunEventsUsesNewestRun(t *testing.T) {
+	store := newMockStore()
+	store.addRun(sampleRun("old", "old-spec", "gpt-4o", 1, 1, 1000, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)))
+	store.addRun(sampleRun("new", "new-spec", "gpt-4o", 1, 1, 1000, time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)))
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	events := decodeSSEEvents(t, rec.Body.String())
+	if len(events) == 0 {
+		t.Fatal("expected events")
+	}
+	if events[0].RunID != "new" {
+		t.Fatalf("legacy stream run id = %q, want new", events[0].RunID)
+	}
+}
+
+func TestHandleRunEventsConcurrentClients(t *testing.T) {
+	store := newMockStore()
+	store.addRun(sampleRun("run-001", "code-explainer", "gpt-4o", 1, 1, 1000, time.Now()))
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, store)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	const clients = 25
+	var wg sync.WaitGroup
+	errCh := make(chan error, clients)
+	for range clients {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := http.Get(ts.URL + "/api/v1/runs/run-001/events") //nolint:gosec,noctx
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer resp.Body.Close() //nolint:errcheck
+			if resp.StatusCode != http.StatusOK {
+				errCh <- &statusError{status: resp.StatusCode}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+type statusError struct {
+	status int
+}
+
+func (e *statusError) Error() string {
+	return "unexpected status " + http.StatusText(e.status)
+}
+
+func decodeSSEEvents(t *testing.T, body string) []RunEvent {
+	t.Helper()
+
+	var events []RunEvent
+	var dataLines []string
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	flush := func() {
+		if len(dataLines) == 0 {
+			return
+		}
+		var event RunEvent
+		if err := json.Unmarshal([]byte(strings.Join(dataLines, "\n")), &event); err != nil {
+			t.Fatalf("decode SSE data: %v", err)
+		}
+		events = append(events, event)
+		dataLines = nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			flush()
+			continue
+		}
+		if strings.HasPrefix(line, "data: ") {
+			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan SSE body: %v", err)
+	}
+	flush()
+	return events
+}

--- a/internal/webapi/handlers.go
+++ b/internal/webapi/handlers.go
@@ -3,6 +3,7 @@ package webapi
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 )
@@ -94,6 +95,74 @@ func (h *Handlers) HandleRunDetail(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, detail)
 }
 
+// HandleRunEvents streams replayable Server-Sent Events for a run.
+func (h *Handlers) HandleRunEvents(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		id = runIDFromEventsPath(r.URL.Path)
+	}
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "run id is required")
+		return
+	}
+
+	lastID, err := lastEventID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	detail, err := h.store.GetRun(id)
+	if err != nil {
+		if errors.Is(err, ErrRunNotFound) {
+			writeError(w, http.StatusNotFound, "run not found")
+		} else {
+			writeError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+
+	events := filterEventsAfter(runEventsFromDetail(detail), lastID)
+	writeSSEHeaders(w)
+	if _, err := fmt.Fprint(w, "retry: 1000\n\n"); err != nil {
+		return
+	}
+	flusher, _ := w.(http.Flusher)
+	if flusher != nil {
+		flusher.Flush()
+	}
+
+	for _, event := range events {
+		select {
+		case <-r.Context().Done():
+			return
+		default:
+		}
+		if err := writeRunSSEEvent(w, event); err != nil {
+			return
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+}
+
+// HandleLatestRunEvents preserves the legacy /api/events stream by replaying
+// the newest run in the same SSE format as the v1 per-run endpoint.
+func (h *Handlers) HandleLatestRunEvents(w http.ResponseWriter, r *http.Request) {
+	runs, err := h.store.ListRuns("timestamp", "desc")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if len(runs) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	r.SetPathValue("id", runs[0].ID)
+	h.HandleRunEvents(w, r)
+}
+
 // HandleStorageStatus returns the current storage configuration status.
 func (h *Handlers) HandleStorageStatus(w http.ResponseWriter, _ *http.Request) {
 	resp := &StorageStatusResponse{
@@ -112,8 +181,10 @@ func RegisterRoutes(mux *http.ServeMux, store RunStore) {
 	h := NewHandlers(store)
 	mux.HandleFunc("GET /api/health", h.HandleHealth)
 	mux.HandleFunc("GET /api/summary", h.HandleSummary)
+	mux.HandleFunc("GET /api/events", h.HandleLatestRunEvents)
 	mux.HandleFunc("GET /api/runs", h.HandleRuns)
 	mux.HandleFunc("GET /api/runs/{id}", h.HandleRunDetail)
+	mux.HandleFunc("GET /api/v1/runs/{id}/events", h.HandleRunEvents)
 	mux.HandleFunc("GET /api/storage/status", h.HandleStorageStatus)
 }
 
@@ -122,8 +193,10 @@ func RegisterRoutesWithStorage(mux *http.ServeMux, store RunStore, cfg *StorageC
 	h := NewHandlersWithStorage(store, cfg)
 	mux.HandleFunc("GET /api/health", h.HandleHealth)
 	mux.HandleFunc("GET /api/summary", h.HandleSummary)
+	mux.HandleFunc("GET /api/events", h.HandleLatestRunEvents)
 	mux.HandleFunc("GET /api/runs", h.HandleRuns)
 	mux.HandleFunc("GET /api/runs/{id}", h.HandleRunDetail)
+	mux.HandleFunc("GET /api/v1/runs/{id}/events", h.HandleRunEvents)
 	mux.HandleFunc("GET /api/storage/status", h.HandleStorageStatus)
 }
 
@@ -141,7 +214,7 @@ func CORSMiddleware(next http.Handler, allowedOrigins ...string) http.Handler {
 		if len(allowedOrigins) > 0 && origin != "" && allowed[origin] {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Last-Event-ID")
 		}
 
 		if r.Method == http.MethodOptions {
@@ -161,4 +234,11 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func writeError(w http.ResponseWriter, code int, msg string) {
 	writeJSON(w, code, ErrorResponse{Error: msg, Code: code})
+}
+
+func runIDFromEventsPath(path string) string {
+	path = strings.TrimPrefix(path, "/api/v1/runs/")
+	path = strings.TrimSuffix(path, "/events")
+	path = strings.Trim(path, "/")
+	return path
 }

--- a/internal/webapi/handlers.go
+++ b/internal/webapi/handlers.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Version is set at build time or defaults to dev.
 var Version = "0.4.0-alpha.1"
+
+var runEventsPollInterval = 250 * time.Millisecond
 
 // Handlers holds the HTTP handler methods for the web API.
 type Handlers struct {
@@ -122,7 +125,6 @@ func (h *Handlers) HandleRunEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	events := filterEventsAfter(runEventsFromDetail(detail), lastID)
 	writeSSEHeaders(w)
 	if _, err := fmt.Fprint(w, "retry: 1000\n\n"); err != nil {
 		return
@@ -132,18 +134,42 @@ func (h *Handlers) HandleRunEvents(w http.ResponseWriter, r *http.Request) {
 		flusher.Flush()
 	}
 
-	for _, event := range events {
+	nextPoll := time.NewTimer(0)
+	defer nextPoll.Stop()
+
+	for {
 		select {
 		case <-r.Context().Done():
 			return
-		default:
+		case <-nextPoll.C:
 		}
-		if err := writeRunSSEEvent(w, event); err != nil {
+
+		events := filterEventsAfter(runEventsFromDetail(detail), lastID)
+		for _, event := range events {
+			if err := writeRunSSEEvent(w, event); err != nil {
+				return
+			}
+			lastID = event.Sequence
+			if flusher != nil {
+				flusher.Flush()
+			}
+			if event.Type == RunEventCompleted || event.Type == RunEventFailed {
+				return
+			}
+		}
+
+		nextPoll.Reset(runEventsPollInterval)
+		select {
+		case <-r.Context().Done():
+			return
+		case <-nextPoll.C:
+		}
+
+		detail, err = h.getRunForEvents(id)
+		if err != nil {
 			return
 		}
-		if flusher != nil {
-			flusher.Flush()
-		}
+		nextPoll.Reset(0)
 	}
 }
 
@@ -237,8 +263,28 @@ func writeError(w http.ResponseWriter, code int, msg string) {
 }
 
 func runIDFromEventsPath(path string) string {
-	path = strings.TrimPrefix(path, "/api/v1/runs/")
-	path = strings.TrimSuffix(path, "/events")
-	path = strings.Trim(path, "/")
-	return path
+	const prefix = "/api/v1/runs/"
+	const suffix = "/events"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return ""
+	}
+	id := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	id = strings.Trim(id, "/")
+	if id == "" || strings.Contains(id, "/") {
+		return ""
+	}
+	return id
+}
+
+type reloadableRunStore interface {
+	Reload() error
+}
+
+func (h *Handlers) getRunForEvents(id string) (*RunDetail, error) {
+	if store, ok := h.store.(reloadableRunStore); ok {
+		if err := store.Reload(); err != nil {
+			return nil, err
+		}
+	}
+	return h.store.GetRun(id)
 }

--- a/site/src/content/docs/guides/dashboard.mdx
+++ b/site/src/content/docs/guides/dashboard.mdx
@@ -76,7 +76,18 @@ Historical metrics over time:
 
 ### Live Updates
 
-Dashboard auto-refreshes when new results are saved:
+The **Live** view uses Server-Sent Events (SSE) to stream run progress from the dashboard API. The per-run endpoint is:
+
+```text
+GET /api/v1/runs/{runId}/events
+Accept: text/event-stream
+```
+
+Each message has an SSE `id` matching the JSON `sequence` field so browsers can reconnect with `Last-Event-ID` and resume after the last event they processed. Event payloads include `schemaVersion`, `runId`, `type`, `timestamp`, and a `data` object. Current event types are `run_started`, `task_started`, `step_executed`, `task_completed`, `run_completed`, and `run_failed`.
+
+The legacy `/api/events` endpoint remains available and replays events for the newest run.
+
+To view progress while iterating locally:
 
 ```bash
 # Terminal 1: Serve dashboard

--- a/site/src/content/docs/guides/dashboard.mdx
+++ b/site/src/content/docs/guides/dashboard.mdx
@@ -83,7 +83,13 @@ GET /api/v1/runs/{runId}/events
 Accept: text/event-stream
 ```
 
-Each message has an SSE `id` matching the JSON `sequence` field so browsers can reconnect with `Last-Event-ID` and resume after the last event they processed. Event payloads include `schemaVersion`, `runId`, `type`, `timestamp`, and a `data` object. Current event types are `run_started`, `task_started`, `step_executed`, `task_completed`, `run_completed`, and `run_failed`.
+Each message has an SSE `id` matching the JSON `sequence` field. Clients can reconnect with the `Last-Event-ID` header, or with the equivalent `lastEventId` query parameter, to resume after the last event they processed:
+
+```text
+GET /api/v1/runs/{runId}/events?lastEventId=42
+```
+
+The stream replays existing events, remains open while the run is still progressing, and closes after `run_completed` or `run_failed`. Event payloads include `schemaVersion`, `runId`, `type`, `timestamp`, and a `data` object. Current event types are `run_started`, `task_started`, `step_executed`, `task_completed`, `run_completed`, and `run_failed`.
 
 The legacy `/api/events` endpoint remains available and replays events for the newest run.
 

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>waza — eval dashboard</title>
-    <script type="module" crossorigin src="/assets/index-TKq7t3qa.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-B61WIPUK.css">
+    <script type="module" crossorigin src="/assets/index-DMRgwpzH.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-SSZPQ-7z.css">
   </head>
   <body class="bg-zinc-900 text-zinc-100 antialiased">
     <div id="root"></div>

--- a/web/e2e/live-view.spec.ts
+++ b/web/e2e/live-view.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from "@playwright/test";
+import { RUNS } from "./fixtures/mock-data";
+
+const liveEvents = [
+  {
+    schemaVersion: "1.0",
+    sequence: 1,
+    runId: "run-001",
+    type: "run_started",
+    data: { totalTasks: 1, spec: "code-explainer", model: "gpt-4o" },
+    timestamp: "2026-06-30T13:00:00Z",
+  },
+  {
+    schemaVersion: "1.0",
+    sequence: 2,
+    runId: "run-001",
+    type: "task_started",
+    data: { taskName: "explain-fibonacci", totalTasks: 1 },
+    timestamp: "2026-06-30T13:00:01Z",
+  },
+  {
+    schemaVersion: "1.0",
+    sequence: 3,
+    runId: "run-001",
+    type: "step_executed",
+    data: {
+      taskName: "explain-fibonacci",
+      graderName: "output-exists",
+      graderType: "code",
+      passed: true,
+      score: 1,
+      message: "Output file found",
+    },
+    timestamp: "2026-06-30T13:00:02Z",
+  },
+  {
+    schemaVersion: "1.0",
+    sequence: 4,
+    runId: "run-001",
+    type: "task_completed",
+    data: {
+      taskName: "explain-fibonacci",
+      outcome: "passed",
+      score: 1,
+      totalTasks: 1,
+      completedTasks: 1,
+    },
+    timestamp: "2026-06-30T13:00:03Z",
+  },
+  {
+    schemaVersion: "1.0",
+    sequence: 5,
+    runId: "run-001",
+    type: "run_completed",
+    data: {
+      outcome: "passed",
+      totalTasks: 1,
+      passCount: 1,
+      failCount: 0,
+      tokens: 12400,
+      cost: 1.24,
+    },
+    timestamp: "2026-06-30T13:00:04Z",
+  },
+];
+
+test.describe("Live View", () => {
+  test("renders progress from run SSE events", async ({ page }) => {
+    await page.route(/\/api\/runs(\?|$)/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(RUNS.slice(0, 1)),
+      }),
+    );
+
+    await page.addInitScript((events) => {
+      class MockEventSource {
+        static readonly CONNECTING = 0;
+        static readonly OPEN = 1;
+        static readonly CLOSED = 2;
+
+        readonly url: string;
+        readyState = MockEventSource.CONNECTING;
+        onopen: ((event: Event) => void) | null = null;
+        onmessage: ((event: MessageEvent<string>) => void) | null = null;
+        onerror: ((event: Event) => void) | null = null;
+
+        constructor(url: string) {
+          this.url = url;
+          setTimeout(() => {
+            this.readyState = MockEventSource.OPEN;
+            this.onopen?.(new Event("open"));
+            for (const event of events) {
+              this.onmessage?.(
+                new MessageEvent("message", {
+                  data: JSON.stringify(event),
+                  lastEventId: String(event.sequence),
+                }),
+              );
+            }
+          }, 0);
+        }
+
+        close() {
+          this.readyState = MockEventSource.CLOSED;
+        }
+
+        addEventListener() {}
+        removeEventListener() {}
+        dispatchEvent() {
+          return true;
+        }
+      }
+
+      window.EventSource = MockEventSource as unknown as typeof EventSource;
+    }, liveEvents);
+
+    await page.goto("/#/live");
+
+    await expect(page.getByRole("heading", { name: "Live" })).toBeVisible();
+    await expect(page.getByText("run_completed")).toBeVisible();
+    await expect(page.getByText("Run complete — 1/1 passed")).toBeVisible();
+    await expect(page.getByText("step_executed")).toBeVisible();
+    await expect(page.getByText("output-exists [code]: ✓ Output file found")).toBeVisible();
+    await expect(page.getByText("12.4K")).toBeVisible();
+  });
+});

--- a/web/e2e/live-view.spec.ts
+++ b/web/e2e/live-view.spec.ts
@@ -64,6 +64,12 @@ const liveEvents = [
   },
 ];
 
+declare global {
+  interface Window {
+    __eventSourceUrls: string[];
+  }
+}
+
 test.describe("Live View", () => {
   test("renders progress from run SSE events", async ({ page }) => {
     await page.route(/\/api\/runs(\?|$)/, (route) =>
@@ -75,6 +81,8 @@ test.describe("Live View", () => {
     );
 
     await page.addInitScript((events) => {
+      window.__eventSourceUrls = [];
+
       class MockEventSource {
         static readonly CONNECTING = 0;
         static readonly OPEN = 1;
@@ -88,6 +96,7 @@ test.describe("Live View", () => {
 
         constructor(url: string) {
           this.url = url;
+          window.__eventSourceUrls.push(url);
           setTimeout(() => {
             this.readyState = MockEventSource.OPEN;
             this.onopen?.(new Event("open"));
@@ -118,6 +127,9 @@ test.describe("Live View", () => {
 
     await page.goto("/#/live");
 
+    await expect
+      .poll(() => page.evaluate(() => window.__eventSourceUrls[0] ?? ""))
+      .toBe("/api/v1/runs/run-001/events");
     await expect(page.getByRole("heading", { name: "Live" })).toBeVisible();
     await expect(page.getByText("run_completed")).toBeVisible();
     await expect(page.getByText("Run complete — 1/1 passed")).toBeVisible();

--- a/web/src/components/LiveView.tsx
+++ b/web/src/components/LiveView.tsx
@@ -53,6 +53,12 @@ function ProgressBar({ completed, total }: { completed: number; total: number })
 
 function EventBadge({ type }: { type: SSEEvent["type"] }) {
   const styles: Record<string, string> = {
+    run_started: "bg-blue-500/10 text-blue-400",
+    task_started: "bg-blue-500/10 text-blue-400",
+    step_executed: "bg-purple-500/10 text-purple-400",
+    task_completed: "bg-green-500/10 text-green-400",
+    run_completed: "bg-yellow-500/10 text-yellow-400",
+    run_failed: "bg-red-500/10 text-red-400",
     task_start: "bg-blue-500/10 text-blue-400",
     task_complete: "bg-green-500/10 text-green-400",
     grader_result: "bg-purple-500/10 text-purple-400",
@@ -73,15 +79,25 @@ function EventCard({ event }: { event: SSEEvent }) {
   const d = event.data;
 
   switch (event.type) {
+    case "run_started":
+      description = `Run started — ${d.totalTasks ?? 0} task${d.totalTasks === 1 ? "" : "s"}`;
+      break;
+    case "task_started":
     case "task_start":
       description = `Started task: ${d.taskName ?? "unknown"}`;
       break;
+    case "task_completed":
     case "task_complete":
       description = `${d.taskName ?? "task"} → ${d.outcome ?? "done"}${d.score != null ? ` (${Math.round(d.score * 100)}%)` : ""}`;
       break;
+    case "step_executed":
     case "grader_result":
       description = `${d.graderName ?? "grader"} [${d.graderType ?? ""}]: ${d.passed ? "✓" : "✗"} ${d.message ?? ""}`;
       break;
+    case "run_failed":
+      description = `Run failed — ${d.passCount ?? 0}/${d.totalTasks ?? 0} passed`;
+      break;
+    case "run_completed":
     case "run_complete":
       description = `Run complete — ${d.passCount ?? 0}/${d.totalTasks ?? 0} passed`;
       break;

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { fetchRuns } from "../api/client";
 
 export interface SSEEventData {
+  spec?: string;
+  model?: string;
   taskName?: string;
   outcome?: string;
   score?: number;
@@ -10,14 +13,28 @@ export interface SSEEventData {
   passed?: boolean;
   message?: string;
   totalTasks?: number;
+  completedTasks?: number;
   passCount?: number;
+  failCount?: number;
   tokens?: number;
   cost?: number;
 }
 
 export interface SSEEvent {
   schemaVersion?: string;
-  type: "task_start" | "task_complete" | "grader_result" | "run_complete";
+  sequence?: number;
+  runId?: string;
+  type:
+    | "run_started"
+    | "task_started"
+    | "step_executed"
+    | "task_completed"
+    | "run_completed"
+    | "run_failed"
+    | "task_start"
+    | "task_complete"
+    | "grader_result"
+    | "run_complete";
   data: SSEEventData;
   timestamp: string;
 }
@@ -39,6 +56,7 @@ interface UseSSEReturn {
   currentRun: LiveRun | null;
   completedTasks: string[];
   events: SSEEvent[];
+  runId: string | null;
 }
 
 const MAX_EVENTS = 200;
@@ -50,6 +68,7 @@ export function useSSE(): UseSSEReturn {
   const [currentRun, setCurrentRun] = useState<LiveRun | null>(null);
   const [completedTasks, setCompletedTasks] = useState<string[]>([]);
   const [events, setEvents] = useState<SSEEvent[]>([]);
+  const [runId, setRunId] = useState<string | null>(null);
   const retryCount = useRef(0);
   const esRef = useRef<EventSource | null>(null);
   const currentRunRef = useRef<LiveRun | null>(null);
@@ -69,6 +88,22 @@ export function useSSE(): UseSSEReturn {
     setEvents((prev) => [event, ...prev].slice(0, MAX_EVENTS));
 
     switch (event.type) {
+      case "run_started":
+        setCompletedTasks([]);
+        updateCurrentRun(() => ({
+          totalTasks: event.data.totalTasks ?? 0,
+          completedTasks: event.data.completedTasks ?? 0,
+          passCount: 0,
+          failCount: 0,
+          tokens: 0,
+          cost: 0,
+          currentTask: null,
+          startTime: new Date(event.timestamp).getTime(),
+          done: false,
+        }));
+        break;
+
+      case "task_started":
       case "task_start":
         if (!currentRunRef.current || currentRunRef.current.done) {
           setCompletedTasks([]);
@@ -93,10 +128,11 @@ export function useSSE(): UseSSEReturn {
         });
         break;
 
+      case "task_completed":
       case "task_complete":
         updateCurrentRun((prev) => {
           if (!prev) return prev;
-          const passed = event.data.outcome === "pass";
+          const passed = event.data.outcome?.startsWith("pass") ?? false;
           return {
             ...prev,
             completedTasks: prev.completedTasks + 1,
@@ -110,17 +146,24 @@ export function useSSE(): UseSSEReturn {
         }
         break;
 
+      case "step_executed":
       case "grader_result":
         // Informational — no state change needed
         break;
 
+      case "run_failed":
+      case "run_completed":
       case "run_complete":
         updateCurrentRun((prev) => {
           if (!prev) return prev;
+          const totalTasks = event.data.totalTasks ?? prev.totalTasks;
+          const passCount = event.data.passCount ?? prev.passCount;
           return {
             ...prev,
-            totalTasks: event.data.totalTasks ?? prev.totalTasks,
-            passCount: event.data.passCount ?? prev.passCount,
+            totalTasks,
+            completedTasks: event.data.completedTasks ?? totalTasks,
+            passCount,
+            failCount: event.data.failCount ?? Math.max(totalTasks - passCount, 0),
             tokens: event.data.tokens ?? prev.tokens,
             cost: event.data.cost ?? prev.cost,
             currentTask: null,
@@ -133,12 +176,39 @@ export function useSSE(): UseSSEReturn {
 
   useEffect(() => {
     let cancelled = false;
+
+    async function loadLatestRun() {
+      try {
+        const runs = await fetchRuns("timestamp", "desc");
+        if (!cancelled) {
+          setRunId(runs[0]?.id ?? null);
+        }
+      } catch (error) {
+        console.warn("Failed to load latest run for live events", error);
+        if (!cancelled) setIsConnected(false);
+      }
+    }
+
+    void loadLatestRun();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!runId) return;
+    const currentRunId = runId;
+
+    let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
 
     function connect() {
       if (cancelled) return;
 
-      const es = new EventSource("/api/events");
+      const es = new EventSource(
+        `/api/v1/runs/${encodeURIComponent(currentRunId)}/events`,
+      );
       esRef.current = es;
 
       es.onopen = () => {
@@ -152,8 +222,17 @@ export function useSSE(): UseSSEReturn {
         try {
           const parsed = JSON.parse(msg.data) as SSEEvent;
           processEvent(parsed);
-        } catch {
-          // ignore malformed events
+          if (
+            parsed.type === "run_completed" ||
+            parsed.type === "run_failed" ||
+            parsed.type === "run_complete"
+          ) {
+            es.close();
+            esRef.current = null;
+            setIsConnected(false);
+          }
+        } catch (error) {
+          console.warn("Failed to parse live event", error);
         }
       };
 
@@ -183,7 +262,7 @@ export function useSSE(): UseSSEReturn {
       }
       setIsConnected(false);
     };
-  }, [processEvent]);
+  }, [processEvent, runId]);
 
-  return { isConnected, currentRun, completedTasks, events };
+  return { isConnected, currentRun, completedTasks, events, runId };
 }

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -72,6 +72,7 @@ export function useSSE(): UseSSEReturn {
   const retryCount = useRef(0);
   const esRef = useRef<EventSource | null>(null);
   const currentRunRef = useRef<LiveRun | null>(null);
+  const lastEventIdRef = useRef<string | null>(null);
 
   const updateCurrentRun = useCallback(
     (updater: (prev: LiveRun | null) => LiveRun | null) => {
@@ -199,6 +200,7 @@ export function useSSE(): UseSSEReturn {
   useEffect(() => {
     if (!runId) return;
     const currentRunId = runId;
+    lastEventIdRef.current = null;
 
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -206,9 +208,11 @@ export function useSSE(): UseSSEReturn {
     function connect() {
       if (cancelled) return;
 
-      const es = new EventSource(
-        `/api/v1/runs/${encodeURIComponent(currentRunId)}/events`,
-      );
+      const baseURL = `/api/v1/runs/${encodeURIComponent(currentRunId)}/events`;
+      const url = lastEventIdRef.current
+        ? `${baseURL}?lastEventId=${encodeURIComponent(lastEventIdRef.current)}`
+        : baseURL;
+      const es = new EventSource(url);
       esRef.current = es;
 
       es.onopen = () => {
@@ -222,6 +226,8 @@ export function useSSE(): UseSSEReturn {
         try {
           const parsed = JSON.parse(msg.data) as SSEEvent;
           processEvent(parsed);
+          lastEventIdRef.current =
+            msg.lastEventId || parsed.sequence?.toString() || lastEventIdRef.current;
           if (
             parsed.type === "run_completed" ||
             parsed.type === "run_failed" ||


### PR DESCRIPTION
## Summary
- Add `/api/v1/runs/{runId}/events` Server-Sent Events stream with sequenced replay and `Last-Event-ID`/`lastEventId` recovery support
- Preserve legacy `/api/events` by replaying the newest run in the same SSE format
- Wire Live View to the per-run SSE stream and cover it with a Playwright integration test
- Document the Live View SSE endpoint and event schema

Closes #178

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Validation
- `go test ./...`
- `npm run build` in `web/`
- `npx playwright test e2e/live-view.spec.ts --project=chromium` in `web/`
- `npm run build` in `site/`
- `golangci-lint run ./internal/webapi ./internal/webserver`

Note: `make lint` currently fails on stale paths from a different local worktree (`../spboyer-glowing-goggles`), while the changed Go packages lint cleanly.