### PR TITLE
fix: spawn user-supplied MCP stdio/http servers from mcp_servers config (#449)

### DIFF
--- a/internal/copilotconfig/mcp.go
+++ b/internal/copilotconfig/mcp.go
@@ -48,12 +48,31 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 				warnf("Warning: mcp_server %q stdio config is invalid: %v, skipping\n", name, err)
 				continue
 			}
+			if strings.TrimSpace(stdio.Command) == "" {
+				warnf("Warning: mcp_server %q stdio config is missing required 'command' field, skipping\n", name)
+				continue
+			}
+			// The bundled Copilot CLI does not spawn MCP servers when the tool
+			// allowlist is omitted. Default to "all tools" so user-supplied
+			// servers behave the same way as the SDK's documented default and
+			// as the hermetic mock servers. Callers that need a narrower
+			// allowlist can still pass an explicit `tools:` list in YAML.
+			if stdio.Tools == nil {
+				stdio.Tools = []string{"*"}
+			}
 			result[name] = stdio
 		case "http", "sse":
 			var http copilot.MCPHTTPServerConfig
 			if err := decode(cfgMap, &http); err != nil {
 				warnf("Warning: mcp_server %q http config is invalid: %v, skipping\n", name, err)
 				continue
+			}
+			if strings.TrimSpace(http.URL) == "" {
+				warnf("Warning: mcp_server %q http config is missing required 'url' field, skipping\n", name)
+				continue
+			}
+			if http.Tools == nil {
+				http.Tools = []string{"*"}
 			}
 			result[name] = http
 		default:

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -52,8 +52,102 @@ func TestConvertMCPServersWithMocks_PreservesRegularServers(t *testing.T) {
 	}, nil, "", nil)
 
 	require.Contains(t, servers, "regular")
-	_, ok := servers["regular"].(copilot.MCPStdioServerConfig)
+	stdio, ok := servers["regular"].(copilot.MCPStdioServerConfig)
 	require.True(t, ok)
+	require.Equal(t, "echo", stdio.Command)
+	// Regression for #449: user-supplied stdio servers must default the tool
+	// allowlist to "*" so the bundled Copilot CLI actually spawns them.
+	require.Equal(t, []string{"*"}, stdio.Tools)
+}
+
+func TestConvertMCPServersWithMocks_DefaultsToolsAllowlistForStdio(t *testing.T) {
+	// Regression for #449: YAML `mcp_servers` entries loaded as generic maps
+	// (mimicking gopkg.in/yaml.v3 output) must produce a stdio config with a
+	// non-nil Tools allowlist and a fully populated Command/Args/Env.
+	var warnings []string
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"probe": map[string]any{
+			"command": "python",
+			"args":    []any{"mcp_probe_server.py"},
+			"env": map[string]any{
+				"WAZA_PROBE_MARKER": "on",
+			},
+		},
+	}, nil, "", func(format string, args ...any) {
+		warnings = append(warnings, fmtString(format, args...))
+	})
+
+	require.Empty(t, warnings)
+	require.Contains(t, servers, "probe")
+	stdio, ok := servers["probe"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Equal(t, "python", stdio.Command)
+	require.Equal(t, []string{"mcp_probe_server.py"}, stdio.Args)
+	require.Equal(t, "on", stdio.Env["WAZA_PROBE_MARKER"])
+	require.Equal(t, []string{"*"}, stdio.Tools,
+		"user-supplied stdio MCP servers must default Tools to [\"*\"] so the CLI spawns them")
+}
+
+func TestConvertMCPServersWithMocks_PreservesExplicitToolsAllowlist(t *testing.T) {
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"probe": map[string]any{
+			"command": "python",
+			"args":    []any{"mcp_probe_server.py"},
+			"tools":   []any{"only_this_tool"},
+		},
+	}, nil, "", nil)
+
+	stdio, ok := servers["probe"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Equal(t, []string{"only_this_tool"}, stdio.Tools,
+		"an explicit tools allowlist from YAML must be preserved verbatim")
+}
+
+func TestConvertMCPServersWithMocks_DefaultsToolsAllowlistForHTTP(t *testing.T) {
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"remote": map[string]any{
+			"type": "http",
+			"url":  "https://example.com/mcp",
+		},
+	}, nil, "", nil)
+
+	http, ok := servers["remote"].(copilot.MCPHTTPServerConfig)
+	require.True(t, ok)
+	require.Equal(t, "https://example.com/mcp", http.URL)
+	require.Equal(t, []string{"*"}, http.Tools,
+		"user-supplied HTTP MCP servers must default Tools to [\"*\"]")
+}
+
+func TestConvertMCPServersWithMocks_SkipsStdioMissingCommand(t *testing.T) {
+	// Regression for #449: a config with no command silently produced an empty
+	// MCPStdioServerConfig that the CLI would ignore. Now we skip it and warn.
+	var warnings []string
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"broken": map[string]any{
+			"args": []any{"mcp_probe_server.py"},
+		},
+	}, nil, "", func(format string, args ...any) {
+		warnings = append(warnings, fmtString(format, args...))
+	})
+
+	require.NotContains(t, servers, "broken")
+	require.NotEmpty(t, warnings)
+	require.Contains(t, warnings[0], "command")
+}
+
+func TestConvertMCPServersWithMocks_SkipsHTTPMissingURL(t *testing.T) {
+	var warnings []string
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"broken": map[string]any{
+			"type": "http",
+		},
+	}, nil, "", func(format string, args ...any) {
+		warnings = append(warnings, fmtString(format, args...))
+	})
+
+	require.NotContains(t, servers, "broken")
+	require.NotEmpty(t, warnings)
+	require.Contains(t, warnings[0], "url")
 }
 
 func TestConvertMCPServersWithMocks_InvalidMockDisablesLiveServerFallback(t *testing.T) {

--- a/internal/trigger/runner_test.go
+++ b/internal/trigger/runner_test.go
@@ -425,9 +425,9 @@ func TestLoadFixtureDir_EmptyDir(t *testing.T) {
 
 func TestConvertMCPServers_SkipsNonMapEntries(t *testing.T) {
 	result := convertMCPServers(map[string]any{
-		"good":  map[string]any{"type": "stdio"},
+		"good":  map[string]any{"type": "stdio", "command": "echo"},
 		"bad":   "not-a-map",
-		"good2": map[string]any{"type": "sse"},
+		"good2": map[string]any{"type": "sse", "url": "https://example.com/mcp"},
 	}, nil, "")
 	require.Len(t, result, 2)
 	require.Contains(t, result, "good")


### PR DESCRIPTION
Closes #449

## Root cause

`session.mcp_servers_loaded` was firing, but the bundled Copilot CLI silently refused to spawn the servers because their `tools` allowlist was omitted on the wire. The mock code path already worked around this (`internal/copilotconfig/mcp.go` line ~104, with an explanatory comment), but user-supplied `mcp_servers` entries were passed through without the same default, so no MCP process ever started and no MCP tools were available to the agent — including under BYOK custom providers.

## Fix

In `ConvertMCPServersWithMocks`:

- Default `Tools` to `["*"]` for stdio and http/sse entries when the YAML omits it, matching the mock path.
- Explicit user allowlists are preserved unchanged.
- Reject stdio entries with no `command` and http/sse entries with no `url` up front with a warning, instead of silently forwarding an empty config the CLI would drop.

## Changed files

- `internal/copilotconfig/mcp.go` — default `Tools` + validate required fields.
- `internal/copilotconfig/mcp_test.go` — 5 new regression tests + expanded existing preservation test.
- `internal/trigger/runner_test.go` — updated one test to supply valid `command`/`url` (it previously relied on the buggy silent-empty-config behavior).

## Validation

- `go test ./...` — full suite green.
- `make build`, `make lint` — green (0 issues).
- New tests cover: stdio default, http default, explicit allowlist preservation, stdio missing command, http missing URL.