### PR TITLE
fix: tolerate existing GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,11 +157,10 @@ jobs:
 
           if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             upload_release_assets
-          elif ! gh release create "$TAG" \
+          elif ! gh release create "$TAG" artifacts/* \
               --repo "${{ github.repository }}" \
               --title "Waza $TAG" \
-              --generate-notes \
-              artifacts/*; then
+              --generate-notes; then
             if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
               upload_release_assets
             else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,16 +149,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ needs.setup-version.outputs.tag }}"
-          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          upload_release_assets() {
             gh release upload "$TAG" artifacts/* \
               --repo "${{ github.repository }}" \
               --clobber
-          else
-            gh release create "$TAG" \
+          }
+
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            upload_release_assets
+          elif ! gh release create "$TAG" \
               --repo "${{ github.repository }}" \
               --title "Waza $TAG" \
               --generate-notes \
-              artifacts/*
+              artifacts/*; then
+            if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+              upload_release_assets
+            else
+              exit 1
+            fi
           fi
 
   # ════════════════════════════════════════════════

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,11 +149,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ needs.setup-version.outputs.tag }}"
-          gh release create "$TAG" \
-            --repo "${{ github.repository }}" \
-            --title "Waza $TAG" \
-            --generate-notes \
-            artifacts/*
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release upload "$TAG" artifacts/* \
+              --repo "${{ github.repository }}" \
+              --clobber
+          else
+            gh release create "$TAG" \
+              --repo "${{ github.repository }}" \
+              --title "Waza $TAG" \
+              --generate-notes \
+              artifacts/*
+          fi
 
   # ════════════════════════════════════════════════
   # FLOW 2: azd Extension Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
           echo "Generated checksums:"
           cat checksums.txt
 
-      - name: Create GitHub Release
+      - name: Create or Update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release workflow idempotency** — CLI artifact publishing now uploads assets to an existing release when the tag's release was created earlier in the workflow, instead of failing on `gh release create`.
 - **Windows update command** — `waza update` now passes the PowerShell installer URL reliably, preventing `Invoke-RestMethod` from failing with a null or empty `Uri` (#448).
 - **JSON schema grader configuration** — `json_schema` graders now accept the documented `extract_json` option in eval and task YAML, extracting exactly one JSON object or array candidate before schema validation (#457).
 - **Live MCP server tool availability** — `config.mcp_servers` entries now default omitted `tools` to `["*"]`, matching MCP mock behavior so configured stdio and HTTP servers expose their tools to Copilot SDK evaluations (#449).


### PR DESCRIPTION
## Summary
- Make CLI artifact release publishing idempotent when an earlier workflow step already created the release for the tag.
- Upload artifacts with `--clobber` when the release exists; otherwise keep the existing `gh release create` behavior.
- Extracted from #439 as a focused replacement PR; the unrelated JSON schema and version/changelog changes were intentionally omitted.

## Validation
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- `bash -n` on the release shell snippet

Supersedes the release-workflow portion of #439.