### PR TITLE
docs: v0.38.0 feature coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-06-30
+
+### Added
+
+- **Focused eval suggestions** — `waza suggest` now supports targeted generation with `--count`, `--focus`, `--dry-run`, `--apply`, and `--force` (#357, #380)
+- **Per-turn checkpoint graders** — Task YAML can run inline graders after specific conversation turns with `checkpoints[]` and `on_failure` policies (#358, #386)
+- **Rubric preset library** — Prompt graders can reuse built-in rubric presets for common judge dimensions; no separate `waza rubric` subcommand ships in this release (#360, #381)
+- **Spec verification** — Added `waza spec verify` to report eval coverage against `SKILL.md` requirements (#361, #385)
+- **OpenTelemetry trace export** — Added `waza run --otel-exporter`, `--otel-endpoint`, `--otel-headers`, `--otel-file`, and `--otel-include-payloads` (#362, #383)
+- **MCP server mocks** — Added eval-level `mcp_mocks:` for hermetic Copilot SDK tool-call evals (#363, #387)
+- **Regression gates** — Added `waza gate` with stable exit codes for pass, regression, golden failure, and config errors (#364, #384)
+- **Adversarial harness** — Added `waza adversarial` and eval-level `adversarial:` pack configuration for prompt-injection and scope-bypass checks (#365, #392)
+- **Tool metrics and structured argument matchers** — Results now include normalized `tool_events[]`; tool graders can assert structured argument matchers through `expect_tools[].args` and `tool_calls.expect[].args` (#366, #388)
+- **Snapshot and replay** — Added `waza run --snapshot` and `waza replay` with a self-contained snapshot artifact format (#367, #391)
+- **Schema version policy** — Documented and enforced MAJOR.MINOR `schemaVersion` compatibility for public artifacts (#368, #382)
+- **Dashboard SSE resume** — Added `Last-Event-ID` / `lastEventId` resume support for dashboard event streams, including legacy `/api/events` (#178, #397)
+
+### Changed
+
+- **Phase 1 internal refactor** — Internal cleanup with no user-facing CLI, schema, or site behavior changes (#10)
+
 ## [0.37.0] - 2026-06-18
 
 ### Added
@@ -533,7 +554,8 @@ pip install waza
 - YAML escaping for regex patterns with backslashes
 - Progress bar now shows 100% on completion
 
-[Unreleased]: https://github.com/microsoft/waza/compare/v0.37.0...HEAD
+[Unreleased]: https://github.com/microsoft/waza/compare/v0.38.0...HEAD
+[0.38.0]: https://github.com/microsoft/waza/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/microsoft/waza/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/microsoft/waza/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/microsoft/waza/compare/v0.34.0...v0.35.0

--- a/README.md
+++ b/README.md
@@ -1007,7 +1007,7 @@ skills/                Example skills
 ```yaml
 name: my-eval
 skill: my-skill
-schemaVersion: "1.1"
+schemaVersion: "1.2"
 version: "1.0"
 
 config:
@@ -1099,9 +1099,9 @@ tasks:
 # range: [1, 10]  # Only include rows 1-10 (0-indexed, skips header)
 ```
 
-`schemaVersion` uses `MAJOR.MINOR` format. Missing values are interpreted as the current schema version (currently `1.1`). Readers allow same-major minor additions with warnings for unknown fields, but reject different majors with a hint to run `waza migrate <file>`.
+`schemaVersion` uses `MAJOR.MINOR` format. Missing values are interpreted as the current schema version (currently `1.2`). Readers allow same-major minor additions with warnings for unknown fields, but reject different majors with a hint to run `waza migrate <file>`.
 
-`results.json` is currently emitted at `schemaVersion` `1.1`, which adds per-turn checkpoints (`runs[].checkpoints[]`, see #358) and the normalized `runs[].tool_events[]` array (`turn`, `sequence`, `tool_call_id`, `tool_name`, `args`, `result`, `success`, `error`, `duration_ms`; see #366). See [docs/PRD](docs/PRD.md) and [schema-changes](site/src/content/docs/reference/schema-changes.md) for details.
+`results.json` is currently emitted at `schemaVersion` `1.2`. Version `1.1` added per-turn checkpoints (`runs[].checkpoints[]`, see #358) and the normalized `runs[].tool_events[]` array (`turn`, `sequence`, `tool_call_id`, `tool_name`, `args`, `result`, `success`, `error`, `duration_ms`; see #366). Version `1.2` adds `runs[].snapshot_path` for `waza run --snapshot` artifacts (#367) and the eval-level `adversarial:` block consumed by `waza adversarial --spec` (#365). See [docs/PRD](docs/PRD.md) and [schema-changes](site/src/content/docs/reference/schema-changes.md) for details.
 
 ### MCP Mock Servers
 
@@ -1115,6 +1115,21 @@ mcp_mocks:
 ```
 
 Inline responses support exact full-argument matching (`match`), JSON Schema matching (`match_schema`), and per-field regex matching (`match_regex`). Unknown tools and unmatched calls fail loudly with an MCP tool error that names the missing fixture.
+
+### Adversarial Packs
+
+Use top-level `adversarial` with `schemaVersion: "1.2"` to pin built-in fault-injection packs for `waza adversarial --spec`:
+
+```yaml
+schemaVersion: "1.2"
+adversarial:
+  packs:
+    - prompt-injection
+    - scope-bypass
+  on_unsafe_outcome: fail
+```
+
+`on_unsafe_outcome: warn` records unsafe outcomes without failing the command.
 
 ### Custom Input Variables
 

--- a/docs/graders/tool_constraint.md
+++ b/docs/graders/tool_constraint.md
@@ -15,6 +15,8 @@ Validates which tools an agent used (or avoided).
         skill_pattern: "my-skill"      # optional regex on the skill argument
       - tool: "edit"                   # match tool name only (any args)
         path_pattern: "\\.go$"         # optional regex on the path argument
+        args:
+          path: { regex: "^src/" }     # structured matcher on arbitrary args
     reject_tools:
       - tool: "bash"
         command_pattern: "rm\\s+-rf"
@@ -34,8 +36,19 @@ Validates which tools an agent used (or avoided).
 | `command_pattern` | str  | no       | Regex matched against the `command` argument (e.g. bash/powershell).  |
 | `skill_pattern`   | str  | no       | Regex matched against the `skill` argument (skill invocations).       |
 | `path_pattern`    | str  | no       | Regex matched against the `path` argument (file-based tools).         |
+| `args`            | map  | no       | Structured argument matchers keyed by argument name.                  |
 
 At least one option must be configured.
+
+`args` supports the same structured matchers used by the `tool_calls` grader:
+
+| Matcher | Meaning |
+|---------|---------|
+| `equals` | Deep equality with the supplied value |
+| `regex` | RE2 match against the stringified argument |
+| `contains` | Substring match against the stringified argument |
+| `range` | Numeric bounds with `gte`, `lte`, `gt`, or `lt` |
+| `json_schema` | JSON Schema validation for the argument value |
 
 **Scoring:** `passed_checks / total_checks`
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -49,6 +49,9 @@ export default defineConfig({
 						{ label: 'Explore the Dashboard', slug: 'guides/dashboard-explore' },
 						{ label: 'CI/CD Integration', slug: 'guides/ci-cd' },
 						{ label: 'OpenTelemetry Tracing', slug: 'guides/otel' },
+						{ label: 'Adversarial Harness', slug: 'guides/adversarial' },
+						{ label: 'Snapshot & Replay', slug: 'guides/snapshot-replay' },
+						{ label: 'Azure Storage', slug: 'guides/azure-storage' },
 					],
 				},
 				{

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -59,6 +59,7 @@ tasks:
 | `tasks_from`  | string | ✗        | Path to an external YAML file containing the task list                                     |
 | `hooks`       | object | ✗        | Lifecycle hooks that run shell commands at specific points (see [Hooks](#hooks))           |
 | `mcp_mocks`   | array  | ✗        | Hermetic MCP server mocks for deterministic tool-call evals; requires `schemaVersion: "1.1"` |
+| `adversarial` | object | ✗        | Built-in fault-injection packs consumed by `waza adversarial --spec`; requires `schemaVersion: "1.2"` |
 | `baseline`    | bool   | ✗        | Mark this spec as a baseline for A/B comparison                                            |
 
 `skill` is required.
@@ -222,6 +223,21 @@ mcp_mocks:
 ```
 
 Each `.json` fixture can either contain a single tool definition (tool name from the filename) or a `{ "tools": { ... } }` object with multiple tools.
+
+## Adversarial Packs
+
+Use top-level `adversarial` to pin the built-in fault-injection packs and unsafe-outcome policy for `waza adversarial --spec`. This is additive in `schemaVersion: "1.2"` and is ignored by normal `waza run` executions.
+
+```yaml
+schemaVersion: "1.2"
+adversarial:
+  packs:
+    - prompt-injection
+    - scope-bypass
+  on_unsafe_outcome: fail  # or "warn"
+```
+
+`packs` must name one or more built-in packs. In v0.38.0 those are `prompt-injection` and `scope-bypass`. `on_unsafe_outcome: fail` exits 2 when an unsafe outcome is observed; `warn` records the unsafe result but exits 0. See the [Adversarial Harness guide](/guides/adversarial/) for pack behavior and CI examples.
 
 ## Graders Section
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -1302,6 +1302,8 @@ A newer version of waza is available: v0.24.0 → v0.28.0. Run: curl -fsSL ... |
 | `WAZA_CACHE` | Cache directory (default: `.waza-cache`) |
 | `WAZA_NO_UPDATE_CHECK` | Set to `1` to disable automatic version check |
 
+OpenTelemetry export is configured with the `waza run --otel-*` flags. v0.38.0 does not read `WAZA_OTEL_*` environment variables.
+
 When a custom provider is active, usage output labels the SDK request counter as `Provider Requests` instead of `Premium Requests`. Result JSON records `usage.provider: "custom"` and a sanitized `usage.provider_host`; the full provider URL is not stored.
 
 ## Next Steps

--- a/site/src/content/docs/reference/releases.mdx
+++ b/site/src/content/docs/reference/releases.mdx
@@ -5,7 +5,34 @@ description: Download waza binaries and the azd extension. Changelog highlights 
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-## Current Release: v0.35.0
+## Current Release: v0.38.0
+
+**Released:** 2026-06-30
+
+### What's New
+
+#### Added
+
+- **Focused eval suggestions** — `waza suggest` can target specific coverage gaps with `--count`, `--focus`, `--dry-run`, `--apply`, and `--force` (#357, #380).
+- **Per-turn checkpoint graders** — Task YAML can assert intermediate multi-turn state with `checkpoints[]` (#358, #386).
+- **Rubric preset library** — Prompt graders can reuse built-in rubrics for groundedness, helpfulness, instruction following, refusal correctness, and tool-use appropriateness (#360, #381).
+- **Spec verification** — `waza spec verify` checks that eval tasks cover the executable contract in `SKILL.md` (#361, #385).
+- **OpenTelemetry export** — `waza run --otel-*` flags export eval, task, turn, model-call, and tool-call spans (#362, #383).
+- **MCP server mocks** — `eval.yaml` can define `mcp_mocks:` for hermetic Copilot SDK evals (#363, #387).
+- **Regression gates** — `waza gate` compares current results with a baseline and exits 0/1/2/3 for pass, regression, golden failure, or config error (#364, #384).
+- **Adversarial harness** — `waza adversarial` runs prompt-injection and scope-bypass packs, optionally configured by `adversarial:` in eval YAML (#365, #392).
+- **Tool metrics and argument matchers** — Results include normalized `tool_events[]`; graders can use structured `expect_tools[].args` and `tool_calls.expect[].args` matchers (#366, #388).
+- **Snapshot and replay** — `waza run --snapshot` captures task snapshots and `waza replay` checks them offline or bisects divergent runs (#367, #391).
+- **Schema semver policy** — `schemaVersion` uses MAJOR.MINOR compatibility rules, documented in the schema changelog (#368, #382).
+- **Dashboard SSE resume** — `/api/v1/runs/{runId}/events` and legacy `/api/events` support `Last-Event-ID` and `lastEventId` resume (#178, #397).
+
+#### Changed
+
+- **Internal refactor** — Phase 1 internal cleanup landed without user-facing CLI or schema changes (#10).
+
+---
+
+## Previous highlighted release: v0.35.0
 
 **Released:** 2026-06-06
 
@@ -17,18 +44,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - **Model-aware dashboard pricing** — Dashboard cost calculation applies per-model pricing for more accurate run costs.
 - **Git worktree resources in task inputs** — Tasks can reference git worktree resources as inputs.
 
-#### Fixed
-
-- **BYOK + `--model` startup arg** — The Copilot CLI validates startup `--model` against the Copilot catalog before BYOK provider config is applied, so provider-only model IDs would fail. The `--model` startup arg is now skipped when a BYOK provider is configured.
-- **Model override propagation** — `--model` is passed via `CLIArgs` so it correctly overrides user settings and experiment flights.
-- **Copilot CLI PATH fallback** — Prevented silent fallback to a Copilot CLI on `PATH` when the bundled binary is unavailable.
-- **Installer latest-release selection** — Installer correctly selects the latest standalone waza release.
-- **Skill best practices doc link** — Fixed the broken skill best practices reference.
-
-#### Changed
-
-- **AgentEngine cancellation** — Simplified `AgentEngine` cancellation handling around caller contexts for more predictable shutdown semantics.
-
 ---
 
 ## Download Binaries
@@ -37,12 +52,12 @@ Pre-built binaries for all major platforms:
 
 | Platform | Architecture | Download |
 |----------|-------------|----------|
-| macOS | Apple Silicon (ARM64) | [waza-darwin-arm64](https://github.com/microsoft/waza/releases/download/v0.35.0/waza-darwin-arm64) |
-| macOS | Intel (AMD64) | [waza-darwin-amd64](https://github.com/microsoft/waza/releases/download/v0.35.0/waza-darwin-amd64) |
-| Linux | x64 (AMD64) | [waza-linux-amd64](https://github.com/microsoft/waza/releases/download/v0.35.0/waza-linux-amd64) |
-| Linux | ARM64 | [waza-linux-arm64](https://github.com/microsoft/waza/releases/download/v0.35.0/waza-linux-arm64) |
-| Windows | x64 (AMD64) | [waza-windows-amd64.exe](https://github.com/microsoft/waza/releases/download/v0.35.0/waza-windows-amd64.exe) |
-| Windows | ARM64 | [waza-windows-arm64.exe](https://github.com/microsoft/waza/releases/download/v0.35.0/waza-windows-arm64.exe) |
+| macOS | Apple Silicon (ARM64) | [waza-darwin-arm64](https://github.com/microsoft/waza/releases/download/v0.38.0/waza-darwin-arm64) |
+| macOS | Intel (AMD64) | [waza-darwin-amd64](https://github.com/microsoft/waza/releases/download/v0.38.0/waza-darwin-amd64) |
+| Linux | x64 (AMD64) | [waza-linux-amd64](https://github.com/microsoft/waza/releases/download/v0.38.0/waza-linux-amd64) |
+| Linux | ARM64 | [waza-linux-arm64](https://github.com/microsoft/waza/releases/download/v0.38.0/waza-linux-arm64) |
+| Windows | x64 (AMD64) | [waza-windows-amd64.exe](https://github.com/microsoft/waza/releases/download/v0.38.0/waza-windows-amd64.exe) |
+| Windows | ARM64 | [waza-windows-arm64.exe](https://github.com/microsoft/waza/releases/download/v0.38.0/waza-windows-arm64.exe) |
 
 ---
 
@@ -64,7 +79,7 @@ On Windows, use this command only from Git Bash, MSYS2, or Cygwin. If PowerShell
 irm https://raw.githubusercontent.com/microsoft/waza/main/install.ps1 | iex
 ```
 
-The installers choose the latest standalone `waza` CLI release, download the matching binary, verify the checksum, and install it. You can also download the Windows binary from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.35.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
+The installers choose the latest standalone `waza` CLI release, download the matching binary, verify the checksum, and install it. You can also download the Windows binary from the [standalone waza release](https://github.com/microsoft/waza/releases/tag/v0.38.0), rename it to `waza.exe`, and place it in a directory on your `PATH`.
 
 </TabItem>
 </Tabs>
@@ -81,11 +96,11 @@ waza --version
 
 Install waza as an [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/) extension.
 
-**Current version:** v0.35.0
+**Current version:** v0.38.0
 
 ```bash
 azd extension install azd-waza \
-  --source https://github.com/microsoft/waza/releases/download/azd-ext-microsoft-azd-waza_0.35.0/azd-ext-microsoft-azd-waza_0.35.0.tar.gz
+  --source https://github.com/microsoft/waza/releases/download/azd-ext-microsoft-azd-waza_0.38.0/azd-ext-microsoft-azd-waza_0.38.0.tar.gz
 ```
 
 Once installed, run evaluations through `azd`:

--- a/site/src/content/docs/reference/rubrics.mdx
+++ b/site/src/content/docs/reference/rubrics.mdx
@@ -40,6 +40,10 @@ The existing inline `prompt:` form keeps working. You can also combine the two: 
 
 Each shipped rubric lives at `internal/graders/data/rubrics/<name>.md` in the waza repo. Open one to see exactly what the judge will be told.
 
+<Aside type="note" title="No rubric subcommand in v0.38.0">
+The v0.38.0 release ships the reusable preset library, not a separate `waza rubric` command. Use presets from `prompt` graders with `config.rubric`; the `waza quality --rubric` flag remains reserved for future custom quality-rubric support.
+</Aside>
+
 ## Rubric file schema
 
 A rubric is a markdown file: YAML frontmatter, then the prompt body.

--- a/site/src/content/docs/reference/schema-changes.md
+++ b/site/src/content/docs/reference/schema-changes.md
@@ -9,10 +9,10 @@ Waza public artifacts use an explicit `schemaVersion` field so checked-in eval s
 
 | Artifact | Field | Current version |
 |---|---|---|
-| `eval.yaml` | `schemaVersion` | `1.1` |
-| `results.json` | `schemaVersion` | `1.1` |
-| `snapshot.json` | `schemaVersion` | Not yet emitted |
-| Dashboard/SSE event envelope | `schemaVersion` | `1.1` |
+| `eval.yaml` | `schemaVersion` | `1.2` |
+| `results.json` | `schemaVersion` | `1.2` |
+| `snapshot.json` | `schemaVersion` | `1.0` |
+| Dashboard/SSE event envelope | `schemaVersion` | `1.0` |
 
 ## Policy
 
@@ -20,8 +20,8 @@ Schema versions use `MAJOR.MINOR` format with no patch component.
 
 - **MINOR** changes are backward-compatible additions, usually optional fields. Readers accept same-major artifacts and warn when they see unknown fields.
 - **MAJOR** changes are breaking. Readers refuse artifacts from a different major version and point to `waza migrate <file>`.
-- Missing `schemaVersion` is interpreted as the current schema version (currently `1.1`). Same-major minor differences are accepted and any unknown fields are warned about; cross-major mismatches are rejected.
-- New artifacts should emit the current `schemaVersion` (currently `1.1`). The version is automatically populated by the writer; you only need to set it manually when authoring fixtures or schema-pinned test data.
+- Missing `schemaVersion` is interpreted as the current schema version (currently `1.2` for eval/result artifacts). Same-major minor differences are accepted and any unknown fields are warned about; cross-major mismatches are rejected.
+- New eval/result artifacts should emit the current `schemaVersion` (currently `1.2`). The version is automatically populated by the writer; you only need to set it manually when authoring fixtures or schema-pinned test data.
 
 ## Migration command
 
@@ -35,6 +35,12 @@ waza migrate results.json
 For schema `1.0`, the command is a no-op because there is no prior major version to migrate from.
 
 ## Changelog
+
+### 1.2
+
+- Added optional `EvalSpec.adversarial` to declare built-in fault-injection packs and the `on_unsafe_outcome` policy consumed by `waza adversarial --spec` (issue #365).
+- Added optional `runs[].snapshot_path` to `results.json`, pointing to the per-task `snapshot.json` artifact produced by `waza run --snapshot` (issue #367).
+- Introduced `snapshot.json` as a separate `task-snapshot` artifact with its own independent `schemaVersion: "1.0"`, prompt/fixture digests, environment allow-list capture, redaction metadata, and ordered tool-event replay tape (issue #367).
 
 ### 1.1
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -15,7 +15,7 @@ Main evaluation configuration file.
 name: code-explainer-eval # Required: eval suite name
 description: "..." # Required: what this eval tests
 skill: code-explainer # Required: skill name
-schemaVersion: "1.1" # Optional: schema version; defaults to 1.0
+schemaVersion: "1.2" # Optional: schema version; defaults to the current version
 version: "1.0" # Optional: version number
 
 config:
@@ -44,6 +44,12 @@ mcp_mocks: # Optional: deterministic local MCP server mocks
           - match: { owner: microsoft, repo: waza }
             return:
               issues: []
+
+adversarial: # Optional: fault-injection packs for waza adversarial
+  packs:
+    - prompt-injection
+    - scope-bypass
+  on_unsafe_outcome: fail
 ```
 
 ## Top-Level Fields
@@ -97,12 +103,12 @@ version: "1.0"
 
 **Type:** string  
 **Required:** no  
-**Default:** current schema version (currently `1.1`)
+**Default:** current schema version (currently `1.2`)
 
 Schema version for the public artifact shape. It uses `MAJOR.MINOR` format with no patch component. Same-major minor additions are backward-compatible; readers ignore unknown fields and warn. Different major versions are rejected with a migration hint.
 
 ```yaml
-schemaVersion: "1.1"
+schemaVersion: "1.2"
 ```
 
 See [Schema Changes](/reference/schema-changes/) for the versioning policy and changelog.
@@ -169,6 +175,30 @@ mcp_mocks:
 | `error` | string | Tool error text returned with `isError: true` |
 
 Response entries are checked in order. Unknown tools and unmatched calls fail loudly with a tool error that names the missing mock fixture.
+
+### adversarial
+
+**Type:** object
+**Required:** no
+**Requires:** `schemaVersion: "1.2"` or newer
+
+Declares built-in adversarial / fault-injection packs for `waza adversarial --spec`. The normal `waza run` command ignores this block; it is consumed by the dedicated adversarial harness.
+
+```yaml
+schemaVersion: "1.2"
+adversarial:
+  packs:
+    - prompt-injection
+    - scope-bypass
+  on_unsafe_outcome: fail
+```
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `packs` | array of strings | yes | Built-in pack identifiers such as `prompt-injection` and `scope-bypass` |
+| `on_unsafe_outcome` | string | no | `fail` (default, exits 2 on unsafe) or `warn` (records unsafe outcomes but exits 0) |
+
+Unknown pack names and empty `packs` lists are rejected with a configuration error.
 
 ## config Section
 


### PR DESCRIPTION
## Summary
- add v0.38.0 release coverage to the changelog and site release page
- fill schema docs for schemaVersion 1.2, adversarial config, snapshots, and tool argument matchers
- expose existing adversarial, snapshot/replay, and Azure Storage guides in the site sidebar
- document that #10 is an internal-only refactor and that no `waza rubric` subcommand ships in v0.38.0

## Validation
- `npm --prefix site install`
- `npm --prefix site run build`
- `git diff --check`