### PR TITLE
fix(update): embed installer URL in Windows -Command script

### DIFF
--- a/cmd/waza/cmd_update.go
+++ b/cmd/waza/cmd_update.go
@@ -175,7 +175,12 @@ func installerForOS(goos string, opts updateCommandOptions) (updateInstaller, er
 			Args:       []string{"-c", `set -euo pipefail; curl -fsSL "$1" | bash`, "waza-installer", opts.BashInstallerURL},
 		}, nil
 	case "windows":
-		script := `$ErrorActionPreference = 'Stop'; Invoke-Expression (Invoke-RestMethod -Uri $args[0])`
+		// PowerShell's -Command does not reliably bind trailing positional arguments to
+		// $args inside the script block (unlike -File), so we embed the installer URL
+		// directly into the script as a single-quoted PowerShell string literal. See
+		// https://github.com/microsoft/waza/issues/448.
+		quotedURL := quotePowerShellSingleQuoted(opts.PowerShellInstallerURL)
+		script := fmt.Sprintf(`$ErrorActionPreference = 'Stop'; Invoke-Expression (Invoke-RestMethod -Uri %s)`, quotedURL)
 		env := []string{fmt.Sprintf("WAZA_UPDATE_PARENT_PID=%d", os.Getpid())}
 		if opts.ExecutablePath != "" {
 			env = append(env, fmt.Sprintf("WAZA_INSTALL_DIR=%s", filepath.Dir(opts.ExecutablePath)))
@@ -184,13 +189,21 @@ func installerForOS(goos string, opts updateCommandOptions) (updateInstaller, er
 			Name:       "PowerShell",
 			ScriptURL:  opts.PowerShellInstallerURL,
 			Candidates: []string{"pwsh", "powershell"},
-			Args:       []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script, opts.PowerShellInstallerURL},
+			Args:       []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script},
 			Env:        env,
 			Async:      true,
 		}, nil
 	default:
 		return updateInstaller{}, fmt.Errorf("unsupported OS for waza update: %s", goos)
 	}
+}
+
+// quotePowerShellSingleQuoted wraps a string in PowerShell single quotes,
+// escaping any embedded single quotes by doubling them. In PowerShell,
+// single-quoted strings are literal (no variable interpolation), so this is
+// the safest way to embed an arbitrary URL as a constant in a -Command script.
+func quotePowerShellSingleQuoted(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 func lookPathAny(lookPath func(string) (string, error), names []string) (string, error) {

--- a/cmd/waza/cmd_update_test.go
+++ b/cmd/waza/cmd_update_test.go
@@ -205,13 +205,18 @@ func TestUpdateCommand_WindowsUsesPowerShellInstaller(t *testing.T) {
 		RunCommand: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader, out, errOut io.Writer) error {
 			ran = true
 			assert.Contains(t, name, "powershell.exe")
-			require.Len(t, args, 6)
+			require.Len(t, args, 5)
 			assert.Equal(t, "-NoProfile", args[0])
 			assert.Equal(t, "-ExecutionPolicy", args[1])
 			assert.Equal(t, "Bypass", args[2])
 			assert.Equal(t, "-Command", args[3])
 			assert.Contains(t, args[4], "Invoke-RestMethod")
-			assert.Equal(t, "https://example.com/install.ps1", args[5])
+			// The installer URL must be embedded directly in the script
+			// (single-quoted) rather than passed as a positional argument,
+			// because PowerShell's -Command does not bind trailing args to
+			// $args reliably. Regression test for #448.
+			assert.Contains(t, args[4], "'https://example.com/install.ps1'")
+			assert.NotContains(t, args[4], "$args")
 			require.Len(t, env, 2)
 			assert.Contains(t, env[0], "WAZA_UPDATE_PARENT_PID=")
 			assert.Equal(t, "WAZA_INSTALL_DIR="+filepath.Dir("C:/tools/waza.exe"), env[1])
@@ -228,6 +233,71 @@ func TestUpdateCommand_WindowsUsesPowerShellInstaller(t *testing.T) {
 	assert.Contains(t, stdout.String(), "PowerShell installer")
 	assert.Contains(t, stdout.String(), "Update started")
 }
+
+func TestUpdateCommand_WindowsEmbedsURLInsteadOfPassingAsArg(t *testing.T) {
+	// Regression test for https://github.com/microsoft/waza/issues/448.
+	//
+	// Previously, the Windows update command passed the installer URL as a
+	// trailing positional argument to `pwsh -Command "... $args[0] ..."`.
+	// PowerShell's -Command does not bind trailing positional arguments to
+	// $args inside the script block (unlike -File), which caused
+	// Invoke-RestMethod to be invoked with a null/empty -Uri and fail.
+	//
+	// The fix embeds the URL directly in the -Command script as a
+	// single-quoted PowerShell literal, so no argument binding is required.
+	installer, err := installerForOS("windows", updateCommandOptions{
+		PowerShellInstallerURL: "https://example.com/install.ps1",
+		ExecutablePath:         "C:/tools/waza.exe",
+	})
+	require.NoError(t, err)
+
+	// The final args slice must NOT include the URL as a trailing positional
+	// argument, and the script must NOT reference $args.
+	require.Len(t, installer.Args, 5)
+	for _, arg := range installer.Args {
+		assert.NotEqual(t, "https://example.com/install.ps1", arg,
+			"URL must not be passed as a trailing positional argument (see #448)")
+	}
+
+	script := installer.Args[4]
+	assert.NotContains(t, script, "$args", "script must not depend on $args (see #448)")
+	assert.Contains(t, script, "Invoke-RestMethod -Uri 'https://example.com/install.ps1'",
+		"URL must be embedded as a single-quoted literal in the script")
+}
+
+func TestUpdateCommand_WindowsEscapesSingleQuotesInURL(t *testing.T) {
+	// Defense in depth: if the installer URL ever contains a single quote,
+	// it must be escaped by doubling so it can't break out of the
+	// single-quoted PowerShell literal.
+	installer, err := installerForOS("windows", updateCommandOptions{
+		PowerShellInstallerURL: "https://example.com/inst'all.ps1",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, installer.Args, 5)
+	script := installer.Args[4]
+	assert.Contains(t, script, "'https://example.com/inst''all.ps1'")
+}
+
+func TestQuotePowerShellSingleQuoted(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain URL", "https://example.com/install.ps1", "'https://example.com/install.ps1'"},
+		{"empty", "", "''"},
+		{"single quote is doubled", "a'b", "'a''b'"},
+		{"multiple single quotes", "'x'y'", "'''x''y'''"},
+		{"no interpolation of dollar sign", "$env:foo", "'$env:foo'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, quotePowerShellSingleQuoted(tc.in))
+		})
+	}
+}
+
 
 func TestUpdateCommand_MissingPowerShellReturnsGuidance(t *testing.T) {
 	cmd := newUpdateCommandWithOptions(&updateCommandOptions{


### PR DESCRIPTION
Closes #448

## Problem

On Windows, `waza update` failed with:

```
Invoke-RestMethod: Cannot validate argument on parameter 'Uri'.
The argument is null or empty.
```

## Root cause

The Windows installer was invoked as:

```
pwsh -NoProfile -ExecutionPolicy Bypass -Command "<script>" <installer-url>
```

PowerShell's `-Command` **does not** bind trailing positional arguments to `$args` inside the script block (unlike `-File`), so `Invoke-RestMethod -Uri $args[0]` received a null/empty value.

## Fix

Embed the installer URL directly into the `-Command` script as a single-quoted PowerShell literal via a new `quotePowerShellSingleQuoted` helper. Single-quoted PS strings are literal (no `$` interpolation), and embedded single quotes are escaped by doubling. The `Args` slice no longer carries a trailing URL positional argument.

## Tests

- Updated `TestUpdateCommand_WindowsUsesPowerShellInstaller` — asserts args length 5 and that the URL appears embedded in the script, not as `$args[0]`.
- Added `TestUpdateCommand_WindowsEmbedsURLInsteadOfPassingAsArg` — regression test for #448.
- Added `TestUpdateCommand_WindowsEscapesSingleQuotesInURL` — verifies `'` doubling.
- Added `TestQuotePowerShellSingleQuoted` — table-driven helper coverage.

`go test ./...` passes locally.