### PR TITLE
ci: validate site builds on pull requests

### DIFF
--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -1,0 +1,51 @@
+name: Site Build
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+# Ensure the check name (`Build`) always reports, even for PRs that don't
+# touch the docs site. This lets branch protection require this check
+# without deadlocking non-site PRs. When no site files changed the job
+# short-circuits after the paths-filter step and reports success.
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Detect site changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            site:
+              - 'site/**'
+              - '.github/workflows/site-ci.yml'
+              - '.github/workflows/pages.yml'
+
+      - name: Skip (no site changes)
+        if: steps.filter.outputs.site != 'true' && github.event_name == 'pull_request'
+        run: echo "No site/** changes detected — skipping site build."
+
+      - name: Setup Node
+        if: steps.filter.outputs.site == 'true' || github.event_name != 'pull_request'
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install dependencies
+        if: steps.filter.outputs.site == 'true' || github.event_name != 'pull_request'
+        working-directory: site
+        run: npm ci
+
+      - name: Build site
+        if: steps.filter.outputs.site == 'true' || github.event_name != 'pull_request'
+        working-directory: site
+        run: npm run build


### PR DESCRIPTION
Closes #473

## Summary

Adds a PR-time build check for the Starlight docs site under `site/**` so broken changes cannot merge with all required checks green (as happened in #446 / #462 / #468, where the Pages build only ran on `push` to `main`).

## Approach

New workflow `.github/workflows/site-ci.yml`:

- Runs on `push` to `main`/`develop` and on every `pull_request` targeting those branches — no top-level `paths` filter, so the check always reports.
- Uses [`dorny/paths-filter`](https://github.com/dorny/paths-filter) inside the job to detect whether the PR touches:
  - `site/**` (source + `site/package-lock.json`)
  - `.github/workflows/site-ci.yml`
  - `.github/workflows/pages.yml`
- Single job named `Build`:
  - On PRs that don't touch those paths → skip shim step logs "No site/** changes detected" and the job passes.
  - On PRs that touch them, and on all `push` events → runs `cd site && npm ci && npm run build` with Node 22.12.0 and npm cache keyed on `site/package-lock.json` (mirrors the existing Pages workflow).

## Why this pattern

- **Safe as a required check.** The job name is stable (`Build`) and always reports success, so branch protection can require it without deadlocking non-site PRs.
- **Efficient.** Only pays the `npm ci` + build cost on PRs that actually touch site files, matching the request in the issue.
- **Mirrors `/web` validation.** Same Node 22 + `npm ci && npm run build` shape as the web build in `go-ci.yml`, adjusted for the site's Node version pin.

## Acceptance criteria

- [x] PRs touching `site/**`, `site/package-lock.json`, or site workflow/config files validate the docs site before merge.
- [x] Non-site PRs still report a successful (skipped) site check.
- [x] Dependabot site PRs will now get the same signal before merge that Pages currently provides only after merge.

## Follow-ups (not in this PR)

- Consider adding the site Playwright e2e tests as an optional job.
- If desired, add this workflow's `Build` job to the required checks list in branch protection settings.