### PR TITLE
fix: enforce json_schema extract_json selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Windows update command** — `waza update` now passes the PowerShell installer URL reliably, preventing `Invoke-RestMethod` from failing with a null or empty `Uri` (#448).
-- **JSON schema grader configuration** — `json_schema` graders now accept the documented `extract_json` option in eval and task YAML (#457).
+- **JSON schema grader configuration** — `json_schema` graders now accept the documented `extract_json` option in eval and task YAML, extracting exactly one JSON object or array candidate before schema validation (#457).
 
 ## [0.38.3] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Windows update command** — `waza update` now passes the PowerShell installer URL reliably, preventing `Invoke-RestMethod` from failing with a null or empty `Uri` (#448).
+- **JSON schema grader configuration** — `json_schema` graders now accept the documented `extract_json` option in eval and task YAML (#457).
 
 ## [0.38.3] - 2026-07-17
 

--- a/docs/graders/json_schema.md
+++ b/docs/graders/json_schema.md
@@ -24,14 +24,15 @@ Validates that the agent output is valid JSON conforming to a given JSON schema.
 |--------|------|-------------|
 | `schema` | object | Inline JSON schema for validation |
 | `schema_file` | string | Path to a JSON schema file (used when `schema` is not provided) |
-| `extract_json` | boolean | Extract one JSON document from prose or a Markdown JSON code block before validation (default: `false`) |
+| `extract_json` | boolean | Extract exactly one JSON object or array from prose or a Markdown JSON code block before validation (default: `false`) |
 
 One of `schema` or `schema_file` must be specified.
 
 By default, the output must be pure JSON. Set `extract_json: true` when the
 agent may add prose or wrap its response in a JSON code block. Extraction
-requires exactly one JSON document; responses with multiple JSON documents
-still fail to avoid validating an ambiguous fragment.
+requires exactly one JSON object or array; responses with zero or multiple
+candidate JSON documents fail to avoid validating an absent or ambiguous
+fragment.
 
 **Scoring:** Binary — `1.0` if the output is valid JSON matching the schema, `0.0` otherwise.
 

--- a/internal/graders/json_schema_grader.go
+++ b/internal/graders/json_schema_grader.go
@@ -43,12 +43,16 @@ func (jsg *jsonSchemaGrader) Grade(ctx context.Context, gradingContext *Context)
 		// remains the default contract for this grader.
 		outputValue, err := parseJSONOutput(gradingContext.Output, jsg.extractJSON)
 		if err != nil {
+			feedback := fmt.Sprintf("Output is not valid JSON: %v", err)
+			if jsg.extractJSON {
+				feedback = fmt.Sprintf("Output must contain exactly one JSON object or array: %v", err)
+			}
 			return &models.GraderResults{
 				Name:     jsg.name,
 				Type:     models.GraderKindJSONSchema,
 				Score:    0.0,
 				Passed:   false,
-				Feedback: fmt.Sprintf("Output is not valid JSON: %v", err),
+				Feedback: feedback,
 				Details: map[string]any{
 					"error": err.Error(),
 				},
@@ -91,14 +95,16 @@ func (jsg *jsonSchemaGrader) Grade(ctx context.Context, gradingContext *Context)
 }
 
 func parseJSONOutput(output string, extractJSON bool) (any, error) {
+	if extractJSON {
+		return exactlyOneJSONValue(embeddedJSONValues(output))
+	}
+
 	var outputValue any
-	if err := json.Unmarshal([]byte(output), &outputValue); err == nil {
-		return outputValue, nil
-	} else if !extractJSON {
+	if err := json.Unmarshal([]byte(output), &outputValue); err != nil {
 		return nil, err
 	}
 
-	return exactlyOneJSONValue(embeddedJSONValues(output))
+	return outputValue, nil
 }
 
 func embeddedJSONValues(output string) []any {
@@ -124,11 +130,11 @@ func embeddedJSONValues(output string) []any {
 func exactlyOneJSONValue(values []any) (any, error) {
 	switch len(values) {
 	case 0:
-		return nil, fmt.Errorf("output does not contain a JSON document")
+		return nil, fmt.Errorf("found zero JSON object or array documents")
 	case 1:
 		return values[0], nil
 	default:
-		return nil, fmt.Errorf("output contains multiple JSON documents")
+		return nil, fmt.Errorf("found multiple JSON object or array documents")
 	}
 }
 

--- a/internal/graders/json_schema_grader_test.go
+++ b/internal/graders/json_schema_grader_test.go
@@ -128,6 +128,20 @@ func TestJSONSchemaGrader_Grade(t *testing.T) {
 		require.True(t, results.Passed)
 	})
 
+	t.Run("extract_json handles pure JSON output", func(t *testing.T) {
+		g, err := NewJSONSchemaGrader("test", models.JSONSchemaGraderParameters{
+			Schema:      map[string]any{"type": "object", "required": []any{"name"}},
+			ExtractJSON: true,
+		})
+		require.NoError(t, err)
+
+		results, err := g.Grade(context.Background(), &Context{
+			Output: `{"name":"Alice"}`,
+		})
+		require.NoError(t, err)
+		require.True(t, results.Passed)
+	})
+
 	t.Run("extract_json rejects output with zero JSON documents", func(t *testing.T) {
 		g, err := NewJSONSchemaGrader("test", models.JSONSchemaGraderParameters{
 			Schema:      map[string]any{"type": "object"},

--- a/internal/graders/json_schema_grader_test.go
+++ b/internal/graders/json_schema_grader_test.go
@@ -111,6 +111,54 @@ func TestJSONSchemaGrader_Grade(t *testing.T) {
 		require.True(t, results.Passed)
 	})
 
+	t.Run("extract_json handles one JSON array document", func(t *testing.T) {
+		g, err := NewJSONSchemaGrader("test", models.JSONSchemaGraderParameters{
+			Schema: map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "integer"},
+			},
+			ExtractJSON: true,
+		})
+		require.NoError(t, err)
+
+		results, err := g.Grade(context.Background(), &Context{
+			Output: "The values are:\n```json\n[1, 2, 3]\n```",
+		})
+		require.NoError(t, err)
+		require.True(t, results.Passed)
+	})
+
+	t.Run("extract_json rejects output with zero JSON documents", func(t *testing.T) {
+		g, err := NewJSONSchemaGrader("test", models.JSONSchemaGraderParameters{
+			Schema:      map[string]any{"type": "object"},
+			ExtractJSON: true,
+		})
+		require.NoError(t, err)
+
+		results, err := g.Grade(context.Background(), &Context{
+			Output: "No structured output was produced.",
+		})
+		require.NoError(t, err)
+		require.False(t, results.Passed)
+		require.Contains(t, results.Feedback, "exactly one JSON object or array")
+		require.Contains(t, results.Feedback, "zero")
+	})
+
+	t.Run("extract_json rejects a JSON scalar", func(t *testing.T) {
+		g, err := NewJSONSchemaGrader("test", models.JSONSchemaGraderParameters{
+			Schema:      map[string]any{"type": "string"},
+			ExtractJSON: true,
+		})
+		require.NoError(t, err)
+
+		results, err := g.Grade(context.Background(), &Context{
+			Output: `"not an object or array"`,
+		})
+		require.NoError(t, err)
+		require.False(t, results.Passed)
+		require.Contains(t, results.Feedback, "zero")
+	})
+
 	t.Run("extract_json rejects ambiguous output", func(t *testing.T) {
 		g, err := NewJSONSchemaGrader("test", models.JSONSchemaGraderParameters{
 			Schema:      map[string]any{"type": "object"},
@@ -123,7 +171,7 @@ func TestJSONSchemaGrader_Grade(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.False(t, results.Passed)
-		require.Contains(t, results.Feedback, "multiple JSON documents")
+		require.Contains(t, results.Feedback, "multiple JSON object or array documents")
 	})
 
 	t.Run("extract_json rejects a fenced document plus another JSON document", func(t *testing.T) {
@@ -138,7 +186,7 @@ func TestJSONSchemaGrader_Grade(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.False(t, results.Passed)
-		require.Contains(t, results.Feedback, "multiple JSON documents")
+		require.Contains(t, results.Feedback, "multiple JSON object or array documents")
 	})
 
 	t.Run("valid JSON not matching schema fails", func(t *testing.T) {

--- a/internal/models/grader_params_test.go
+++ b/internal/models/grader_params_test.go
@@ -25,6 +25,12 @@ graders:
     config:
       prompt: "judge this output"
       continue_session: true
+  - name: schema-check
+    type: json_schema
+    config:
+      schema:
+        type: object
+      extract_json: true
   - name: future-check
     type: custom_future
     config:
@@ -59,9 +65,21 @@ tasks: []
 		t.Fatalf("unexpected prompt params: %#v", promptParams)
 	}
 
-	genericParams, ok := spec.Graders[2].Parameters.(GenericGraderParameters)
+	schemaParams, ok := spec.Graders[2].Parameters.(JSONSchemaGraderParameters)
 	if !ok {
-		t.Fatalf("expected GenericGraderParameters, got %T", spec.Graders[2].Parameters)
+		t.Fatalf("expected JSONSchemaGraderParameters, got %T", spec.Graders[2].Parameters)
+	}
+	typeVal, ok := schemaParams.Schema["type"].(string)
+	if !ok || typeVal != "object" {
+		t.Fatalf("unexpected schema params: %#v", schemaParams)
+	}
+	if !schemaParams.ExtractJSON {
+		t.Fatalf("expected extract_json to be true")
+	}
+
+	genericParams, ok := spec.Graders[3].Parameters.(GenericGraderParameters)
+	if !ok {
+		t.Fatalf("expected GenericGraderParameters, got %T", spec.Graders[3].Parameters)
 	}
 	flag, ok := genericParams["some_flag"].(bool)
 	if !ok || !flag {

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -1264,7 +1264,7 @@
         "extract_json": {
           "type": "boolean",
           "default": false,
-          "description": "Extract exactly one JSON document from prose or a Markdown JSON code block before validation."
+          "description": "Extract exactly one JSON object or array from prose or a Markdown JSON code block before validation."
         }
       }
     },

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -1106,7 +1106,7 @@
         "extract_json": {
           "type": "boolean",
           "default": false,
-          "description": "Extract exactly one JSON document from prose or a Markdown JSON code block before validation."
+          "description": "Extract exactly one JSON object or array from prose or a Markdown JSON code block before validation."
         }
       }
     },

--- a/site/src/content/docs/guides/graders.mdx
+++ b/site/src/content/docs/guides/graders.mdx
@@ -288,13 +288,14 @@ Validates that the agent output is valid JSON conforming to a given schema. Supp
 | ------------- | -------- | ----------------------------- |
 | `schema`      | `object` | Inline JSON Schema definition |
 | `schema_file` | `string` | Path to a `.json` schema file |
-| `extract_json` | `boolean` | Extract one JSON document from prose or a Markdown JSON code block before validation (default: `false`) |
+| `extract_json` | `boolean` | Extract exactly one JSON object or array from prose or a Markdown JSON code block before validation (default: `false`) |
 
 One of `schema` or `schema_file` is required.
 
 By default, the output must be pure JSON. Set `extract_json: true` when the
 agent may add prose or wrap a response in a JSON code block. Extraction
-requires exactly one JSON document, so ambiguous responses still fail.
+requires exactly one JSON object or array; responses with zero or multiple
+candidate JSON documents fail.
 
 ### Example: schema file
 


### PR DESCRIPTION
## Summary
- Enforce `extract_json: true` as exactly one embedded JSON object or array candidate before schema validation.
- Return clear zero/multiple-candidate feedback for extraction failures.
- Add eval/task model decoding and grader regressions for single, zero, multiple, array, and scalar JSON extraction cases.
- Update json_schema grader docs and schema descriptions for the object/array extraction semantics.

Closes #457

## Tests
- `go test ./internal/graders ./internal/models`
- `go test ./...`
- `cd site && npm ci && npm run build`