### PR TITLE
fix: expose MCP mock tools to Copilot CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.3] - 2026-07-17
+
+### Fixed
+
+- **MCP mock tool availability** — `mcp_mocks` now explicitly exposes declared tools to the bundled Copilot CLI, preventing valid mock servers from being skipped during Copilot SDK evaluations (#440).
+
 ## [0.38.2] - 2026-07-16
 
 ### Fixed
@@ -572,7 +578,8 @@ pip install waza
 - YAML escaping for regex patterns with backslashes
 - Progress bar now shows 100% on completion
 
-[Unreleased]: https://github.com/microsoft/waza/compare/v0.38.2...HEAD
+[Unreleased]: https://github.com/microsoft/waza/compare/v0.38.3...HEAD
+[0.38.3]: https://github.com/microsoft/waza/compare/v0.38.2...v0.38.3
 [0.38.2]: https://github.com/microsoft/waza/compare/v0.38.1...v0.38.2
 [0.38.1]: https://github.com/microsoft/waza/compare/v0.38.0...v0.38.1
 [0.38.0]: https://github.com/microsoft/waza/compare/v0.37.0...v0.38.0

--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ tasks:
 
 ### MCP Mock Servers
 
-Use top-level `mcp_mocks` with `schemaVersion: "1.1"` for deterministic Copilot SDK evals that need MCP tools without live services. Waza launches each mock as a local stdio MCP server, so CI runs do not need network ports, external credentials, or real service state.
+Use top-level `mcp_mocks` with `schemaVersion: "1.1"` for deterministic Copilot SDK evals that need MCP tools without live services. Waza launches each mock as a local stdio MCP server, so CI runs do not need network ports, external credentials, or real service state. Waza exposes every tool declared by each mock to the Copilot CLI automatically; do not add a separate `tools` allowlist.
 
 ```yaml
 schemaVersion: "1.1"

--- a/internal/copilotconfig/mcp.go
+++ b/internal/copilotconfig/mcp.go
@@ -101,6 +101,8 @@ func mockServerConfig(cfg mcpmock.Config) (copilot.MCPStdioServerConfig, error) 
 	return copilot.MCPStdioServerConfig{
 		Command: exe,
 		Args:    []string{"__mcp-mock", "--config-file", configFile},
+		// The bundled CLI rejects mock servers when the allowlist is omitted.
+		Tools: []string{"*"},
 		Env: map[string]string{
 			"WAZA_NO_UPDATE_CHECK": "1",
 		},

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -32,6 +32,7 @@ func TestConvertMCPServersWithMocks_AddsHermeticStdioServer(t *testing.T) {
 	require.True(t, ok)
 	require.NotEmpty(t, stdio.Command)
 	require.Equal(t, "1", stdio.Env["WAZA_NO_UPDATE_CHECK"])
+	require.Equal(t, []string{"*"}, stdio.Tools)
 	require.Len(t, stdio.Args, 3)
 	require.Equal(t, "__mcp-mock", stdio.Args[0])
 	require.Equal(t, "--config-file", stdio.Args[1])

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -168,7 +168,7 @@ With this setting, Waza still discovers skills, passes them to the Copilot SDK, 
 
 ## MCP Mock Servers
 
-Use top-level `mcp_mocks` to replace live MCP dependencies with deterministic local stdio servers. This keeps Copilot SDK evals hermetic in CI: no network listener, no port allocation, and no external service credentials. Because this is an additive eval schema field, set `schemaVersion: "1.1"` or newer.
+Use top-level `mcp_mocks` to replace live MCP dependencies with deterministic local stdio servers. This keeps Copilot SDK evals hermetic in CI: no network listener, no port allocation, and no external service credentials. Waza automatically exposes every tool declared by a mock to the Copilot CLI, so no separate `tools` allowlist is needed. Because this is an additive eval schema field, set `schemaVersion: "1.1"` or newer.
 
 ```yaml
 name: issue-triage-eval


### PR DESCRIPTION
Closes #440

## Summary
- configure generated `mcp_mocks` stdio servers with the explicit Copilot CLI `tools: ["*"]` allowlist
- add a regression assertion for the generated SDK configuration
- document automatic mock tool exposure and prepare the v0.38.3 changelog entry

## Validation
- `go test ./...`
- `cd site && npm ci --no-audit --no-fund && npm run build`

Rubber-duck review: no blocking concerns.