### PR TITLE
docs: add repository gotchas to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,3 +60,60 @@ If you make a decision that affects other team members, write it to:
 .squad/decisions/inbox/copilot-{brief-slug}.md
 ```
 The Scribe will merge it into the shared decisions file.
+
+## Repository Gotchas (learned from past sessions)
+
+These come up repeatedly across sessions. Handle them proactively.
+
+### 1. First `go build/test/lint` in a fresh worktree needs a `web/dist` stub
+
+The Go binary embeds the dashboard via `//go:embed all:dist` (`web/embed.go`). In a fresh
+worktree the built assets don't exist, so any Go command fails until you scaffold them:
+
+```bash
+mkdir -p web/dist && [ -f web/dist/index.html ] || echo '<html></html>' > web/dist/index.html
+```
+
+Run this **once** at the start of any session before `go build`, `go test`, or `golangci-lint run`.
+
+### 2. Never restage a regenerated `web/dist/index.html`
+
+`web/dist/assets/*` is gitignored but `web/dist/index.html` **is tracked**. Running
+`cd web && npm run build` rewrites `index.html` with new hashed asset refs, which then
+shows up as an unrelated diff. Before `git add`:
+
+```bash
+git diff -- web/dist/index.html   # if only hash refs changed, revert it
+git checkout -- web/dist/index.html
+```
+
+Only commit `web/dist/index.html` changes when you intentionally shipped new dashboard code.
+
+### 3. Standard verify chain: format → test → lint
+
+`golangci-lint` fails on unformatted code, so always run `gofmt` first to avoid a
+retry loop:
+
+```bash
+gofmt -w ./... && go test ./... && golangci-lint run
+```
+
+For the docs site and dashboard, add:
+
+```bash
+cd site && npm run build
+cd ../web && npm run build && npm run lint
+```
+
+### 4. Clean up scratch dirs before committing
+
+Agent tooling can leave `.impeccable/` in the worktree, and Node builds create
+`web/node_modules/` and `site/node_modules/`. None of these should be staged. Before
+`git add`:
+
+```bash
+rm -rf .impeccable web/node_modules site/node_modules
+git status --short   # verify only intended files remain
+```
+
+`git add -A` from the repo root is risky — prefer explicit paths.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,7 +68,8 @@ These come up repeatedly across sessions. Handle them proactively.
 ### 1. First `go build/test/lint` in a fresh worktree needs a `web/dist` stub
 
 The Go binary embeds the dashboard via `//go:embed all:dist` (`web/embed.go`). In a fresh
-worktree the built assets don't exist, so any Go command fails until you scaffold them:
+worktree the built assets don't exist, so commands that compile packages including the
+embedded dashboard assets fail until you scaffold them:
 
 ```bash
 mkdir -p web/dist
@@ -97,7 +98,7 @@ Only commit `web/dist/index.html` changes when you intentionally shipped new das
 
 ### 3. Standard verify chain: format → test → lint
 
-`golangci-lint` fails on unformatted code, so always run `gofmt` first to avoid a
+`golangci-lint` fails on unformatted code, so always run `go fmt` first to avoid a
 retry loop:
 
 ```bash

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,7 @@ Only commit `web/dist/index.html` changes when you intentionally shipped new das
 retry loop:
 
 ```bash
-gofmt -w ./... && go test ./... && golangci-lint run
+go fmt ./... && go test ./... && golangci-lint run
 ```
 
 For the docs site and dashboard, add:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,13 @@ The Go binary embeds the dashboard via `//go:embed all:dist` (`web/embed.go`). I
 worktree the built assets don't exist, so any Go command fails until you scaffold them:
 
 ```bash
-mkdir -p web/dist && [ -f web/dist/index.html ] || echo '<html></html>' > web/dist/index.html
+mkdir -p web/dist
+if [ ! -f web/dist/index.html ]; then
+  printf '<html><body>stub</body></html>\n' > web/dist/index.html
+fi
+if [ ! -f web/dist/favicon.svg ]; then
+  printf '<svg xmlns="http://www.w3.org/2000/svg"></svg>\n' > web/dist/favicon.svg
+fi
 ```
 
 Run this **once** at the start of any session before `go build`, `go test`, or `golangci-lint run`.


### PR DESCRIPTION
Captures recurring friction patterns observed across ~70 recent Copilot CLI sessions in this repo, so future sessions don't rediscover them.

## Added: "Repository Gotchas" section

1. **Fresh worktree `web/dist` stub** — Go binary embeds dashboard via `//go:embed all:dist` (`web/embed.go`). Fresh worktrees have no built assets, so `go build/test/lint` fails until you scaffold `web/dist/index.html`. Seen in 7+ sessions.
2. **Don't restage regenerated `web/dist/index.html`** — `web/dist/assets/*` is gitignored but `index.html` is tracked. `npm run build` rewrites it with new hashed refs; revert unless intentional. Seen in 5+ sessions.
3. **Verify chain: `gofmt → test → lint`** — `golangci-lint` fails on unformatted code, forcing retry cycles.
4. **Clean up scratch dirs** — `.impeccable/`, `web/node_modules/`, `site/node_modules/` should never be staged.

Sourced from `/chronicle improve` analysis of session store data.