### PR TITLE
ci: validate site builds on pull requests

### DIFF
--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -33,11 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Detect site changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
         with:
           filters: |
             site:
@@ -47,7 +47,7 @@ jobs:
 
       - name: Setup Node
         if: steps.filter.outputs.site == 'true' || github.event_name == 'push'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.12.0'
           cache: npm

--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: site-ci-${{ github.ref }}

--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -1,0 +1,65 @@
+name: Site Build
+
+# PR-time validation for the Starlight docs site (site/).
+#
+# This workflow always runs on pull requests targeting main so it can be
+# used as a required status check without deadlocking non-site PRs. A
+# path-filter step detects whether site files actually changed; if not,
+# the expensive build is skipped and the job reports success. The Pages
+# deploy workflow (.github/workflows/pages.yml) still handles the actual
+# deploy on push to main.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/site-ci.yml'
+      - '.github/workflows/pages.yml'
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Detect site changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            site:
+              - 'site/**'
+              - '.github/workflows/site-ci.yml'
+              - '.github/workflows/pages.yml'
+
+      - name: Setup Node
+        if: steps.filter.outputs.site == 'true' || github.event_name == 'push'
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install dependencies
+        if: steps.filter.outputs.site == 'true' || github.event_name == 'push'
+        run: cd site && npm ci
+
+      - name: Build site
+        if: steps.filter.outputs.site == 'true' || github.event_name == 'push'
+        run: cd site && npm run build
+
+      - name: Skip (no site changes)
+        if: steps.filter.outputs.site != 'true' && github.event_name == 'pull_request'
+        run: echo "No site/** changes detected — skipping site build."


### PR DESCRIPTION
Closes #473

## Summary

Adds `.github/workflows/site-ci.yml` — a PR-time validation workflow for the Starlight docs site that runs `cd site && npm ci && npm run build` so broken site changes are caught **before** merge instead of after.

## Design

The workflow is triggered on **every** `pull_request` targeting `main`, so it can safely be marked as a required status check without deadlocking non-site PRs. Inside the single `build` job:

1. `dorny/paths-filter@v3` checks whether any of these paths changed:
   - `site/**` (source, `package.json`, `package-lock.json`, config, content, e2e)
   - `.github/workflows/site-ci.yml`
   - `.github/workflows/pages.yml`
2. **If yes** → set up Node 22.12.0 (mirrors `pages.yml`), `npm ci`, `npm run build`.
3. **If no** → skip the build step and emit a fast success ("No site/** changes detected — skipping site build.").

The workflow also runs on `push` to `main` with the same path filter, so main-branch trend validation stays covered.

## Why this shape

- **Required-check safe.** The single job always reports a conclusion on every PR, so branch protection can require `Site Build / Build site` without stalling PRs that don't touch the site.
- **Fast for non-site PRs.** Only checkout + a tiny filter action run when nothing under `site/**` changed. No Node setup, no `npm ci`.
- **Mirrors existing patterns.** Node version, cache setup, and build commands match the deploy workflow (`.github/workflows/pages.yml`), so nothing drifts between the PR check and the deploy path.
- **Deploy path untouched.** `pages.yml` still owns the actual GitHub Pages deploy on push to `main`.

## Acceptance criteria mapping

- ✅ PRs touching `site/**` (including `site/package-lock.json`), `site-ci.yml`, or `pages.yml` build the docs site before merge.
- ✅ Non-site PRs still get a successful `Site Build / Build site` check (fast skip), so it can be added to required checks without deadlock.
- ✅ Dependabot PRs under `site/**` will now get the same PR-time build signal that `pages.yml` currently only provides after merge.

## Follow-ups (out of scope, noted in issue)

- Optionally wire the site Playwright e2e job into this workflow (issue #473 lists it as an optional follow-up).
- Add `Site Build / Build site` to branch-protection required checks (requires repo-admin action).