### PR TITLE
Fix tool call arg grading from tool events

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/cmd/waza/cmd_grade_test.go
+++ b/cmd/waza/cmd_grade_test.go
@@ -431,6 +431,56 @@ inputs:
 	require.Equal(t, false, parsed["passed"])
 }
 
+func TestGradeCommand_ToolCallsArgsUseToolEventsAfterResultsRoundTrip(t *testing.T) {
+	const taskWithToolCallsGrader = `id: task-tool-query
+name: Tool Query
+inputs:
+  prompt: "Search for docs"
+graders:
+  - name: search_query
+    type: tool_calls
+    config:
+      expect:
+        - tool: search
+          args:
+            query:
+              equals: "auth docs"
+`
+
+	dir := t.TempDir()
+	specPath := gradeSpec(t, dir, minimalSpec)
+	writeTaskFile(t, dir, "task.yaml", taskWithToolCallsGrader)
+
+	resultsPath := gradeResultsFile(t, dir, outcomeWithTasks(models.TestOutcome{
+		TestID: "task-tool-query",
+		Runs: []models.RunResult{{
+			FinalOutput: "output",
+			DurationMs:  1000,
+			SessionDigest: models.SessionDigest{
+				SessionID: "s-1",
+				ToolCalls: []models.ToolCall{{
+					ID:   "call-1",
+					Name: "search",
+				}},
+			},
+			ToolEvents: []models.ToolEvent{{
+				ToolCallID: "call-1",
+				ToolName:   "search",
+				Args:       map[string]any{"query": "auth docs"},
+				Success:    true,
+			}},
+		}},
+	}))
+
+	output, err := executeGrade(t, specPath, "--task", "task-tool-query", "--results", resultsPath)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	require.Equal(t, true, parsed["passed"])
+	require.Equal(t, 1.0, parsed["overall_score"])
+}
+
 func TestGradeCommand_CodeExplainerIntegration(t *testing.T) {
 	evalPath := filepath.Join("../..", "examples", "code-explainer", "eval.yaml")
 	if _, err := os.Stat(evalPath); err != nil {

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,10 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents holds the canonical, replay-friendly tool calls for this run.
+	// Prefer this over Session.ToolCalls when graders need arbitrary tool args.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -34,17 +34,110 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 		out[k] = v
 	}
 	// Merge engine-specific extras last so they win over zero-valued known
-	// fields. Known-field collisions (e.g. an MCP tool that happens to
-	// declare a `path` arg with extra metadata) keep the typed value from
-	// ToolCallArgs since it has already been written above and Extra by
-	// construction holds only keys mapstructure could not place.
+	// fields.
 	for k, v := range call.Arguments.Extra {
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
 		if _, present := out[k]; present {
 			continue
 		}
 		out[k] = v
 	}
 	return out, nil
+}
+
+func toolCallsForGrading(session *models.SessionDigest, toolEvents []models.ToolEvent) []models.ToolCall {
+	if len(toolEvents) == 0 {
+		if session == nil {
+			return nil
+		}
+		return session.ToolCalls
+	}
+
+	fallbacksByID := make(map[string]models.ToolCall)
+	fallbacksByName := make(map[string][]models.ToolCall)
+	if session != nil {
+		for _, call := range session.ToolCalls {
+			if call.ID != "" {
+				fallbacksByID[call.ID] = call
+			}
+			fallbacksByName[call.Name] = append(fallbacksByName[call.Name], call)
+		}
+	}
+
+	calls := make([]models.ToolCall, 0, len(toolEvents))
+	nameOffsets := make(map[string]int)
+	for _, event := range toolEvents {
+		if event.ToolName == "" {
+			continue
+		}
+
+		call := models.ToolCall{
+			ID:      event.ToolCallID,
+			Name:    event.ToolName,
+			Success: event.Success,
+		}
+		if event.ToolCallID != "" {
+			if fallback, ok := fallbacksByID[event.ToolCallID]; ok {
+				call.Result = fallback.Result
+				call.Arguments = fallback.Arguments
+			}
+		} else if byName := fallbacksByName[event.ToolName]; len(byName) > nameOffsets[event.ToolName] {
+			fallback := byName[nameOffsets[event.ToolName]]
+			nameOffsets[event.ToolName]++
+			call.Result = fallback.Result
+			call.Arguments = fallback.Arguments
+		}
+
+		if event.Args != nil {
+			call.Arguments = toolCallArgsFromEvent(event.Args)
+		}
+		calls = append(calls, call)
+	}
+	if len(calls) == 0 && session != nil {
+		return session.ToolCalls
+	}
+	return calls
+}
+
+func toolCallArgsFromEvent(args any) models.ToolCallArgs {
+	raw, ok := normalizeToolEventArgs(args)
+	if !ok {
+		return models.ToolCallArgs{}
+	}
+
+	out := models.ToolCallArgs{}
+	if s, ok := raw["path"].(string); ok {
+		out.Path = s
+	}
+	if s, ok := raw["file_text"].(string); ok {
+		out.FileText = s
+	}
+	if s, ok := raw["command"].(string); ok {
+		out.Command = s
+	}
+	if s, ok := raw["description"].(string); ok {
+		out.Description = s
+	}
+	if s, ok := raw["skill"].(string); ok {
+		out.Skill = s
+	}
+
+	out.Extra = raw
+	return out
+}
+
+func normalizeToolEventArgs(args any) (map[string]any, bool) {
+	data, err := json.Marshal(args)
+	if err != nil {
+		return nil, false
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, false
+	}
+	return raw, true
 }
 
 // evaluateArgMatchers returns a slice of human-readable failures describing

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -84,11 +84,12 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 			}, nil
 		}
 
-		calledSet := make(map[string]bool, len(gCtx.Session.ToolCalls))
-		for _, tc := range gCtx.Session.ToolCalls {
+		toolCalls := toolCallsForGrading(gCtx.Session, gCtx.ToolEvents)
+		calledSet := make(map[string]bool, len(toolCalls))
+		for _, tc := range toolCalls {
 			calledSet[tc.Name] = true
 		}
-		totalCalls := len(gCtx.Session.ToolCalls)
+		totalCalls := len(toolCalls)
 
 		var totalChecks, passedChecks int
 		var failures []string
@@ -135,7 +136,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, toolCalls)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -2,6 +2,7 @@ package graders
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/microsoft/waza/internal/graders/argmatcher"
@@ -368,6 +369,65 @@ func TestToolCallsGrader_Expect_NoArgs_Passes(t *testing.T) {
 		Session: &models.SessionDigest{
 			ToolCalls: []models.ToolCall{{Name: "bash", Arguments: models.ToolCallArgs{Command: "ls"}}},
 		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_NoArgs_PassesWithToolEvents(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "search"}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{},
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "call-1",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "auth docs"},
+			Success:    true,
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_UsesToolEventArgsAfterResultsRoundTrip(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "auth docs"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	run := models.RunResult{
+		SessionDigest: models.SessionDigest{
+			ToolCalls: []models.ToolCall{{
+				ID:   "call-1",
+				Name: "search",
+			}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "call-1",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "auth docs"},
+			Success:    true,
+		}},
+	}
+	data, err := json.Marshal(run)
+	require.NoError(t, err)
+
+	var restored models.RunResult
+	require.NoError(t, json.Unmarshal(data, &restored))
+	require.Empty(t, restored.SessionDigest.ToolCalls[0].Arguments.Extra)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session:    &restored.SessionDigest,
+		ToolEvents: restored.ToolEvents,
 	})
 	require.NoError(t, err)
 	require.True(t, res.Passed, "feedback: %s", res.Feedback)

--- a/internal/graders/tool_constraint_grader.go
+++ b/internal/graders/tool_constraint_grader.go
@@ -108,8 +108,10 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 
 		var failures []string
 
-		failures = append(failures, tc.checkExpectTools(session)...)
-		failures = append(failures, tc.checkRejectTools(session)...)
+		toolCalls := toolCallsForGrading(session, gradingContext.ToolEvents)
+
+		failures = append(failures, tc.checkExpectTools(toolCalls)...)
+		failures = append(failures, tc.checkRejectTools(toolCalls)...)
 
 		totalChecks := tc.countTotalChecks()
 		passedChecks := totalChecks - len(failures)
@@ -227,7 +229,7 @@ func describeToolSpecs(specs []models.ToolSpecParameters) []string {
 	return out
 }
 
-func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkExpectTools(toolCalls []models.ToolCall) []string {
 	if len(tc.expectTools) == 0 {
 		return nil
 	}
@@ -236,7 +238,7 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 	for _, spec := range tc.expectTools {
 		found := false
 
-		for _, call := range session.ToolCalls {
+		for _, call := range toolCalls {
 			if matchesToolCall(spec, call) {
 				found = true
 				break
@@ -250,7 +252,7 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 	return failures
 }
 
-func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkRejectTools(toolCalls []models.ToolCall) []string {
 	if len(tc.rejectTools) == 0 {
 		return nil
 	}
@@ -259,7 +261,7 @@ func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) 
 	for _, spec := range tc.rejectTools {
 		found := false
 
-		for _, call := range session.ToolCalls {
+		for _, call := range toolCalls {
 			if matchesToolCall(spec, call) {
 				found = true
 				break

--- a/internal/orchestration/checkpoints.go
+++ b/internal/orchestration/checkpoints.go
@@ -79,7 +79,8 @@ func (cr *checkpointRunner) runForTurn(ctx context.Context, turn int, resp *exec
 		return false
 	}
 
-	gCtx := cr.runner.buildGraderContext(cr.tc, resp, copilotevents.ToSDK(resp.Events))
+	sdkEvents := copilotevents.ToSDK(resp.Events)
+	gCtx := cr.runner.buildGraderContext(cr.tc, resp, sdkEvents, buildToolEvents(sdkEvents))
 
 	// Run only the checkpoint's graders. Reuse graders.RunAll by passing a
 	// synthetic TestCase whose Validators field carries the checkpoint

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1246,8 +1246,10 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 	// buildToolEvents.
 	sdkEvents := copilotevents.ToSDK(resp.Events)
 
+	toolEvents := buildToolEvents(sdkEvents)
+
 	// Build validation context
-	vCtx := r.buildGraderContext(tc, resp, sdkEvents)
+	vCtx := r.buildGraderContext(tc, resp, sdkEvents, toolEvents)
 
 	var gradersResults map[string]models.GraderResults
 	if r.skipGraders {
@@ -1344,7 +1346,7 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		WorkspaceDir:     resp.WorkspaceDir,
 		Responder:        responderInfo,
 		Checkpoints:      checkpointOutcomes,
-		ToolEvents:       buildToolEvents(sdkEvents),
+		ToolEvents:       toolEvents,
 	}
 	r.captureSnapshot(tc, req, resp, &run)
 	return returnWithArtifacts(run)
@@ -2040,7 +2042,7 @@ func convertMCPServers(serverConfigs map[string]any, mocks []models.MCPMockConfi
 	})
 }
 
-func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse, sdkEvents []copilot.SessionEvent) *graders.Context {
+func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse, sdkEvents []copilot.SessionEvent, toolEvents []models.ToolEvent) *graders.Context {
 	// Reuse the shared transcript builder so the conversion is preallocated
 	// (entries := make([]TranscriptEvent, 0, len(events))) and produced in a
 	// single place.
@@ -2060,6 +2062,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       toolEvents,
 		Executor:         r.engine,
 	}
 }

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -392,7 +392,8 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 		}),
 	}
 
-	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp, copilotevents.ToSDK(resp.Events))
+	sdkEvents := copilotevents.ToSDK(resp.Events)
+	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp, sdkEvents, buildToolEvents(sdkEvents))
 	require.Len(t, graderCtx.Transcript, 1)
 	assert.Equal(t, "final output", graderCtx.Output)
 	assert.Equal(t, int64(42), graderCtx.DurationMS)


### PR DESCRIPTION
## Summary
- Prefer canonical `tool_events[].args` when grading `tool_calls.expect[].args`, with `session_digest.tool_calls` fallback for older results.
- Carry tool events into live, checkpoint, and offline `waza grade` grader contexts without changing the results schema.
- Add regressions for the results.json round-trip `query` arg case and tool-name-only matching with tool events.

## Validation
- `go test ./internal/graders ./cmd/waza ./internal/orchestration`
- `go test ./...`
- `golangci-lint run --allow-parallel-runners`

Closes #474