### PR TITLE
fix: default MCP server tools allowlist for user-supplied servers (#449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BYO MCP servers with copilot-sdk executor** — User-supplied `mcp_servers` (stdio, http, and sse) now default the `tools` allowlist to `["*"]` when omitted, matching the workaround previously applied to `mcp_mocks` in v0.38.3. The bundled Copilot CLI silently drops MCP servers whose `tools` field is absent, so configured servers were emitting `session.mcp_servers_loaded` events but never actually connecting or exposing tools. Users who explicitly set `tools: []` (opt-out) or a named allowlist keep their configuration verbatim (#449).
+
 ## [0.38.3] - 2026-07-17
 
 ### Fixed

--- a/internal/copilotconfig/mcp.go
+++ b/internal/copilotconfig/mcp.go
@@ -48,12 +48,22 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 				warnf("Warning: mcp_server %q stdio config is invalid: %v, skipping\n", name, err)
 				continue
 			}
+			// The bundled CLI silently drops MCP servers whose tool allowlist is
+			// omitted, so default to "*" (all tools) when the user did not set
+			// tools explicitly. See issue #449.
+			if stdio.Tools == nil {
+				stdio.Tools = []string{"*"}
+			}
 			result[name] = stdio
 		case "http", "sse":
 			var http copilot.MCPHTTPServerConfig
 			if err := decode(cfgMap, &http); err != nil {
 				warnf("Warning: mcp_server %q http config is invalid: %v, skipping\n", name, err)
 				continue
+			}
+			// Same allowlist workaround as stdio, applied to remote transports.
+			if http.Tools == nil {
+				http.Tools = []string{"*"}
 			}
 			result[name] = http
 		default:

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -52,8 +52,66 @@ func TestConvertMCPServersWithMocks_PreservesRegularServers(t *testing.T) {
 	}, nil, "", nil)
 
 	require.Contains(t, servers, "regular")
-	_, ok := servers["regular"].(copilot.MCPStdioServerConfig)
+	stdio, ok := servers["regular"].(copilot.MCPStdioServerConfig)
 	require.True(t, ok)
+	// Regression for issue #449: the bundled Copilot CLI silently drops MCP
+	// servers whose tools allowlist is omitted, so we must default to "*".
+	require.Equal(t, []string{"*"}, stdio.Tools)
+}
+
+func TestConvertMCPServersWithMocks_StdioDefaultsToolsAllowlistWhenTypeOmitted(t *testing.T) {
+	// Users often omit the "type" field for stdio servers; the default branch
+	// must still install the "*" allowlist workaround for issue #449.
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"probe": map[string]any{"command": "bash", "args": []any{"-c", "echo hi"}},
+	}, nil, "", nil)
+
+	stdio, ok := servers["probe"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Equal(t, []string{"*"}, stdio.Tools)
+}
+
+func TestConvertMCPServersWithMocks_HTTPDefaultsToolsAllowlist(t *testing.T) {
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"remote": map[string]any{"type": "http", "url": "https://example.com/mcp"},
+	}, nil, "", nil)
+
+	http, ok := servers["remote"].(copilot.MCPHTTPServerConfig)
+	require.True(t, ok)
+	require.Equal(t, []string{"*"}, http.Tools)
+}
+
+func TestConvertMCPServersWithMocks_PreservesExplicitToolsAllowlist(t *testing.T) {
+	// A user-supplied named allowlist must be respected verbatim; do not clobber
+	// with "*".
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"scoped": map[string]any{
+			"type":    "stdio",
+			"command": "echo",
+			"tools":   []any{"list_issues", "get_pr"},
+		},
+	}, nil, "", nil)
+
+	stdio, ok := servers["scoped"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Equal(t, []string{"list_issues", "get_pr"}, stdio.Tools)
+}
+
+func TestConvertMCPServersWithMocks_PreservesExplicitEmptyToolsAllowlist(t *testing.T) {
+	// An explicit empty allowlist is the SDK's "expose no tools" opt-out; the
+	// #449 default must not overwrite it.
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"muted": map[string]any{
+			"type":    "stdio",
+			"command": "echo",
+			"tools":   []any{},
+		},
+	}, nil, "", nil)
+
+	stdio, ok := servers["muted"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.NotNil(t, stdio.Tools)
+	require.Empty(t, stdio.Tools)
 }
 
 func TestConvertMCPServersWithMocks_InvalidMockDisablesLiveServerFallback(t *testing.T) {


### PR DESCRIPTION
Fixes #449.

## Repro

With `executor: copilot-sdk` and a stdio `mcp_servers` entry (no `tools:` field) — for example, a probe that writes a proof file when spawned:

```yaml
mcp_servers:
  nessie_candidate_probe:
    type: stdio
    command: bash
    args: ["-c", "touch /tmp/waza-449-proof && exec my-mcp-server"]
```

The session emits `session.mcp_servers_loaded` and `session.tools_updated`, but:

- the stdio subprocess is never spawned (no `/tmp/waza-449-proof` side effect), and
- the assistant cannot see any of the server's tools.

Reproduces on both the default provider and BYOK provider paths.

## Root cause

The bundled Copilot CLI shipped inside `copilot-sdk` **silently drops** MCP servers whose `tools` field is omitted on the wire, even though the SDK type docstring for `MCPStdioServerConfig.Tools` says:

> nil (omitted from the wire): all tools (CLI default)

This is the exact same class of bug that #440 / #441 fixed for waza-built `mcp_mocks` (`internal/copilotconfig/mcp.go` already carries the comment "The bundled CLI rejects mock servers when the allowlist is omitted" and sets `Tools: []string{"*"}` for mocks). The user-supplied `mcp_servers` conversion path never got the same treatment — user stdio/http entries are decoded raw and forwarded with `Tools == nil`, so the CLI drops them.

## Fix

In `ConvertMCPServersWithMocks`, after decoding a user stdio or http/sse entry, default `Tools` to `[]string{"*"}` when it is nil. Explicit empty allowlists (`tools: []` opt-out) and named allowlists (`tools: [foo, bar]`) are preserved verbatim — we only inject the default when the user didn't say anything.

Surgical, mirrors the existing mock-server workaround, and stays production-safe.

## Tests

Adds 4 regression tests and tightens 1 existing test in `internal/copilotconfig/mcp_test.go`:

- `TestConvertMCPServersWithMocks_PreservesRegularServers` (tightened) — asserts stdio users get `Tools: ["*"]` by default.
- `TestConvertMCPServersWithMocks_StdioDefaultsToolsAllowlistWhenTypeOmitted` — covers the `"type"` omitted branch.
- `TestConvertMCPServersWithMocks_HTTPDefaultsToolsAllowlist` — covers http/sse.
- `TestConvertMCPServersWithMocks_PreservesExplicitToolsAllowlist` — named allowlist untouched.
- `TestConvertMCPServersWithMocks_PreservesExplicitEmptyToolsAllowlist` — explicit opt-out untouched.

All 6 tests in the package pass; the 4 new ones would have failed against `main` because `stdio.Tools` / `http.Tools` would be `nil` instead of `[]string{"*"}`.

## Verification

```
go test ./...           # all packages pass
golangci-lint run ./... # 0 issues
```

## Notes / upstream gap

The SDK type docstring (`~/go/pkg/mod/github.com/github/copilot-sdk/go@v1.0.6/types.go:830-834`) documents nil `Tools` as "all tools (CLI default)", but the bundled CLI does not honor that on the connect path. The workaround here matches the one used for `mcp_mocks` since v0.38.3. When the upstream CLI is fixed to actually treat omitted `tools` as "all tools", these defaults can be removed with no behavior change (`["*"]` is documented as "explicit all tools").