### PR TITLE
Fix tool_calls args grading from tool_events

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/cmd/waza/cmd_grade_test.go
+++ b/cmd/waza/cmd_grade_test.go
@@ -209,6 +209,61 @@ func TestGradeCommand_SingleTask_Passing(t *testing.T) {
 	require.Contains(t, tasks, "task-001")
 }
 
+func TestGradeCommand_ToolCallsExpectArgsUsesToolEventsFromResults(t *testing.T) {
+	const taskWithToolCallsGrader = `id: task-tool-args
+name: Tool Args
+inputs:
+  prompt: "Call entity_search_clients"
+graders:
+  - name: called_with_expected_args
+    type: tool_calls
+    config:
+      expect:
+        - tool: nessie-candidate-entity_search_clients
+          args:
+            query:
+              equals: Bissell
+`
+	dir := t.TempDir()
+	specPath := gradeSpec(t, dir, minimalSpec)
+	writeTaskFile(t, dir, "task.yaml", taskWithToolCallsGrader)
+
+	results := gradeResultsFile(t, dir, outcomeWithTasks(models.TestOutcome{
+		TestID: "task-tool-args",
+		Runs: []models.RunResult{{
+			RunNumber:   1,
+			FinalOutput: "client_id: c-4471",
+			DurationMs:  1000,
+			SessionDigest: models.SessionDigest{
+				SessionID:     "s-tool-args",
+				ToolCallCount: 1,
+				ToolsUsed:     []string{"nessie-candidate-entity_search_clients"},
+				ToolCalls: []models.ToolCall{{
+					ID:        "call-1",
+					Name:      "nessie-candidate-entity_search_clients",
+					Arguments: models.ToolCallArgs{},
+					Success:   true,
+				}},
+			},
+			ToolEvents: []models.ToolEvent{{
+				Turn:       1,
+				Sequence:   1,
+				ToolCallID: "call-1",
+				ToolName:   "nessie-candidate-entity_search_clients",
+				Args:       map[string]any{"query": "Bissell"},
+				Success:    true,
+			}},
+		}},
+	}))
+	output, err := executeGrade(t, specPath, "--task", "task-tool-args", "--results", results)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	require.Equal(t, true, parsed["passed"])
+	require.Equal(t, 1.0, parsed["overall_score"])
+}
+
 func TestGradeCommand_SingleTask_Failing(t *testing.T) {
 	dir := t.TempDir()
 	specPath := gradeSpec(t, dir, minimalSpec)

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,11 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents holds the canonical per-call tool records for this run. Newer
+	// result files preserve arbitrary MCP/custom tool arguments here even when
+	// legacy SessionDigest.ToolCalls only has typed built-in fields.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -47,6 +47,44 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	return out, nil
 }
 
+func normalizeToolEventArgs(event models.ToolEvent) (map[string]any, error) {
+	if event.Args == nil {
+		return map[string]any{}, nil
+	}
+	data, err := json.Marshal(event.Args)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling tool event args: %w", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("tool event args must be an object: %w", err)
+	}
+	return out, nil
+}
+
+func findToolEventForCall(call models.ToolCall, index int, events []models.ToolEvent) *models.ToolEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	if call.ID != "" {
+		for i := range events {
+			if events[i].ToolCallID == call.ID {
+				return &events[i]
+			}
+		}
+	}
+	sequence := index + 1
+	for i := range events {
+		if events[i].Sequence == sequence && events[i].ToolName == call.Name {
+			return &events[i]
+		}
+	}
+	if index < len(events) && events[index].ToolName == call.Name {
+		return &events[index]
+	}
+	return nil
+}
+
 // evaluateArgMatchers returns a slice of human-readable failures describing
 // any matcher in `matchers` whose key was absent from `args` or whose value
 // failed to match. An empty slice means every matcher passed.

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -135,7 +135,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls, gCtx.ToolEvents)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -180,7 +180,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall, toolEvents []models.ToolEvent) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
@@ -202,6 +202,13 @@ func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool
 		if err != nil {
 			lastReason = err.Error()
 			continue
+		}
+		if event := findToolEventForCall(call, i, toolEvents); event != nil {
+			args, err = normalizeToolEventArgs(*event)
+			if err != nil {
+				lastReason = err.Error()
+				continue
+			}
 		}
 		failures := evaluateArgMatchers(exp.matcher, args)
 		if len(failures) == 0 {

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -373,6 +373,51 @@ func TestToolCallsGrader_Expect_NoArgs_Passes(t *testing.T) {
 	require.True(t, res.Passed, "feedback: %s", res.Feedback)
 }
 
+func TestToolCallsGrader_Expect_NoArgs_PassesWithoutToolEvents(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "nessie-candidate-entity_search_clients"}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{ID: "call-1", Name: "nessie-candidate-entity_search_clients"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_UsesToolEventArgsWhenDigestDropsExtra(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "nessie-candidate-entity_search_clients",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "Bissell"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{
+				ID:        "call-1",
+				Name:      "nessie-candidate-entity_search_clients",
+				Arguments: models.ToolCallArgs{},
+			}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			Sequence:   1,
+			ToolCallID: "call-1",
+			ToolName:   "nessie-candidate-entity_search_clients",
+			Args:       map[string]any{"query": "Bissell"},
+			Success:    true,
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
 func TestToolCallsGrader_Expect_MissingTool_Fails(t *testing.T) {
 	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
 		Expect: []models.ToolExpectation{{Tool: "bash"}, {Tool: "view"}},

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -2060,6 +2060,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       buildToolEvents(sdkEvents),
 		Executor:         r.engine,
 	}
 }


### PR DESCRIPTION
Closes #474

## Summary
- Carry canonical `tool_events` into live and offline grader contexts.
- Prefer matching `tool_events[].args` over legacy `session_digest.tool_calls[].arguments` when evaluating `tool_calls` `expect[].args`.
- Add regressions for the failing MCP-style `query` arg case and for tool-name-only matching without `tool_events`.

## Validation
- `go test ./internal/graders ./cmd/waza -run 'TestToolCallsGrader_Expect|TestGradeCommand_ToolCallsExpectArgsUsesToolEventsFromResults'`
- `go test ./internal/graders ./cmd/waza ./internal/orchestration`
- `go test ./...`
- `golangci-lint run`