### PR TITLE
fix: clarify fixture workspace behavior

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -170,8 +170,12 @@ Add test case YAML files in `tasks/`:
 ```yaml
 # tasks/basic-usage.yaml
 id: basic-usage
+name: Basic usage
 description: "Explain a simple Python function"
-prompt: "Read sample.py and explain what this function does."
+inputs:
+  prompt: "Read sample.py and explain what this function does."
+  files:
+    - path: sample.py
 expectedOutput:
   - type: contains
     value: "function"

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -171,7 +171,7 @@ Add test case YAML files in `tasks/`:
 # tasks/basic-usage.yaml
 id: basic-usage
 description: "Explain a simple Python function"
-prompt: "Explain what this function does:\n{{fixture:sample.py}}"
+prompt: "Read sample.py and explain what this function does."
 expectedOutput:
   - type: contains
     value: "function"

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -141,7 +141,7 @@ tags:
   - basic
   - happy-path
 inputs:
-  prompt: "Help me with this task"
+  prompt: "Read sample.py and explain the function it contains."
   files:
     - path: sample.py
 expected:

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -97,6 +97,8 @@ func TestTaskFiles(t *testing.T) {
 	assert.Len(t, tasks, 3)
 
 	assert.Contains(t, tasks["basic-usage.yaml"], "id: basic-usage-001")
+	assert.Contains(t, tasks["basic-usage.yaml"], `prompt: "Read sample.py and explain the function it contains."`)
+	assert.Contains(t, tasks["basic-usage.yaml"], "path: sample.py")
 	assert.Contains(t, tasks["edge-case.yaml"], "id: edge-case-001")
 	assert.Contains(t, tasks["should-not-trigger.yaml"], "id: should-not-trigger-001")
 }

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -161,7 +161,7 @@ tags:
   - basic
   - happy-path
 inputs:
-  prompt: "Explain this function"
+  prompt: "Read sample.py and explain the function it contains."
   files:
     - path: sample.py
 expected:
@@ -184,6 +184,11 @@ def fibonacci(n):
         return n
     return fibonacci(n - 1) + fibonacci(n - 2)
 ```
+
+`inputs.files` copies each listed file from the suite's `fixtures/` directory
+into the fresh workspace for that task. File contents are **not** automatically
+added to the prompt, so name the file and ask the agent to read it, as in the
+task above.
 
 ### Step 6: Configure Your Evaluation
 

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -398,7 +398,7 @@ tags:
   - happy-path
 
 inputs:
-  prompt: "Explain this function"
+  prompt: "Read sample.py and explain the function it contains."
   files:
     - path: sample.py
 
@@ -440,6 +440,11 @@ inputs:
         def hello():
             print("Hello")
 ```
+
+`inputs.files` loads each `path` from the active fixtures directory
+(`evals/<skill>/fixtures/` by default) and copies it into the fresh task
+workspace. It does not add file contents to `prompt`; tell the agent which
+workspace file to read. Use `content` to define a file inline instead.
 
 `inputs.context.fixture` is resolved relative to the eval spec directory. When it points to a directory, Waza copies that directory's contents into the fresh task workspace before the agent runs.
 
@@ -523,13 +528,14 @@ Each checkpoint accepts:
 
 Outcomes are recorded per-checkpoint on `results.json` under `checkpoints[]`, alongside the final `validations`. `waza gate` still uses final-pass status. Available with `schemaVersion: "1.1"` and above (additive — older 1.0 files load unchanged).
 
-Prompt supports templating:
+When a task includes workspace files, name the file in the prompt so the agent
+knows to read it:
 
 ```yaml
 inputs:
-  prompt: |
-    Explain this code:
-    {{fixture:sample.py}}
+  prompt: "Read sample.py and explain this code."
+  files:
+    - path: sample.py
 ```
 
 ### Expected Section
@@ -596,7 +602,7 @@ Reference in tasks:
 
 ```yaml
 inputs:
-  prompt: "Analyze {{fixture:sample.py}}"
+  prompt: "Read sample.py and analyze it."
   files:
     - path: sample.py
 ```
@@ -848,16 +854,14 @@ tasks:
   - "tasks/scaffold/*.yaml"
 ```
 
-Prompt templating also supports fixture file injection:
+Fixture files are copied into the task workspace, not inlined in the prompt:
 
 ```yaml
 inputs:
-  prompt: |
-    Explain this code:
-    {{fixture:sample.py}}
+  prompt: "Read sample.py and explain this code."
+  files:
+    - path: sample.py
 ```
-
-The `{{fixture:filename}}` syntax inlines the content of a file from the fixtures directory into the prompt.
 
 ---
 

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -441,8 +441,8 @@ inputs:
             print("Hello")
 ```
 
-`inputs.files` loads each `path` from the active fixtures directory
-(`evals/<skill>/fixtures/` by default) and copies it into the fresh task
+`inputs.files` loads each `path` from the active fixtures directory (`./fixtures`
+relative to the eval spec file by default) and copies it into the fresh task
 workspace. It does not add file contents to `prompt`; tell the agent which
 workspace file to read. Use `content` to define a file inline instead.
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -604,13 +604,14 @@ inputs:
 **Type:** string  
 **Required:** yes (unless `prompt_file` is used)
 
-Instruction text sent to the agent. Supports templating:
+Instruction text sent to the agent. When a task includes workspace files, name
+the file and tell the agent to read it:
 
 ```yaml
 inputs:
-  prompt: |
-    Explain this Python code:
-    {{fixture:sample.py}}
+  prompt: "Read sample.py and explain this Python code."
+  files:
+    - path: sample.py
 ```
 
 ### prompt_file
@@ -701,12 +702,15 @@ Each checkpoint's outcomes appear on `results.json` under `checkpoints[]`. The f
 **Type:** array  
 **Required:** no
 
-Files to include in the task context.
+Files copied into the fresh task workspace. A `path` is resolved from the
+active fixtures directory (`evals/<skill>/fixtures/` by default); `content`
+creates a file directly in the workspace. File contents are not inserted into
+the prompt automatically.
 
 ```yaml
 inputs:
   files:
-    - path: sample.py # Reference fixture
+    - path: sample.py # Loaded from the fixtures directory
     - content: "def foo(): ..." # Or inline content
 ```
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -703,9 +703,9 @@ Each checkpoint's outcomes appear on `results.json` under `checkpoints[]`. The f
 **Required:** no
 
 Files copied into the fresh task workspace. A `path` is resolved from the
-active fixtures directory (`evals/<skill>/fixtures/` by default); `content`
-creates a file directly in the workspace. File contents are not inserted into
-the prompt automatically.
+active fixtures directory (`./fixtures` relative to the eval spec file by
+default); `content` creates a file directly in the workspace. File contents are
+not inserted into the prompt automatically.
 
 ```yaml
 inputs:

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -702,16 +702,19 @@ Each checkpoint's outcomes appear on `results.json` under `checkpoints[]`. The f
 **Type:** array  
 **Required:** no
 
-Files copied into the fresh task workspace. A `path` is resolved from the
-active fixtures directory (`./fixtures` relative to the eval spec file by
-default); `content` creates a file directly in the workspace. File contents are
-not inserted into the prompt automatically.
+Files copied into the fresh task workspace. A `path` is required for both
+fixture-backed and inline files. When `content` is omitted, `path` is resolved
+from the active fixtures directory (`./fixtures` relative to the eval spec file
+by default). When `content` is provided, Waza writes that content to `path`
+directly in the workspace. File contents are not inserted into the prompt
+automatically.
 
 ```yaml
 inputs:
   files:
     - path: sample.py # Loaded from the fixtures directory
-    - content: "def foo(): ..." # Or inline content
+    - path: inline.py
+      content: "def foo(): ..." # Or inline content
 ```
 
 ### repos


### PR DESCRIPTION
## Summary
- make scaffolded tasks explicitly ask the agent to read `sample.py`
- clarify that `inputs.files` copies fixtures to the task workspace rather than inlining them in prompts
- remove unsupported `{{fixture:...}}` prompt-injection examples

## Validation
- `go test ./...`
- `make lint`
- `cd site && npm run build`