### PR TITLE
fix: bind Windows update installer URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows update command** — `waza update` now passes the PowerShell installer URL reliably, preventing `Invoke-RestMethod` from failing with a null or empty `Uri` (#448).
+
 ## [0.38.3] - 2026-07-17
 
 ### Fixed

--- a/cmd/waza/cmd_update.go
+++ b/cmd/waza/cmd_update.go
@@ -17,6 +17,7 @@ import (
 )
 
 const latestReleaseURL = "https://github.com/microsoft/waza/releases/latest"
+const powerShellInstallerCommand = `& { param([string] $InstallerUrl) if ([string]::IsNullOrWhiteSpace($InstallerUrl)) { throw 'Installer URL argument was not provided.' }; $ErrorActionPreference = 'Stop'; Invoke-Expression (Invoke-RestMethod -Uri $InstallerUrl) }`
 
 type updateCommandOptions struct {
 	BashInstallerURL       string
@@ -175,7 +176,6 @@ func installerForOS(goos string, opts updateCommandOptions) (updateInstaller, er
 			Args:       []string{"-c", `set -euo pipefail; curl -fsSL "$1" | bash`, "waza-installer", opts.BashInstallerURL},
 		}, nil
 	case "windows":
-		script := `$ErrorActionPreference = 'Stop'; Invoke-Expression (Invoke-RestMethod -Uri $args[0])`
 		env := []string{fmt.Sprintf("WAZA_UPDATE_PARENT_PID=%d", os.Getpid())}
 		if opts.ExecutablePath != "" {
 			env = append(env, fmt.Sprintf("WAZA_INSTALL_DIR=%s", filepath.Dir(opts.ExecutablePath)))
@@ -184,7 +184,7 @@ func installerForOS(goos string, opts updateCommandOptions) (updateInstaller, er
 			Name:       "PowerShell",
 			ScriptURL:  opts.PowerShellInstallerURL,
 			Candidates: []string{"pwsh", "powershell"},
-			Args:       []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script, opts.PowerShellInstallerURL},
+			Args:       []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", powerShellInstallerCommand, "-InstallerUrl", opts.PowerShellInstallerURL},
 			Env:        env,
 			Async:      true,
 		}, nil

--- a/cmd/waza/cmd_update_test.go
+++ b/cmd/waza/cmd_update_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -205,13 +206,17 @@ func TestUpdateCommand_WindowsUsesPowerShellInstaller(t *testing.T) {
 		RunCommand: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader, out, errOut io.Writer) error {
 			ran = true
 			assert.Contains(t, name, "powershell.exe")
-			require.Len(t, args, 6)
+			require.Len(t, args, 7)
 			assert.Equal(t, "-NoProfile", args[0])
 			assert.Equal(t, "-ExecutionPolicy", args[1])
 			assert.Equal(t, "Bypass", args[2])
 			assert.Equal(t, "-Command", args[3])
 			assert.Contains(t, args[4], "Invoke-RestMethod")
-			assert.Equal(t, "https://example.com/install.ps1", args[5])
+			assert.Contains(t, args[4], "param(")
+			assert.Contains(t, args[4], "$InstallerUrl")
+			assert.NotContains(t, args[4], "$args[0]")
+			assert.Equal(t, "-InstallerUrl", args[5])
+			assert.Equal(t, "https://example.com/install.ps1", args[6])
 			require.Len(t, env, 2)
 			assert.Contains(t, env[0], "WAZA_UPDATE_PARENT_PID=")
 			assert.Equal(t, "WAZA_INSTALL_DIR="+filepath.Dir("C:/tools/waza.exe"), env[1])
@@ -227,6 +232,34 @@ func TestUpdateCommand_WindowsUsesPowerShellInstaller(t *testing.T) {
 	assert.Equal(t, []string{"pwsh", "powershell"}, lookups)
 	assert.Contains(t, stdout.String(), "PowerShell installer")
 	assert.Contains(t, stdout.String(), "Update started")
+}
+
+func TestUpdateCommand_WindowsPowerShellArgumentsBindInstallerURL(t *testing.T) {
+	pwshPath, err := exec.LookPath("pwsh")
+	if err != nil {
+		t.Skip("pwsh not available")
+	}
+
+	installer, err := installerForOS("windows", updateCommandOptions{
+		PowerShellInstallerURL: "https://example.com/install.ps1",
+	})
+	require.NoError(t, err)
+	require.Len(t, installer.Args, 7)
+
+	script := strings.Replace(
+		installer.Args[4],
+		"$ErrorActionPreference = 'Stop';",
+		`$ErrorActionPreference = 'Stop'; function Invoke-RestMethod { param([string] $Uri) if ([string]::IsNullOrEmpty($Uri)) { throw 'empty Uri' }; return "installer:$Uri" }; function Invoke-Expression { param([string] $Command) Write-Output $Command };`,
+		1,
+	)
+	require.NotEqual(t, installer.Args[4], script)
+
+	args := append([]string(nil), installer.Args...)
+	args[4] = script
+	cmd := exec.Command(pwshPath, args...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	assert.Equal(t, "installer:https://example.com/install.ps1", strings.TrimSpace(string(output)))
 }
 
 func TestUpdateCommand_MissingPowerShellReturnsGuidance(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix Windows `waza update` PowerShell invocation so the installer URL is bound via a script-block parameter instead of `$args[0]` after `-Command`.
- Add regression coverage for the Windows argv shape, including a `pwsh`-backed test that mocks `Invoke-RestMethod` and verifies the URL reaches `-Uri`.

## Tests
- `go test ./cmd/waza -run 'TestUpdateCommand|TestShouldRunUpdateCheck|TestRootCommand_RegistersUpdateCommand' -count=1`
- `go test ./...`

Closes #448
