### PR TITLE
fix: start eval-configured MCP servers by default

### DIFF
--- a/internal/copilotconfig/mcp.go
+++ b/internal/copilotconfig/mcp.go
@@ -48,6 +48,7 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 				warnf("Warning: mcp_server %q stdio config is invalid: %v, skipping\n", name, err)
 				continue
 			}
+			defaultToolsToAll(cfgMap, &stdio.Tools)
 			result[name] = stdio
 		case "http", "sse":
 			var http copilot.MCPHTTPServerConfig
@@ -55,6 +56,7 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 				warnf("Warning: mcp_server %q http config is invalid: %v, skipping\n", name, err)
 				continue
 			}
+			defaultToolsToAll(cfgMap, &http.Tools)
 			result[name] = http
 		default:
 			warnf("Warning: mcp_server %q has unsupported type %q, skipping\n", name, serverType)
@@ -83,6 +85,13 @@ func ConvertMCPServersWithMocks(serverConfigs map[string]any, mocks []models.MCP
 		return nil
 	}
 	return result
+}
+
+func defaultToolsToAll(cfgMap map[string]any, tools *[]string) {
+	if _, ok := cfgMap["tools"]; ok && cfgMap["tools"] != nil {
+		return
+	}
+	*tools = []string{"*"}
 }
 
 func mockServerConfig(cfg mcpmock.Config) (copilot.MCPStdioServerConfig, error) {

--- a/internal/copilotconfig/mcp_test.go
+++ b/internal/copilotconfig/mcp_test.go
@@ -52,8 +52,20 @@ func TestConvertMCPServersWithMocks_PreservesRegularServers(t *testing.T) {
 	}, nil, "", nil)
 
 	require.Contains(t, servers, "regular")
-	_, ok := servers["regular"].(copilot.MCPStdioServerConfig)
+	stdio, ok := servers["regular"].(copilot.MCPStdioServerConfig)
 	require.True(t, ok)
+	require.Equal(t, []string{"*"}, stdio.Tools)
+}
+
+func TestConvertMCPServersWithMocks_PreservesExplicitEmptyTools(t *testing.T) {
+	servers := ConvertMCPServersWithMocks(map[string]any{
+		"regular": map[string]any{"type": "stdio", "command": "echo", "tools": []any{}},
+	}, nil, "", nil)
+
+	require.Contains(t, servers, "regular")
+	stdio, ok := servers["regular"].(copilot.MCPStdioServerConfig)
+	require.True(t, ok)
+	require.Empty(t, stdio.Tools)
 }
 
 func TestConvertMCPServersWithMocks_InvalidMockDisablesLiveServerFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #449 by making Waza's eval `config.mcp_servers` conversion match the Copilot SDK/CLI behavior needed for live MCP server startup: when a server omits `tools`, Waza now sends an explicit `tools: ["*"]` allowlist to the embedded Copilot CLI.

## Repro

On current `origin/main` (`a431744e`), I reproduced with a minimal stdio Python MCP probe server configured via `config.mcp_servers`. The probe writes `/tmp/waza-449-proof.log` on process start and exposes `nessie_candidate_probe`.

Observed before the fix:
- `session.mcp_servers_loaded` and `session.tools_updated` events were emitted.
- The proof file was not created, so the stdio process was not spawned.
- The assistant reported `nessie_candidate_probe` was unavailable.

Adding `tools: ["*"]` manually to the eval config made the same probe spawn and the tool returned `probe:hi`.

## Root cause

Waza decoded live eval `mcp_servers` and forwarded them to `copilot.SessionConfig.MCPServers`, but left `Tools` nil when the YAML omitted `tools`. The embedded CLI path used by Waza does not start/connect that eval-configured MCP server unless an explicit tool allowlist is present. Waza already applies this workaround for hermetic `mcp_mocks`; live `config.mcp_servers` needed the same default.

## Fix

- Default omitted `tools` to `[]string{"*"}` for converted stdio and HTTP/SSE MCP server configs.
- Preserve an explicitly configured empty `tools: []` list so users can intentionally expose no tools.
- Added regression coverage for both omitted and explicit-empty tool allowlists.

## Test evidence

- `go test ./internal/copilotconfig ./internal/execution ./internal/orchestration ./internal/trigger`
- `go test ./...`
- `make lint`
- Manual repro after fix, with omitted `tools`: proof file was created and `nessie_candidate_probe` executed successfully, returning `probe:hi`.

