### PR TITLE
fix: expose configured MCP server tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Windows update command** — `waza update` now passes the PowerShell installer URL reliably, preventing `Invoke-RestMethod` from failing with a null or empty `Uri` (#448).
 - **JSON schema grader configuration** — `json_schema` graders now accept the documented `extract_json` option in eval and task YAML, extracting exactly one JSON object or array candidate before schema validation (#457).
+- **Live MCP server tool availability** — `config.mcp_servers` entries now default omitted `tools` to `["*"]`, matching MCP mock behavior so configured stdio and HTTP servers expose their tools to Copilot SDK evaluations (#449).
 
 ## [0.38.3] - 2026-07-17
 

--- a/internal/copilotconfig/mcp.go
+++ b/internal/copilotconfig/mcp.go
@@ -88,7 +88,7 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 }
 
 func defaultMCPTools(cfgMap map[string]any, tools *[]string) {
-	if _, ok := cfgMap["tools"]; !ok {
+	if value, ok := cfgMap["tools"]; !ok || value == nil {
 		*tools = []string{"*"}
 	}
 }

--- a/internal/copilotconfig/mcp.go
+++ b/internal/copilotconfig/mcp.go
@@ -48,6 +48,7 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 				warnf("Warning: mcp_server %q stdio config is invalid: %v, skipping\n", name, err)
 				continue
 			}
+			defaultMCPTools(cfgMap, &stdio.Tools)
 			result[name] = stdio
 		case "http", "sse":
 			var http copilot.MCPHTTPServerConfig
@@ -55,6 +56,7 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 				warnf("Warning: mcp_server %q http config is invalid: %v, skipping\n", name, err)
 				continue
 			}
+			defaultMCPTools(cfgMap, &http.Tools)
 			result[name] = http
 		default:
 			warnf("Warning: mcp_server %q has unsupported type %q, skipping\n", name, serverType)
@@ -83,6 +85,12 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 		return nil
 	}
 	return result
+}
+
+func defaultMCPTools(cfgMap map[string]any, tools *[]string) {
+	if _, ok := cfgMap["tools"]; !ok {
+		*tools = []string{"*"}
+	}
 }
 
 func mockServerConfig(cfg mcpmock.Config) (copilot.MCPStdioServerConfig, error) {

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -52,8 +52,45 @@ func TestConvertMCPServersWithMocks_PreservesRegularServers(t *testing.T) {
 	}, nil, "", nil)
 
 	require.Contains(t, servers, "regular")
-	_, ok := servers["regular"].(copilot.MCPStdioServerConfig)
+	stdio, ok := servers["regular"].(copilot.MCPStdioServerConfig)
 	require.True(t, ok)
+	require.Equal(t, []string{"*"}, stdio.Tools)
+}
+
+func TestConvertMCPServersWithMocks_PreservesExplicitToolAllowlist(t *testing.T) {
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"stdio": map[string]any{
+			"type":    "stdio",
+			"command": "echo",
+			"tools":   []any{"one", "two"},
+		},
+		"http": map[string]any{
+			"type":  "http",
+			"url":   "https://example.test/mcp",
+			"tools": []any{},
+		},
+	}, nil, "", nil)
+
+	stdio, ok := servers["stdio"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Equal(t, []string{"one", "two"}, stdio.Tools)
+
+	http, ok := servers["http"].(copilot.MCPHTTPServerConfig)
+	require.True(t, ok)
+	require.Empty(t, http.Tools)
+}
+
+func TestConvertMCPServersWithMocks_DefaultsHTTPToolsToAll(t *testing.T) {
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"remote": map[string]any{
+			"type": "http",
+			"url":  "https://example.test/mcp",
+		},
+	}, nil, "", nil)
+
+	http, ok := servers["remote"].(copilot.MCPHTTPServerConfig)
+	require.True(t, ok)
+	require.Equal(t, []string{"*"}, http.Tools)
 }
 
 func TestConvertMCPServersWithMocks_InvalidMockDisablesLiveServerFallback(t *testing.T) {

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -95,11 +95,20 @@ func TestConvertMCPServersWithMocks_DefaultsHTTPToolsToAll(t *testing.T) {
 			"type": "http",
 			"url":  "https://example.test/mcp",
 		},
+		"stdio-null": map[string]any{
+			"type":    "stdio",
+			"command": "echo",
+			"tools":   nil,
+		},
 	}, nil, "", nil)
 
 	http, ok := servers["remote"].(copilot.MCPHTTPServerConfig)
 	require.True(t, ok)
 	require.Equal(t, []string{"*"}, http.Tools)
+
+	stdio, ok := servers["stdio-null"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Equal(t, []string{"*"}, stdio.Tools)
 }
 
 func TestConvertMCPServersWithMocks_InvalidMockDisablesLiveServerFallback(t *testing.T) {

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -69,6 +69,11 @@ func TestConvertMCPServersWithMocks_PreservesExplicitToolAllowlist(t *testing.T)
 			"url":   "https://example.test/mcp",
 			"tools": []any{},
 		},
+		"stdio-empty": map[string]any{
+			"type":    "stdio",
+			"command": "cat",
+			"tools":   []any{},
+		},
 	}, nil, "", nil)
 
 	stdio, ok := servers["stdio"].(copilot.MCPStdioServerConfig)
@@ -78,6 +83,10 @@ func TestConvertMCPServersWithMocks_PreservesExplicitToolAllowlist(t *testing.T)
 	http, ok := servers["http"].(copilot.MCPHTTPServerConfig)
 	require.True(t, ok)
 	require.Empty(t, http.Tools)
+
+	stdioEmpty, ok := servers["stdio-empty"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Empty(t, stdioEmpty.Tools)
 }
 
 func TestConvertMCPServersWithMocks_DefaultsHTTPToolsToAll(t *testing.T) {

--- a/internal/trigger/runner_test.go
+++ b/internal/trigger/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	copilot "github.com/github/copilot-sdk/go"
 	"github.com/microsoft/waza/internal/config"
 	"github.com/microsoft/waza/internal/execution"
 	"github.com/microsoft/waza/internal/models"
@@ -415,6 +416,9 @@ func TestEvalRunnerPassesMCPServers(t *testing.T) {
 	require.NotNil(t, engine.LastReq())
 	require.Len(t, engine.LastReq().MCPServers, 1, "expected 1 MCP server")
 	require.Contains(t, engine.LastReq().MCPServers, "test-mcp")
+	stdio, ok := engine.LastReq().MCPServers["test-mcp"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Equal(t, []string{"*"}, stdio.Tools)
 }
 
 func TestLoadFixtureDir_EmptyDir(t *testing.T) {

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -128,7 +128,7 @@ config:
 | `inject_skill_body` | bool      | true              | Inject the target `SKILL.md` or `.agent.md` body into the system prompt |
 | `disabled_skills`   | list[str] | `[]`              | Skills to disable. Use `["*"]` to disable all skills        |
 | `required_skills`   | list[str] | `[]`              | Skills that must be available before running                |
-| `mcp_servers`       | object    | —                 | MCP server configurations for the evaluation. When `tools` is omitted for a server, Waza exposes all server tools by sending `["*"]` to the Copilot SDK. |
+| `mcp_servers`       | object    | —                 | MCP server configurations for the evaluation. When `tools` is omitted or null for a server, Waza exposes all server tools by sending `["*"]` to the Copilot SDK. Set `tools` to an explicit list, including `[]`, to restrict or disable exposed tools. |
 
 ### Trigger-precision evals
 

--- a/site/src/content/docs/guides/eval-yaml.mdx
+++ b/site/src/content/docs/guides/eval-yaml.mdx
@@ -128,7 +128,7 @@ config:
 | `inject_skill_body` | bool      | true              | Inject the target `SKILL.md` or `.agent.md` body into the system prompt |
 | `disabled_skills`   | list[str] | `[]`              | Skills to disable. Use `["*"]` to disable all skills        |
 | `required_skills`   | list[str] | `[]`              | Skills that must be available before running                |
-| `mcp_servers`       | object    | —                 | MCP server configurations for the evaluation                |
+| `mcp_servers`       | object    | —                 | MCP server configurations for the evaluation. When `tools` is omitted for a server, Waza exposes all server tools by sending `["*"]` to the Copilot SDK. |
 
 ### Trigger-precision evals
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -431,6 +431,7 @@ config:
       args: [--root, /data]
       tools: ["*"]
     github:
+      type: http
       url: http://localhost:3000
 ```
 

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -421,6 +421,7 @@ config:
 **Default:** (none)
 
 MCP (Model Context Protocol) server configurations for this evaluation. Each key is a server name, and the value is its configuration.
+When `tools` is omitted for a live stdio or HTTP/SSE server, Waza exposes all tools by sending an explicit `["*"]` allowlist to the Copilot SDK. Set `tools` explicitly to restrict or disable exposed tools.
 
 ```yaml
 config:
@@ -428,6 +429,7 @@ config:
     filesystem:
       command: /path/to/server
       args: [--root, /data]
+      tools: ["*"]
     github:
       url: http://localhost:3000
 ```

--- a/site/src/content/docs/reference/schema.mdx
+++ b/site/src/content/docs/reference/schema.mdx
@@ -421,7 +421,7 @@ config:
 **Default:** (none)
 
 MCP (Model Context Protocol) server configurations for this evaluation. Each key is a server name, and the value is its configuration.
-When `tools` is omitted for a live stdio or HTTP/SSE server, Waza exposes all tools by sending an explicit `["*"]` allowlist to the Copilot SDK. Set `tools` explicitly to restrict or disable exposed tools.
+When `tools` is omitted or null for a live stdio or HTTP/SSE server, Waza exposes all tools by sending an explicit `["*"]` allowlist to the Copilot SDK. Set `tools` to an explicit list, including `[]`, to restrict or disable exposed tools.
 
 ```yaml
 config:


### PR DESCRIPTION
## Summary

Configured `mcp_servers` entries now default to an explicit `tools: ["*"]` allowlist when eval YAML omits `tools`. This matches the behavior already required for hermetic MCP mock servers and ensures configured stdio/HTTP MCP servers are exposed to the embedded Copilot CLI instead of being loaded without available tools.

## Related issue

Refs #449

## Agent handoff

- Scope: Surgical conversion-layer fix for eval `mcp_servers` configs.
- Key files changed: `internal/copilotconfig/mcp.go`, `internal/copilotconfig/mcp_test.go`, `internal/trigger/runner_test.go`.
- Important decisions: Preserve explicit `tools` settings, including `tools: []`, and only default omitted `tools` to `*`.
- Follow-ups or known gaps: Live BYOK validation was not run because it requires external provider credentials; regression coverage verifies the request wiring that controls MCP tool exposure.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor or maintenance
- [ ] CI/CD or release change

## Validation

- [x] `go test ./...`
- [ ] `make lint` or `golangci-lint run`
- [ ] Docs site checked, if docs changed
- [ ] Web/dashboard checks run, if `web/` changed
- [x] Manual validation completed: targeted `go test ./internal/copilotconfig ./internal/trigger ./internal/execution`
- [ ] Not applicable; reason:

## Documentation

- [ ] README updated, if user-facing behavior changed
- [ ] `site/` docs updated, if CLI, YAML, dashboard, or validator behavior changed
- [ ] Examples updated, if relevant
- [x] Not applicable

## Risk and rollback

- Risk level: Low
- Rollback plan: Revert this PR to restore prior omitted-`tools` behavior.

## Notes for reviewers

The critical compatibility point is that explicit `tools` values remain authoritative. Only omitted `tools` is normalized to `[]string{"*"}` before the SDK receives the MCP server config.
