### PR TITLE
docs: add executor to getting started manifest

### DIFF
--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -199,6 +199,7 @@ config:
   trials_per_task: 1
   timeout_seconds: 300
   parallel: false
+  executor: mock
   model: claude-sonnet-4.6
 
 graders:


### PR DESCRIPTION
## Summary

The Getting Started `eval.yaml` example omitted the required `config.executor` field, so copied manifests did not conform to the schema. Add `executor: mock` to make the starter manifest valid without requiring API access.

## Related issue

Closes #436

## Agent handoff

- Scope: Correct the published getting-started eval manifest.
- Key files changed: `site/src/content/docs/getting-started.mdx`
- Important decisions: Use `mock`, matching the repository's existing getting-started and example manifests.
- Follow-ups or known gaps: None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor or maintenance
- [ ] CI/CD or release change

## Validation

- [ ] `go test ./...`
- [ ] `make lint` or `golangci-lint run`
- [x] Docs site checked, if docs changed
- [ ] Web/dashboard checks run, if `web/` changed
- [x] Manual validation completed: Confirmed the manifest includes `config.executor`.
- [x] Not applicable; reason: No Go or web/dashboard code changed.

## Documentation

- [ ] README updated, if user-facing behavior changed
- [x] `site/` docs updated, if CLI, YAML, dashboard, or validator behavior changed
- [ ] Examples updated, if relevant
- [ ] Not applicable

## Risk and rollback

- Risk level: Low
- Rollback plan: Revert the single documentation line.

## Notes for reviewers

No behavior changes; verify the starter manifest remains aligned with the eval schema.