### PR TITLE
chore(deps): bump setup-python action

### DIFF
--- a/.github/workflows/waza.yaml
+++ b/.github/workflows/waza.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v7
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       


### PR DESCRIPTION
## Summary
- Bumps `actions/setup-python` from v6 to v7 in `.github/workflows/waza.yaml`.
- Checked open dependency PRs first to avoid duplicating existing coverage. Existing open PRs already cover root Go dependency updates, Copilot SDK, setup-go/setup-node, and web/site package bumps.

## Validation
- `git diff --check`
- `gh pr list --repo microsoft/waza --state open --search 'setup-python in:title' --json number,title,headRefName,url,author` returned no open setup-python PRs.