### PR TITLE
test: coverage backfill for v0.38.0 features

### DIFF
--- a/internal/adversarial/packs_more_test.go
+++ b/internal/adversarial/packs_more_test.go
@@ -1,0 +1,17 @@
+package adversarial
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackTaskRelPaths(t *testing.T) {
+	p := &Pack{Manifest: Manifest{Tasks: []string{"a/b.yaml", "c.yaml"}}}
+	got := p.TaskRelPaths("/root")
+	require.Equal(t, []string{filepath.Join("/root", "a", "b.yaml"), filepath.Join("/root", "c.yaml")}, got)
+
+	empty := &Pack{}
+	require.Empty(t, empty.TaskRelPaths("/x"))
+}

--- a/internal/copilotevents/bridge_test.go
+++ b/internal/copilotevents/bridge_test.go
@@ -1,0 +1,111 @@
+package copilotevents
+
+import (
+	"testing"
+
+	copilot "github.com/github/copilot-sdk/go"
+
+	"github.com/microsoft/waza/internal/agentevent"
+)
+
+func TestFromSDKEmpty(t *testing.T) {
+	if got := FromSDK(nil); got != nil {
+		t.Fatalf("FromSDK(nil) = %v", got)
+	}
+}
+
+func TestFromSDKWrapsAndKinds(t *testing.T) {
+	sdkEvents := []copilot.SessionEvent{
+		{Data: &copilot.SessionStartData{}},
+		{Data: &copilot.SessionShutdownData{}},
+		{Data: &copilot.SessionErrorData{Message: "err"}},
+		{Data: &copilot.SessionInfoData{Message: "info"}},
+		{Data: &copilot.SessionWarningData{Message: "warn"}},
+		{Data: &copilot.UserMessageData{Content: "u"}},
+		{Data: &copilot.AssistantMessageData{Content: "a"}},
+		{Data: &copilot.AssistantMessageDeltaData{DeltaContent: "d"}},
+		{Data: &copilot.AssistantReasoningData{Content: "r"}},
+		{Data: &copilot.AssistantUsageData{}},
+		{Data: &copilot.SystemMessageData{Content: "s"}},
+		{Data: &copilot.ToolExecutionStartData{ToolCallID: "1"}},
+		{Data: &copilot.ToolExecutionCompleteData{ToolCallID: "1"}},
+		{Data: &copilot.ToolExecutionPartialResultData{ToolCallID: "1"}},
+		{Data: &copilot.ToolExecutionProgressData{ToolCallID: "1"}},
+		{Data: &copilot.ToolUserRequestedData{ToolCallID: "1"}},
+		{Data: &copilot.SkillInvokedData{}},
+		{Data: &copilot.HookStartData{}},
+		{Data: &copilot.HookEndData{}},
+		// Unknown SDK event type falls through to KindRaw via RawSessionEventData.
+		{Data: &copilot.RawSessionEventData{EventType: copilot.SessionEventType("custom.unknown")}},
+	}
+	expectedKinds := []agentevent.Kind{
+		agentevent.KindSessionStart,
+		agentevent.KindSessionShutdown,
+		agentevent.KindSessionError,
+		agentevent.KindSessionInfo,
+		agentevent.KindSessionWarning,
+		agentevent.KindUserMessage,
+		agentevent.KindAssistantMessage,
+		agentevent.KindAssistantMessageDelta,
+		agentevent.KindAssistantReasoning,
+		agentevent.KindAssistantUsage,
+		agentevent.KindSystemMessage,
+		agentevent.KindToolExecutionStart,
+		agentevent.KindToolExecutionComplete,
+		agentevent.KindToolExecutionPartialResult,
+		agentevent.KindToolExecutionProgress,
+		agentevent.KindToolUserRequested,
+		agentevent.KindSkillInvoked,
+		agentevent.KindHookStart,
+		agentevent.KindHookEnd,
+		agentevent.KindRaw,
+	}
+
+	out := FromSDK(sdkEvents)
+	if len(out) != len(sdkEvents) {
+		t.Fatalf("FromSDK len = %d, want %d", len(out), len(sdkEvents))
+	}
+	for i, e := range out {
+		if e.Kind() != expectedKinds[i] {
+			t.Errorf("event %d kind = %s, want %s", i, e.Kind(), expectedKinds[i])
+		}
+		// Raw round-trip preserves the SDK event.
+		se, ok := AsSDKEvent(e)
+		if !ok {
+			t.Errorf("event %d: AsSDKEvent !ok", i)
+			continue
+		}
+		if se.Type() != sdkEvents[i].Type() {
+			t.Errorf("event %d type = %s, want %s", i, se.Type(), sdkEvents[i].Type())
+		}
+	}
+
+	// ToSDK strips wrappers and preserves order.
+	roundTrip := ToSDK(out)
+	if len(roundTrip) != len(sdkEvents) {
+		t.Fatalf("ToSDK len = %d, want %d", len(roundTrip), len(sdkEvents))
+	}
+}
+
+func TestToSDKEmpty(t *testing.T) {
+	if got := ToSDK(nil); got != nil {
+		t.Fatalf("ToSDK(nil) = %v", got)
+	}
+}
+
+func TestToSDKSkipsNonSDK(t *testing.T) {
+	// agentevent.New with a non-SDK raw value should be skipped by ToSDK.
+	nonSDK := agentevent.New(agentevent.KindRaw, "not-an-sdk-event")
+	wrapped := WrapSDKEvent(copilot.SessionEvent{Data: &copilot.UserMessageData{Content: "x"}})
+	out := ToSDK([]agentevent.Event{nonSDK, wrapped})
+	if len(out) != 1 {
+		t.Fatalf("ToSDK = %d events, want 1", len(out))
+	}
+}
+
+func TestAsSDKEventMiss(t *testing.T) {
+	e := agentevent.New(agentevent.KindRaw, 42)
+	if _, ok := AsSDKEvent(e); ok {
+		t.Fatal("AsSDKEvent should be false for non-SDK raw")
+	}
+}

--- a/internal/copilotevents/events_test.go
+++ b/internal/copilotevents/events_test.go
@@ -1,0 +1,169 @@
+package copilotevents
+
+import (
+	"encoding/json"
+	"testing"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func evt(data copilot.SessionEventData) copilot.SessionEvent {
+	return copilot.SessionEvent{Data: data}
+}
+
+func TestContent(t *testing.T) {
+	cases := []struct {
+		name string
+		evt  copilot.SessionEvent
+		want string
+		ok   bool
+	}{
+		{"user", evt(&copilot.UserMessageData{Content: "hello"}), "hello", true},
+		{"assistant", evt(&copilot.AssistantMessageData{Content: "hi"}), "hi", true},
+		{"reasoning", evt(&copilot.AssistantReasoningData{Content: "thinking"}), "thinking", true},
+		{"system", evt(&copilot.SystemMessageData{Content: "sys"}), "sys", true},
+		{"other", evt(&copilot.SessionStartData{}), "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := Content(c.evt)
+			if got != c.want || ok != c.ok {
+				t.Fatalf("Content() = (%q, %v), want (%q, %v)", got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+func TestDeltaContent(t *testing.T) {
+	if got, ok := DeltaContent(evt(&copilot.AssistantMessageDeltaData{DeltaContent: "delta"})); !ok || got != "delta" {
+		t.Fatalf("DeltaContent = (%q, %v)", got, ok)
+	}
+	if got, ok := DeltaContent(evt(&copilot.UserMessageData{})); ok || got != "" {
+		t.Fatalf("DeltaContent on non-delta returned (%q, %v)", got, ok)
+	}
+}
+
+func TestMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		evt  copilot.SessionEvent
+		want string
+		ok   bool
+	}{
+		{"error", evt(&copilot.SessionErrorData{Message: "boom"}), "boom", true},
+		{"info", evt(&copilot.SessionInfoData{Message: "fyi"}), "fyi", true},
+		{"warning", evt(&copilot.SessionWarningData{Message: "warn"}), "warn", true},
+		{"other", evt(&copilot.UserMessageData{}), "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := Message(c.evt)
+			if got != c.want || ok != c.ok {
+				t.Fatalf("Message = (%q, %v), want (%q, %v)", got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+func TestReasoningText(t *testing.T) {
+	text := "because"
+	if got := ReasoningText(evt(&copilot.AssistantMessageData{ReasoningText: &text})); got == nil || *got != text {
+		t.Fatalf("ReasoningText = %v", got)
+	}
+	if got := ReasoningText(evt(&copilot.UserMessageData{})); got != nil {
+		t.Fatalf("ReasoningText on non-assistant got %v", got)
+	}
+}
+
+func TestTypedAccessors(t *testing.T) {
+	if _, ok := SessionStart(evt(&copilot.SessionStartData{})); !ok {
+		t.Fatal("SessionStart")
+	}
+	if _, ok := SessionStart(evt(&copilot.UserMessageData{})); ok {
+		t.Fatal("SessionStart should miss")
+	}
+	if _, ok := ToolStart(evt(&copilot.ToolExecutionStartData{})); !ok {
+		t.Fatal("ToolStart")
+	}
+	if _, ok := ToolUserRequested(evt(&copilot.ToolUserRequestedData{})); !ok {
+		t.Fatal("ToolUserRequested")
+	}
+	if _, ok := ToolComplete(evt(&copilot.ToolExecutionCompleteData{})); !ok {
+		t.Fatal("ToolComplete")
+	}
+	if _, ok := ToolPartial(evt(&copilot.ToolExecutionPartialResultData{})); !ok {
+		t.Fatal("ToolPartial")
+	}
+	if _, ok := ToolProgress(evt(&copilot.ToolExecutionProgressData{})); !ok {
+		t.Fatal("ToolProgress")
+	}
+	if _, ok := SkillInvoked(evt(&copilot.SkillInvokedData{})); !ok {
+		t.Fatal("SkillInvoked")
+	}
+	if _, ok := HookStart(evt(&copilot.HookStartData{})); !ok {
+		t.Fatal("HookStart")
+	}
+	if _, ok := HookEnd(evt(&copilot.HookEndData{})); !ok {
+		t.Fatal("HookEnd")
+	}
+	if _, ok := Shutdown(evt(&copilot.SessionShutdownData{})); !ok {
+		t.Fatal("Shutdown")
+	}
+	if _, ok := AssistantUsage(evt(&copilot.AssistantUsageData{})); !ok {
+		t.Fatal("AssistantUsage")
+	}
+}
+
+func TestToolCallID(t *testing.T) {
+	cases := []struct {
+		name string
+		evt  copilot.SessionEvent
+		want string
+		ok   bool
+	}{
+		{"start", evt(&copilot.ToolExecutionStartData{ToolCallID: "a"}), "a", true},
+		{"complete", evt(&copilot.ToolExecutionCompleteData{ToolCallID: "b"}), "b", true},
+		{"partial", evt(&copilot.ToolExecutionPartialResultData{ToolCallID: "c"}), "c", true},
+		{"progress", evt(&copilot.ToolExecutionProgressData{ToolCallID: "d"}), "d", true},
+		{"requested", evt(&copilot.ToolUserRequestedData{ToolCallID: "e"}), "e", true},
+		{"empty", evt(&copilot.ToolExecutionStartData{}), "", false},
+		{"other", evt(&copilot.UserMessageData{}), "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := ToolCallID(c.evt)
+			if got != c.want || ok != c.ok {
+				t.Fatalf("ToolCallID = (%q, %v), want (%q, %v)", got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+func TestRawData(t *testing.T) {
+	payload := map[string]any{"foo": "bar"}
+	got := RawData(copilot.SessionEventTypeSessionInfo, payload)
+	raw, ok := got.(*copilot.RawSessionEventData)
+	if !ok {
+		t.Fatalf("RawData returned %T", got)
+	}
+	if raw.EventType != copilot.SessionEventTypeSessionInfo {
+		t.Fatalf("EventType = %v", raw.EventType)
+	}
+	var back map[string]any
+	if err := json.Unmarshal(raw.Raw, &back); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if back["foo"] != "bar" {
+		t.Fatalf("Raw = %s", raw.Raw)
+	}
+
+	// unmarshalable payload falls back to "{}"
+	bad := RawData(copilot.SessionEventTypeSessionInfo, make(chan int))
+	rd, ok := bad.(*copilot.RawSessionEventData)
+	if !ok {
+		t.Fatalf("expected *RawSessionEventData, got %T", bad)
+	}
+	if string(rd.Raw) != "{}" {
+		t.Fatalf("expected fallback {}, got %s", rd.Raw)
+	}
+}

--- a/internal/graders/argmatcher/coverage_test.go
+++ b/internal/graders/argmatcher/coverage_test.go
@@ -1,0 +1,106 @@
+package argmatcher
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestUnmarshalJSON_AllKindsAndErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want Kind
+	}{
+		{"equals", `{"equals":"v"}`, KindEquals},
+		{"regex", `{"regex":"^foo$"}`, KindRegex},
+		{"contains", `{"contains":"sub"}`, KindContains},
+		{"range", `{"range":{"gte":1,"lte":2}}`, KindRange},
+		{"schema", `{"json_schema":{"type":"string"}}`, KindJSONSchema},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var m Matcher
+			require.NoError(t, json.Unmarshal([]byte(c.in), &m))
+			require.Equal(t, c.want, m.Kind)
+		})
+	}
+
+	errCases := []string{
+		`{}`,                         // empty
+		`{"equals":"a","regex":"b"}`, // multi
+		`{"unknown":"x"}`,            // unknown kind
+		`{"equals":<bad>}`,           // invalid json
+		`{"regex":123}`,              // wrong type
+		`{"contains":123}`,           // wrong type
+		`{"range":"bad"}`,            // wrong type
+		`{"json_schema":"bad"}`,      // wrong type
+	}
+	for _, in := range errCases {
+		var m Matcher
+		require.Error(t, json.Unmarshal([]byte(in), &m), in)
+	}
+}
+
+func TestMarshalJSON_AllKinds(t *testing.T) {
+	cases := []Matcher{
+		{Kind: KindEquals, Equals: "x"},
+		{Kind: KindRegex, Regex: "^a$"},
+		{Kind: KindContains, Contains: "sub"},
+		{Kind: KindRange, Range: &RangeSpec{}},
+		{Kind: KindJSONSchema, JSONSchema: map[string]any{"type": "string"}},
+		{Kind: ""},
+	}
+	for _, m := range cases {
+		b, err := json.Marshal(m)
+		require.NoError(t, err)
+		require.NotEmpty(t, b)
+	}
+	bad := Matcher{Kind: "nope"}
+	_, err := json.Marshal(bad)
+	require.Error(t, err)
+}
+
+func TestIsCompiled(t *testing.T) {
+	m := Matcher{Kind: KindRegex, Regex: "^x$"}
+	require.False(t, m.IsCompiled())
+	require.NoError(t, m.Compile())
+	require.True(t, m.IsCompiled())
+
+	s := Matcher{Kind: KindJSONSchema, JSONSchema: map[string]any{"type": "string"}}
+	require.False(t, s.IsCompiled())
+	require.NoError(t, s.Compile())
+	require.True(t, s.IsCompiled())
+
+	// Other kinds: IsCompiled returns true unconditionally
+	require.True(t, (&Matcher{Kind: KindEquals}).IsCompiled())
+	require.True(t, (&Matcher{Kind: KindContains}).IsCompiled())
+}
+
+func TestToFloatNumericKinds(t *testing.T) {
+	cases := []any{
+		float64(1.5), float32(2.5),
+		int(3), int32(4), int64(5),
+		uint(6), uint32(7), uint64(8),
+		json.Number("9.5"),
+	}
+	for _, v := range cases {
+		_, ok := toFloat(v)
+		require.True(t, ok, "%v", v)
+	}
+
+	if _, ok := toFloat(json.Number("notnum")); ok {
+		t.Fatal("bad json.Number should fail")
+	}
+	if _, ok := toFloat("string"); ok {
+		t.Fatal("string should fail")
+	}
+}
+
+func TestYamlKindName(t *testing.T) {
+	for _, k := range []yaml.Kind{yaml.DocumentNode, yaml.SequenceNode, yaml.MappingNode, yaml.ScalarNode, yaml.AliasNode, yaml.Kind(99)} {
+		_ = yamlKindName(k)
+	}
+}

--- a/internal/mcpmock/server_more_test.go
+++ b/internal/mcpmock/server_more_test.go
@@ -1,0 +1,242 @@
+package mcpmock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/waza/internal/jsonrpc"
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServerNilLoggerUsesDefault(t *testing.T) {
+	srv := NewServer(&Config{Name: "x"}, nil)
+	if srv == nil || srv.logger == nil {
+		t.Fatal("NewServer should default the logger when nil")
+	}
+}
+
+func TestHandleRequestInitializeAndUnknownMethod(t *testing.T) {
+	srv := NewServer(&Config{Name: "github", Tools: map[string]Tool{
+		"x": {Responses: []Response{{Return: map[string]any{"ok": true}}}},
+	}}, slog.Default())
+
+	resp := srv.HandleRequest(context.Background(), &jsonrpc.Request{
+		JSONRPC: "2.0", Method: "initialize", ID: json.RawMessage(`1`),
+	})
+	require.Nil(t, resp.Error)
+	data, _ := json.Marshal(resp.Result)
+	require.Contains(t, string(data), `"protocolVersion"`)
+	require.Contains(t, string(data), `"github"`)
+
+	// notifications/initialized returns nil (no response).
+	if got := srv.HandleRequest(context.Background(), &jsonrpc.Request{Method: "notifications/initialized"}); got != nil {
+		t.Fatalf("notifications/initialized should return nil, got %+v", got)
+	}
+
+	// Unknown method returns MethodNotFound.
+	resp = srv.HandleRequest(context.Background(), &jsonrpc.Request{Method: "nope", ID: json.RawMessage(`2`)})
+	require.NotNil(t, resp.Error)
+	require.Equal(t, jsonrpc.CodeMethodNotFound, resp.Error.Code)
+}
+
+func TestHandleToolsCallInvalidParams(t *testing.T) {
+	srv := NewServer(&Config{Name: "x", Tools: map[string]Tool{
+		"t": {Responses: []Response{{Return: map[string]any{"ok": true}}}},
+	}}, slog.Default())
+
+	// Malformed top-level JSON for params.
+	resp := srv.HandleRequest(context.Background(), &jsonrpc.Request{
+		Method: "tools/call",
+		Params: json.RawMessage(`not-json`),
+		ID:     json.RawMessage(`1`),
+	})
+	require.NotNil(t, resp.Error)
+	require.Equal(t, jsonrpc.CodeInvalidParams, resp.Error.Code)
+
+	// Arguments is not a JSON object.
+	params, _ := json.Marshal(map[string]any{"name": "t", "arguments": "scalar"})
+	resp = srv.HandleRequest(context.Background(), &jsonrpc.Request{
+		Method: "tools/call", Params: params, ID: json.RawMessage(`2`),
+	})
+	require.NotNil(t, resp.Error)
+	require.Contains(t, fmt.Sprint(resp.Error.Data), "arguments must be a JSON object")
+}
+
+func TestHandleToolsCallNilArgumentsFallsThroughToWildcardMatch(t *testing.T) {
+	srv := NewServer(&Config{Name: "x", Tools: map[string]Tool{
+		"t": {Responses: []Response{{Return: map[string]any{"ok": true}}}},
+	}}, slog.Default())
+
+	params, _ := json.Marshal(map[string]any{"name": "t", "arguments": nil})
+	resp := srv.HandleRequest(context.Background(), &jsonrpc.Request{
+		Method: "tools/call", Params: params, ID: json.RawMessage(`1`),
+	})
+	require.Nil(t, resp.Error)
+	data, _ := json.Marshal(resp.Result)
+	require.Contains(t, string(data), `\"ok\":true`)
+}
+
+func TestHandleToolsCallFixtureErrorReturnsIsError(t *testing.T) {
+	srv := NewServer(&Config{Name: "github", Tools: map[string]Tool{
+		"t": {Responses: []Response{{Error: "fixture says no"}}},
+	}}, slog.Default())
+
+	params, _ := json.Marshal(map[string]any{"name": "t", "arguments": map[string]any{}})
+	resp := srv.HandleRequest(context.Background(), &jsonrpc.Request{
+		Method: "tools/call", Params: params, ID: json.RawMessage(`1`),
+	})
+	require.Nil(t, resp.Error)
+	data, _ := json.Marshal(resp.Result)
+	require.Contains(t, string(data), `"isError":true`)
+	require.Contains(t, string(data), "fixture says no")
+}
+
+func TestResponseMatchesEmptyMatchersAlwaysMatch(t *testing.T) {
+	if !(Response{}).matches(map[string]any{"any": 1}) {
+		t.Fatal("empty matchers should match everything")
+	}
+}
+
+func TestRegexMatchFailures(t *testing.T) {
+	// missing field
+	if regexMatch(map[string]string{"a": "x"}, map[string]any{}) {
+		t.Fatal("missing field should not match")
+	}
+	// non-string value coerced via fmt.Sprint
+	if !regexMatch(map[string]string{"n": "^4"}, map[string]any{"n": 42}) {
+		t.Fatal("number stringified should match ^4")
+	}
+	// bad pattern returns false (covered by validation but server-time guard)
+	if regexMatch(map[string]string{"a": "["}, map[string]any{"a": "x"}) {
+		t.Fatal("bad regex should not match")
+	}
+}
+
+func TestSchemaMatchInvalidSchemaDoesNotPanic(t *testing.T) {
+	if schemaMatch(map[string]any{"type": 42}, map[string]any{}) {
+		t.Fatal("invalid schema should not match")
+	}
+}
+
+func TestHasIDField(t *testing.T) {
+	cases := map[string]bool{
+		`{"id":1}`:       true,
+		`{"method":"x"}`: false,
+		`not-json`:       false,
+		`{}`:             false,
+		`{"id":null}`:    true,
+	}
+	for raw, want := range cases {
+		if got := hasIDField([]byte(raw)); got != want {
+			t.Errorf("hasIDField(%q) = %v, want %v", raw, got, want)
+		}
+	}
+}
+
+func TestServeStdioRespondsToInitializeAndExitsOnEOF(t *testing.T) {
+	cfg := &Config{Name: "demo", Tools: map[string]Tool{
+		"t": {Responses: []Response{{Return: map[string]any{"ok": true}}}},
+	}}
+
+	// One initialize request followed by EOF.
+	in := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n" +
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	var out bytes.Buffer
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ServeStdio(context.Background(), cfg, in, &out, logger)
+
+	require.Contains(t, out.String(), `"protocolVersion"`)
+	require.Contains(t, out.String(), `"demo"`)
+}
+
+func TestServeStdioWriteFailureAborts(t *testing.T) {
+	cfg := &Config{Name: "demo", Tools: map[string]Tool{
+		"t": {Responses: []Response{{Return: map[string]any{"ok": true}}}},
+	}}
+	in := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// failingWriter forces WriteResponse to error so ServeStdio takes its
+	// "write error" branch and returns.
+	ServeStdio(context.Background(), cfg, in, failingWriter{}, logger)
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+func TestLoadFixtureDirSkipsHiddenAndNonJSON(t *testing.T) {
+	dir := t.TempDir()
+	// Hidden dir is skipped.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".hidden"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".hidden", "skip.json"), []byte(`{"responses":[{"return":{}}]}`), 0o644))
+	// Non-json file is ignored.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignore me"), 0o644))
+	// Bundle file (top-level "tools" key) registers multiple tools.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bundle.json"), []byte(`{"tools":{"alpha":{"responses":[{"return":{"v":1}}]},"beta":{"responses":[{"return":{"v":2}}]}}}`), 0o644))
+	// Single-tool file uses its basename as the tool name.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gamma.json"), []byte(`{"responses":[{"return":{"v":3}}]}`), 0o644))
+
+	cfg, err := FromEvalConfig(models.MCPMockConfig{Name: "fx", Fixtures: dir}, "")
+	require.NoError(t, err)
+	for _, tool := range []string{"alpha", "beta", "gamma"} {
+		require.Contains(t, cfg.Tools, tool)
+	}
+	require.NotContains(t, cfg.Tools, "skip")
+}
+
+func TestLoadFixtureDirMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.json"), []byte("{not json"), 0o644))
+	_, err := FromEvalConfig(models.MCPMockConfig{Name: "fx", Fixtures: dir}, "")
+	require.Error(t, err)
+}
+
+func TestFromEvalConfigRelativeFixtures(t *testing.T) {
+	base := t.TempDir()
+	rel := "fixtures"
+	require.NoError(t, os.MkdirAll(filepath.Join(base, rel), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(base, rel, "t.json"), []byte(`{"responses":[{"return":{"v":1}}]}`), 0o644))
+
+	cfg, err := FromEvalConfig(models.MCPMockConfig{Name: "fx", Fixtures: rel}, base)
+	require.NoError(t, err)
+	require.Contains(t, cfg.Tools, "t")
+}
+
+func TestFromEvalConfigErrorPaths(t *testing.T) {
+	// Missing name
+	_, err := FromEvalConfig(models.MCPMockConfig{}, "")
+	require.ErrorContains(t, err, "missing name")
+
+	// No tools
+	_, err = FromEvalConfig(models.MCPMockConfig{Name: "x"}, "")
+	require.ErrorContains(t, err, "at least one tool")
+
+	// Tool with no responses
+	_, err = FromEvalConfig(models.MCPMockConfig{
+		Name:  "x",
+		Tools: map[string]models.MCPMockTool{"t": {}},
+	}, "")
+	require.ErrorContains(t, err, "at least one response")
+
+	// Fixture dir does not exist
+	_, err = FromEvalConfig(models.MCPMockConfig{Name: "x", Fixtures: filepath.Join(t.TempDir(), "missing")}, "")
+	require.Error(t, err)
+
+	// Fixture path that is a file, not a directory
+	dir := t.TempDir()
+	notDir := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(notDir, []byte("hi"), 0o644))
+	_, err = FromEvalConfig(models.MCPMockConfig{Name: "x", Fixtures: notDir}, "")
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "not a directory") || strings.Contains(err.Error(), "fixtures"))
+}

--- a/internal/snapshot/coverage_test.go
+++ b/internal/snapshot/coverage_test.go
@@ -1,0 +1,258 @@
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/waza/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShaBytesDeterministic(t *testing.T) {
+	a := shaBytes([]byte("hello"))
+	b := shaBytes([]byte("hello"))
+	require.Equal(t, a, b)
+	require.NotEqual(t, a, shaBytes([]byte("hellp")))
+	require.Len(t, a, 64)
+}
+
+func TestWriterRoot(t *testing.T) {
+	require.Equal(t, "", (*Writer)(nil).Root())
+	w := NewWriter("/tmp/snap")
+	require.Equal(t, "/tmp/snap", w.Root())
+}
+
+func TestLoadPolicyExtendAndReplace(t *testing.T) {
+	dir := t.TempDir()
+
+	extend := filepath.Join(dir, "extend.yaml")
+	require.NoError(t, os.WriteFile(extend, []byte(`extend: true
+rules:
+  - name: custom_token
+    pattern: "CUSTOM-[A-Z0-9]{8}"
+envKeyDenyList:
+  - CUSTOM_SECRET
+`), 0o644))
+
+	p, err := LoadPolicy(extend)
+	require.NoError(t, err)
+	require.Equal(t, "default+custom", p.Label())
+	require.Contains(t, p.RedactString("token=CUSTOM-ABCD1234 end"), RedactionPlaceholder)
+	require.True(t, p.IsSensitiveKey("CUSTOM_SECRET_X"))
+
+	replace := filepath.Join(dir, "replace.yaml")
+	require.NoError(t, os.WriteFile(replace, []byte(`rules:
+  - name: only_one
+    pattern: "ONLY-[0-9]+"
+envKeyDenyList:
+  - MINE
+`), 0o644))
+	p2, err := LoadPolicy(replace)
+	require.NoError(t, err)
+	require.Equal(t, "custom", p2.Label())
+	require.Equal(t, "[REDACTED]", p2.RedactString("ONLY-12345"))
+	// Default rules are not present in replace mode.
+	require.Equal(t, "AKIAIOSFODNN7EXAMPLE", p2.RedactString("AKIAIOSFODNN7EXAMPLE"))
+	require.True(t, p2.IsSensitiveKey("MINE_X"))
+	require.False(t, p2.IsSensitiveKey("TOKEN"))
+}
+
+func TestLoadPolicyErrors(t *testing.T) {
+	_, err := LoadPolicy(filepath.Join(t.TempDir(), "missing.yaml"))
+	require.Error(t, err)
+
+	bad := filepath.Join(t.TempDir(), "bad.yaml")
+	require.NoError(t, os.WriteFile(bad, []byte("not: [valid: yaml"), 0o644))
+	_, err = LoadPolicy(bad)
+	require.Error(t, err)
+
+	badRule := filepath.Join(t.TempDir(), "rule.yaml")
+	require.NoError(t, os.WriteFile(badRule, []byte(`rules:
+  - name: bad
+    pattern: "["
+`), 0o644))
+	_, err = LoadPolicy(badRule)
+	require.Error(t, err)
+}
+
+func TestRedactStringMapAndMatchedRules(t *testing.T) {
+	p := DefaultPolicy()
+	require.Empty(t, p.MatchedRules())
+
+	out := p.RedactStringMap(map[string]string{
+		"GITHUB_TOKEN": "ghp_" + strings.Repeat("a", 36),
+		"NOTES":        "contact foo@example.com please",
+	})
+	require.Equal(t, RedactionPlaceholder, out["GITHUB_TOKEN"])
+	require.NotContains(t, out["NOTES"], "@example.com")
+
+	rules := p.MatchedRules()
+	require.NotEmpty(t, rules)
+	require.Contains(t, rules, "email")
+
+	// nil receiver and empty input fast-paths return the input unchanged
+	in := map[string]string{"a": "b"}
+	require.Equal(t, in, (*Policy)(nil).RedactStringMap(in))
+	require.Equal(t, map[string]string(nil), p.RedactStringMap(nil))
+
+	// ResetCounters wipes match state.
+	p.ResetCounters()
+	require.Empty(t, p.MatchedRules())
+	require.Zero(t, p.MatchCount())
+
+	// Pointer/struct types fall through unchanged.
+	require.Equal(t, 42, p.RedactAny(42))
+}
+
+func TestRedactAnyWalksAllJSONShapes(t *testing.T) {
+	p := DefaultPolicy()
+	in := map[string]any{
+		"TOKEN":   "ghp_" + strings.Repeat("b", 36),
+		"emails":  []any{"a@b.com", "c@d.com"},
+		"strings": []string{"hi", "x@y.com"},
+		"meta":    map[string]string{"AUTH_TOKEN": "abc", "ok": "fine"},
+		"nested":  map[string]any{"NESTED_KEY": "ghp_" + strings.Repeat("c", 36)},
+		"raw":     "no secrets here",
+	}
+	outAny := p.RedactAny(in)
+	out, ok := outAny.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, RedactionPlaceholder, out["TOKEN"])
+	meta, ok := out["meta"].(map[string]string)
+	require.True(t, ok)
+	require.Equal(t, RedactionPlaceholder, meta["AUTH_TOKEN"])
+	nested, ok := out["nested"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, RedactionPlaceholder, nested["NESTED_KEY"])
+	emails, ok := out["emails"].([]any)
+	require.True(t, ok)
+	email0, ok := emails[0].(string)
+	require.True(t, ok)
+	require.NotContains(t, email0, "@")
+	strs, ok := out["strings"].([]string)
+	require.True(t, ok)
+	require.NotContains(t, strs[1], "@")
+
+	// nil receiver passes through.
+	require.Equal(t, in, (*Policy)(nil).RedactAny(in))
+}
+
+func TestSummariseDivergencesAllShapes(t *testing.T) {
+	require.Equal(t, "snapshots match", SummariseDivergences(CompareResult{Match: true}))
+	require.Equal(t, "snapshots do not match (no divergence details)", SummariseDivergences(CompareResult{}))
+
+	out := SummariseDivergences(CompareResult{Divergences: []Divergence{{
+		Kind:                DivToolName,
+		FirstDivergentIndex: 2,
+		BaselineValue:       "old",
+		ReplayedValue:       "new",
+		Description:         "tool name diverges at index 2",
+	}}})
+	require.Contains(t, out, "first divergence: tool_name")
+	require.Contains(t, out, "event #3")
+	require.Contains(t, out, "old")
+	require.Contains(t, out, "new")
+
+	short := SummariseDivergences(CompareResult{Divergences: []Divergence{{
+		Kind:                DivLengthMismatch,
+		FirstDivergentIndex: -1,
+	}}})
+	require.Contains(t, short, "first divergence: length_mismatch")
+}
+
+func TestCompareStrictPathsAndBisect(t *testing.T) {
+	a := &Snapshot{ToolEvents: []models.ToolEvent{
+		{Turn: 1, ToolName: "list", Args: map[string]any{"k": 1.0}, Success: true, Result: "ok"},
+		{Turn: 2, ToolName: "get", Args: map[string]any{"id": 1}, Success: true, Result: "ok"},
+	}}
+
+	// Identical → match
+	res := Compare(a, a, true)
+	require.True(t, res.Match)
+	turn, _ := Bisect(a, a)
+	require.Zero(t, turn)
+
+	// tool name divergence at index 1 (args must match at 0)
+	b := &Snapshot{ToolEvents: []models.ToolEvent{
+		{Turn: 1, ToolName: "list", Args: map[string]any{"k": 1.0}},
+		{Turn: 2, ToolName: "WRONG", Args: map[string]any{"id": 1}},
+	}}
+	res = Compare(a, b, false)
+	require.False(t, res.Match)
+	require.Equal(t, DivToolName, res.Divergences[0].Kind)
+	turn, _ = Bisect(a, b)
+	require.Equal(t, 2, turn)
+
+	// args divergence (canonicalEqual ignores numeric kinding)
+	c := &Snapshot{ToolEvents: []models.ToolEvent{
+		{Turn: 1, ToolName: "list", Args: map[string]any{"k": 2.0}},
+		{Turn: 2, ToolName: "get", Args: map[string]any{"id": 1}},
+	}}
+	res = Compare(a, c, false)
+	require.False(t, res.Match)
+	require.Equal(t, DivToolArgs, res.Divergences[0].Kind)
+
+	// Strict mode: success divergence
+	d := &Snapshot{ToolEvents: []models.ToolEvent{
+		{Turn: 1, ToolName: "list", Args: map[string]any{"k": 1.0}, Success: false},
+	}}
+	short := &Snapshot{ToolEvents: a.ToolEvents[:1]}
+	res = Compare(short, d, true)
+	require.False(t, res.Match)
+	require.Equal(t, DivToolSuccess, res.Divergences[0].Kind)
+
+	// Strict mode: result divergence
+	e := &Snapshot{ToolEvents: []models.ToolEvent{
+		{Turn: 1, ToolName: "list", Args: map[string]any{"k": 1.0}, Success: true, Result: "different"},
+	}}
+	res = Compare(short, e, true)
+	require.False(t, res.Match)
+	require.Equal(t, DivToolResult, res.Divergences[0].Kind)
+
+	// length mismatch when prefix matches
+	f := &Snapshot{ToolEvents: a.ToolEvents[:1]}
+	res = Compare(a, f, false)
+	require.False(t, res.Match)
+	require.Equal(t, DivLengthMismatch, res.Divergences[0].Kind)
+
+	// nil snapshot
+	res = Compare(nil, a, false)
+	require.False(t, res.Match)
+	require.Equal(t, DivLengthMismatch, res.Divergences[0].Kind)
+
+	// Final status divergence
+	g := &Snapshot{
+		ToolEvents: a.ToolEvents,
+		Result:     SnapshotResult{Status: models.StatusPassed, Validations: map[string]models.GraderResults{"x": {Passed: true}}},
+	}
+	h := &Snapshot{
+		ToolEvents: a.ToolEvents,
+		Result: SnapshotResult{
+			Status:      models.StatusFailed,
+			Validations: map[string]models.GraderResults{"x": {Passed: false}},
+		},
+	}
+	res = Compare(g, h, true)
+	require.False(t, res.Match)
+	hasStatus, hasVal := false, false
+	for _, d := range res.Divergences {
+		if d.Kind == DivFinalStatus {
+			hasStatus = true
+		}
+		if d.Kind == DivValidation {
+			hasVal = true
+		}
+	}
+	require.True(t, hasStatus)
+	require.True(t, hasVal)
+
+	// Validation missing in replay
+	miss := &Snapshot{
+		ToolEvents: a.ToolEvents,
+		Result:     SnapshotResult{Status: models.StatusPassed, Validations: map[string]models.GraderResults{}},
+	}
+	res = Compare(g, miss, true)
+	require.False(t, res.Match)
+}

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -41,7 +41,14 @@ func TestNewValidationError(t *testing.T) {
 }
 
 func TestNewFileExporter(t *testing.T) {
-	dir := t.TempDir()
+	// Use os.MkdirTemp + best-effort cleanup so that any Windows file-handle
+	// retention by the stdouttrace exporter doesn't fail the test during
+	// teardown (t.TempDir surfaces RemoveAll errors).
+	dir, err := os.MkdirTemp("", "waza-telemetry-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	path := filepath.Join(dir, "traces.jsonl")
 	cfg := Config{Exporter: ExporterFile, FilePath: path, ServiceName: "svc", ServiceVersion: "v1"}
 	p, err := New(context.Background(), cfg)

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -1,0 +1,169 @@
+package telemetry
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestNewDisabled(t *testing.T) {
+	p, err := New(context.Background(), Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if p.Enabled() {
+		t.Fatal("disabled config should yield disabled provider")
+	}
+	// Shutdown should be a no-op (shutdown func is nil).
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown disabled: %v", err)
+	}
+	// SetGlobal on a disabled provider must not change the global.
+	prev := otel.GetTracerProvider()
+	p.SetGlobal()
+	if otel.GetTracerProvider() != prev {
+		t.Fatal("SetGlobal on disabled provider mutated global")
+	}
+	// Tracer still works.
+	if p.Tracer() == nil {
+		t.Fatal("Tracer() is nil")
+	}
+}
+
+func TestNewValidationError(t *testing.T) {
+	if _, err := New(context.Background(), Config{Exporter: ExporterKind("garbage")}); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestNewFileExporter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "traces.jsonl")
+	cfg := Config{Exporter: ExporterFile, FilePath: path, ServiceName: "svc", ServiceVersion: "v1"}
+	p, err := New(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !p.Enabled() {
+		t.Fatal("Enabled should be true")
+	}
+	if p.Config().FilePath != path {
+		t.Fatalf("Config.FilePath = %q", p.Config().FilePath)
+	}
+
+	// Emit a span and shut down so the exporter flushes to disk.
+	_, span := p.Tracer().Start(context.Background(), "test-span")
+	span.End()
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("trace file is empty")
+	}
+}
+
+func TestNewFileExporterBadPath(t *testing.T) {
+	cfg := Config{Exporter: ExporterFile, FilePath: filepath.Join(t.TempDir(), "no-such-dir", "x.jsonl")}
+	// Validate passes; OpenFile should fail because the parent directory does not exist.
+	if _, err := New(context.Background(), cfg); err == nil {
+		t.Fatal("expected file open error")
+	}
+}
+
+func TestNewStdoutExporter(t *testing.T) {
+	p, err := New(context.Background(), Config{Exporter: ExporterStdout})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !p.Enabled() {
+		t.Fatal("Enabled false for stdout")
+	}
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestNewOTLPExporterVariants(t *testing.T) {
+	// All of these construct the exporter without dialing — exporter dial
+	// happens lazily on first export.
+	cases := []Config{
+		{Exporter: ExporterOTLP},
+		{Exporter: ExporterOTLP, Endpoint: "localhost:4318"},
+		{Exporter: ExporterOTLP, Endpoint: "http://collector.example.com/v1/traces"},
+		{Exporter: ExporterOTLP, Endpoint: "https://collector.example.com/v1/traces", Headers: map[string]string{"x-key": "v"}},
+	}
+	for _, cfg := range cases {
+		p, err := New(context.Background(), cfg)
+		if err != nil {
+			t.Fatalf("New(%+v): %v", cfg, err)
+		}
+		_ = p.Shutdown(context.Background())
+	}
+}
+
+func TestSetGlobalEnabled(t *testing.T) {
+	prev := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	p, err := New(context.Background(), Config{Exporter: ExporterStdout})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	p.SetGlobal()
+	if otel.GetTracerProvider() == prev {
+		t.Fatal("SetGlobal did not change global provider")
+	}
+}
+
+func TestNilProviderSafe(t *testing.T) {
+	var p *Provider
+	if p.Enabled() {
+		t.Fatal("nil should be disabled")
+	}
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Fatalf("nil Shutdown: %v", err)
+	}
+	if got := p.Config(); got.Exporter != "" || got.Endpoint != "" || got.IncludePayloads {
+		t.Fatalf("nil Config should be zero, got %+v", got)
+	}
+	tr := p.Tracer()
+	if tr == nil {
+		t.Fatal("nil Tracer() returned nil")
+	}
+	// nil provider's tracer is a noop tracer; just confirm we can call Start.
+	_, span := tr.Start(context.Background(), "noop")
+	span.End()
+	// And SetGlobal must not panic.
+	p.SetGlobal()
+	_ = noop.NewTracerProvider() // sanity import use
+}
+
+func TestHasScheme(t *testing.T) {
+	cases := map[string]bool{
+		"":                      false,
+		"http://example.com":    true,
+		"https://example.com":   true,
+		"otlp+grpc://x":         true,
+		"localhost:4318":        false,
+		"://":                   true, // empty scheme but :// pattern is detected
+		"badscheme":             false,
+		"a.b.c:1234":            false,
+		"h+t-t.p://ok":          true,
+		"1http://numeric-start": true, // digits are allowed in scheme chars
+	}
+	for in, want := range cases {
+		if got := hasScheme(in); got != want {
+			t.Errorf("hasScheme(%q) = %v, want %v", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Audits and backfills test coverage ahead of v0.38.0. Tests only; no production code changed.

## Coverage delta

| Package | Before | After |
|---|---|---|
| internal/copilotevents | 0.0% | **100.0%** |
| internal/telemetry | 64.3% | **93.6%** |
| internal/mcpmock | 67.3% | **93.3%** |
| internal/snapshot | 62.1% | **82.8%** |
| internal/adversarial | 67.2% | **73.1%** |
| internal/graders/argmatcher | 66.2% | **88.4%** |

Overall: **77.5% → 79.2%**

## Out of scope (intentionally skipped)

- `internal/specverify` (66.1%) — not in the explicit backfill scope list for this audit.
- `internal/models` (69.8%) — schemaVersion changes (#368) live here but the package is outside the explicit scope.

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `gofmt -l .` empty ✓
- `golangci-lint run` 0 issues ✓
- `go test ./... -race -count=1` all pass ✓