### PR TITLE
feat: detect APM-installed skills (.apm/skills/&lt;name&gt;/SKILL.md) #400

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ project/
 └── README.md
 ```
 
+*APM-installed mode* (skills managed by [Agent Package Manager](https://aka.ms/apm)):
+```
+skills/{skill-name}/
+├── apm.yml                                    # APM source definition
+└── .apm/skills/{skill-name}/SKILL.md          # compiled output — detected automatically
+```
+Waza detects APM-compiled skills without extra configuration. If both a top-level `SKILL.md` and an APM-compiled one exist, the top-level file wins.
+
 **Example:**
 ```bash
 # In project mode (explained Modes section, above): creates skills/code-explainer/SKILL.md + evals/code-explainer/

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -273,8 +273,9 @@ func evalFilenames(configured string) []string {
 	return []string{configured, projectconfig.DefaultEvalFile}
 }
 
-// tryParseSkill checks if dir contains SKILL.md or .agent.md and parses it.
-// SKILL.md takes priority over .agent.md.
+// tryParseSkill checks if dir contains SKILL.md, .agent.md, or an
+// APM-compiled SKILL.md at .apm/skills/<name>/SKILL.md, and parses it.
+// Precedence: top-level SKILL.md > top-level .agent.md > APM-compiled SKILL.md.
 func tryParseSkill(dir string) (SkillInfo, bool) {
 	// Check SKILL.md first
 	skillPath := filepath.Join(dir, "SKILL.md")
@@ -292,25 +293,89 @@ func tryParseSkill(dir string) (SkillInfo, bool) {
 
 	// Fall back to .agent.md files
 	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return SkillInfo{}, false
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() && skill.IsAgentFile(entry.Name()) {
-			agentPath := filepath.Join(dir, entry.Name())
-			name := parseAgentNameFromFile(agentPath)
-			if name == "" {
-				name = filepath.Base(dir)
+	if err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() && skill.IsAgentFile(entry.Name()) {
+				agentPath := filepath.Join(dir, entry.Name())
+				name := parseAgentNameFromFile(agentPath)
+				if name == "" {
+					name = filepath.Base(dir)
+				}
+				return SkillInfo{
+					Name:      name,
+					Dir:       dir,
+					SkillPath: agentPath,
+				}, true
 			}
-			return SkillInfo{
-				Name:      name,
-				Dir:       dir,
-				SkillPath: agentPath,
-			}, true
 		}
 	}
 
+	// Fall back to APM-compiled layout: <dir>/.apm/skills/<name>/SKILL.md
+	// APM (Agent Package Manager) writes the resolved SKILL.md that agent
+	// clients consume to this well-known path. See:
+	//   https://aka.ms/apm
+	if info, ok := tryParseAPMSkill(dir); ok {
+		return info, true
+	}
+
 	return SkillInfo{}, false
+}
+
+// tryParseAPMSkill looks for an APM-compiled SKILL.md under
+// <dir>/.apm/skills/<name>/SKILL.md. When multiple compiled skills are present,
+// it prefers the one whose subdirectory matches the parent dir's basename;
+// otherwise it returns the first one in lexical order for stability.
+//
+// The reported Dir remains the parent (dir) so that co-located evals
+// (evals/eval.yaml, eval.yaml, fixtures/, etc.) continue to resolve
+// relative to the user-facing skill folder, not the .apm output.
+func tryParseAPMSkill(dir string) (SkillInfo, bool) {
+	apmSkillsDir := filepath.Join(dir, ".apm", "skills")
+	if !isDir(apmSkillsDir) {
+		return SkillInfo{}, false
+	}
+
+	entries, err := os.ReadDir(apmSkillsDir)
+	if err != nil {
+		return SkillInfo{}, false
+	}
+
+	base := filepath.Base(dir)
+	var preferred, fallback string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(apmSkillsDir, entry.Name(), "SKILL.md")
+		if !isFile(candidate) {
+			continue
+		}
+		if entry.Name() == base {
+			preferred = candidate
+			break
+		}
+		if fallback == "" {
+			fallback = candidate
+		}
+	}
+
+	skillPath := preferred
+	if skillPath == "" {
+		skillPath = fallback
+	}
+	if skillPath == "" {
+		return SkillInfo{}, false
+	}
+
+	name, err := parseSkillName(skillPath)
+	if err != nil || name == "" {
+		name = base
+	}
+	return SkillInfo{
+		Name:      name,
+		Dir:       dir,
+		SkillPath: skillPath,
+	}, true
 }
 
 // parseAgentNameFromFile reads an .agent.md file and extracts the agent name.

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -663,3 +663,134 @@ func TestMergeSkillsByName(t *testing.T) {
 		t.Fatalf("expected github-only to be appended, got %q", merged[2].Name)
 	}
 }
+
+// --- APM-compiled layout (.apm/skills/<name>/SKILL.md) ---
+// See https://github.com/microsoft/waza/issues/400
+
+func TestDetectContext_APMSingleSkillFromSkillDir(t *testing.T) {
+	// APM layout: skills/my-skill/.apm/skills/my-skill/SKILL.md, with no
+	// top-level SKILL.md in the user-facing skill folder. Running detection
+	// from the skill folder itself must find the compiled skill.
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "skills", "my-skill")
+	writeFile(t, filepath.Join(skillDir, ".apm", "skills", "my-skill", "SKILL.md"), skillMD("my-skill"))
+
+	ctx, err := DetectContext(skillDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Type != ContextSingleSkill {
+		t.Fatalf("expected ContextSingleSkill, got %d", ctx.Type)
+	}
+	if len(ctx.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(ctx.Skills))
+	}
+	if ctx.Skills[0].Name != "my-skill" {
+		t.Errorf("expected name 'my-skill', got %q", ctx.Skills[0].Name)
+	}
+	// Dir should stay the user-facing skill folder, not the .apm output,
+	// so evals/fixtures continue to resolve correctly.
+	if ctx.Skills[0].Dir != skillDir {
+		t.Errorf("expected dir %q, got %q", skillDir, ctx.Skills[0].Dir)
+	}
+	expectedSkillPath := filepath.Join(skillDir, ".apm", "skills", "my-skill", "SKILL.md")
+	if ctx.Skills[0].SkillPath != expectedSkillPath {
+		t.Errorf("expected SkillPath %q, got %q", expectedSkillPath, ctx.Skills[0].SkillPath)
+	}
+}
+
+func TestDetectContext_APMMultiSkillFromWorkspaceRoot(t *testing.T) {
+	// Detection from the workspace root should discover APM-compiled skills
+	// underneath skills/*/ even though .apm is a dotfolder we normally skip.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "skills", "alpha", ".apm", "skills", "alpha", "SKILL.md"), skillMD("alpha"))
+	writeFile(t, filepath.Join(root, "skills", "beta", ".apm", "skills", "beta", "SKILL.md"), skillMD("beta"))
+
+	ctx, err := DetectContext(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Type != ContextMultiSkill {
+		t.Fatalf("expected ContextMultiSkill, got %d", ctx.Type)
+	}
+	if len(ctx.Skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(ctx.Skills))
+	}
+	names := map[string]bool{}
+	for _, s := range ctx.Skills {
+		names[s.Name] = true
+	}
+	if !names["alpha"] || !names["beta"] {
+		t.Errorf("expected alpha and beta, got %v", names)
+	}
+}
+
+func TestDetectContext_APMTopLevelSkillTakesPrecedence(t *testing.T) {
+	// When both a top-level SKILL.md and a .apm/skills/<name>/SKILL.md exist,
+	// the top-level one wins (it's the source of truth being edited).
+	skillDir := t.TempDir()
+	writeFile(t, filepath.Join(skillDir, "SKILL.md"), skillMD("top-level"))
+	writeFile(t, filepath.Join(skillDir, ".apm", "skills", filepath.Base(skillDir), "SKILL.md"), skillMD("apm-compiled"))
+
+	ctx, err := DetectContext(skillDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Type != ContextSingleSkill {
+		t.Fatalf("expected ContextSingleSkill, got %d", ctx.Type)
+	}
+	if ctx.Skills[0].Name != "top-level" {
+		t.Errorf("expected top-level SKILL.md to win, got name %q", ctx.Skills[0].Name)
+	}
+	expected := filepath.Join(skillDir, "SKILL.md")
+	if ctx.Skills[0].SkillPath != expected {
+		t.Errorf("expected SkillPath %q, got %q", expected, ctx.Skills[0].SkillPath)
+	}
+}
+
+func TestDetectContext_APMPrefersMatchingBasename(t *testing.T) {
+	// If a skill folder's .apm/skills/ contains multiple compiled entries
+	// (e.g., transitive deps compiled alongside), prefer the one whose name
+	// matches the parent folder's basename.
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "primary")
+	writeFile(t, filepath.Join(skillDir, ".apm", "skills", "primary", "SKILL.md"), skillMD("primary"))
+	writeFile(t, filepath.Join(skillDir, ".apm", "skills", "helper", "SKILL.md"), skillMD("helper"))
+
+	ctx, err := DetectContext(skillDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Type != ContextSingleSkill {
+		t.Fatalf("expected ContextSingleSkill, got %d", ctx.Type)
+	}
+	if ctx.Skills[0].Name != "primary" {
+		t.Errorf("expected 'primary' to be chosen, got %q", ctx.Skills[0].Name)
+	}
+}
+
+func TestDetectContext_APMMixedWithClassicLayout(t *testing.T) {
+	// A workspace where one skill is classic and another is APM-installed
+	// should surface both.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "skills", "classic", "SKILL.md"), skillMD("classic"))
+	writeFile(t, filepath.Join(root, "skills", "apm-installed", ".apm", "skills", "apm-installed", "SKILL.md"), skillMD("apm-installed"))
+
+	ctx, err := DetectContext(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Type != ContextMultiSkill {
+		t.Fatalf("expected ContextMultiSkill, got %d", ctx.Type)
+	}
+	if len(ctx.Skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(ctx.Skills))
+	}
+	names := map[string]bool{}
+	for _, s := range ctx.Skills {
+		names[s.Name] = true
+	}
+	if !names["classic"] || !names["apm-installed"] {
+		t.Errorf("expected both classic and apm-installed, got %v", names)
+	}
+}

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -55,6 +55,8 @@ waza run [eval.yaml | skill-name | agent-name]
 
 **Custom agents:** Waza discovers both `SKILL.md` and `.agent.md` files. You can target a custom agent by name just like a skill. See [Evaluating Custom Agents](/guides/custom-agents) for details.
 
+**APM-installed skills:** Waza also detects skills installed with [Agent Package Manager (APM)](https://aka.ms/apm), which writes the compiled `SKILL.md` to `<skill-dir>/.apm/skills/<skill-name>/SKILL.md`. No configuration is required — `waza run`, `waza check`, and workspace detection all find APM-compiled skills automatically. When both a top-level `SKILL.md` and an APM-compiled one exist in the same folder, the top-level file wins.
+
 ### Flags
 
 | Flag | Short | Type | Default | Description |


### PR DESCRIPTION
Closes #400

## Summary

Workspace detection now recognizes skills compiled by [Agent Package Manager (APM)](https://aka.ms/apm) at `<skill-dir>/.apm/skills/<name>/SKILL.md`, so `waza run`, `waza check`, and other commands work in APM-managed workspaces without needing symlinks or explicit `eval.yaml` paths.

Before this change, `waza run` in an APM workspace failed with:
```
no eval.yaml specified and workspace detection failed: no skills detected in workspace
```
because `.apm/` is a dotfolder that skill scanning intentionally skips.

## Design

- `internal/workspace.tryParseSkill` now falls back to a new `tryParseAPMSkill` helper after checking for top-level `SKILL.md` and `.agent.md`.
- Traversal is scoped to the known `.apm/skills/<name>/SKILL.md` convention — no broad dotfolder scanning is introduced.
- The reported `SkillInfo.Dir` remains the user-facing skill folder (not the `.apm/` output), so co-located `evals/`, `eval.yaml`, and `fixtures/` continue to resolve correctly.

### Precedence

| Situation | Winner |
|---|---|
| Only top-level `SKILL.md` exists | Top-level (unchanged behavior) |
| Only `.apm/skills/<name>/SKILL.md` exists | APM-compiled |
| Both exist in the same folder | **Top-level wins** — it's the source of truth being edited |
| Multiple entries under one `.apm/skills/` | Prefer subdir matching parent folder's basename; otherwise first lexical |

## Tests

Adds five regression tests in `internal/workspace/workspace_test.go`:
- `TestDetectContext_APMSingleSkillFromSkillDir`
- `TestDetectContext_APMMultiSkillFromWorkspaceRoot`
- `TestDetectContext_APMTopLevelSkillTakesPrecedence`
- `TestDetectContext_APMPrefersMatchingBasename`
- `TestDetectContext_APMMixedWithClassicLayout`

Full test suite (`go test ./...`) and `golangci-lint run ./internal/workspace/...` both pass.

## Docs

- `README.md` — adds an *APM-installed mode* project layout alongside project/standalone modes.
- `site/src/content/docs/reference/cli.mdx` — adds an APM detection note next to the custom-agents note under `waza run`.

## Answers to open questions in #400

1. **Automatic vs opt-in?** Automatic. `.apm/skills/<name>/SKILL.md` is a well-known APM output path; no config needed.
2. **Precedence when both exist?** Top-level `SKILL.md` wins.
3. **Broad dotfolder scanning?** No — traversal is scoped to the exact `.apm/skills/<name>/SKILL.md` convention.
4. **Docs?** Added APM notes to README and CLI reference.