### PR TITLE
Fix tool_calls arg matching from tool_events

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/cmd/waza/cmd_grade_test.go
+++ b/cmd/waza/cmd_grade_test.go
@@ -111,6 +111,21 @@ graders:
       contains:
         - "hello"
 `
+
+	taskWithToolCallsGrader = `id: task-003
+name: Tool Args Task
+inputs:
+  prompt: "Call the client search tool"
+graders:
+  - name: called_with_expected_args
+    type: tool_calls
+    config:
+      expect:
+        - tool: nessie-candidate-entity_search_clients
+          args:
+            query:
+              equals: Bissell
+`
 )
 
 func TestGradeCommand_NoArgs(t *testing.T) {
@@ -207,6 +222,47 @@ func TestGradeCommand_SingleTask_Passing(t *testing.T) {
 	require.Equal(t, true, parsed["passed"])
 	tasks := parseMap(t, parsed, "tasks")
 	require.Contains(t, tasks, "task-001")
+}
+
+func TestGradeCommand_UsesToolEventsArgsFromResultsJSON(t *testing.T) {
+	const toolName = "nessie-candidate-entity_search_clients"
+	dir := t.TempDir()
+	specPath := gradeSpec(t, dir, minimalSpec)
+	writeTaskFile(t, dir, "task.yaml", taskWithToolCallsGrader)
+
+	results := gradeResultsFile(t, dir, outcomeWithTasks(models.TestOutcome{
+		TestID: "task-003",
+		Runs: []models.RunResult{{
+			RunNumber:   1,
+			FinalOutput: "c-4471",
+			DurationMs:  1000,
+			SessionDigest: models.SessionDigest{
+				SessionID: "s-task-003",
+				ToolCalls: []models.ToolCall{{
+					ID:   "call-1",
+					Name: toolName,
+					Arguments: models.ToolCallArgs{
+						Extra: map[string]any{"query": "Bissell"},
+					},
+					Success: true,
+				}},
+			},
+			ToolEvents: []models.ToolEvent{{
+				Sequence:   1,
+				ToolCallID: "call-1",
+				ToolName:   toolName,
+				Args:       map[string]any{"query": "Bissell"},
+				Success:    true,
+			}},
+		}},
+	}))
+	output, err := executeGrade(t, specPath, "--task", "task-003", "--results", results)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	require.Equal(t, true, parsed["passed"])
+	require.Equal(t, 1.0, parsed["overall_score"])
 }
 
 func TestGradeCommand_SingleTask_Failing(t *testing.T) {

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,12 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents holds the canonical per-call tool event records from results.json.
+	// Graders that inspect arbitrary tool arguments should prefer this over
+	// Session.ToolCalls because ToolCallArgs.Extra is not serialized in the
+	// legacy session digest.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -47,6 +47,24 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	return out, nil
 }
 
+func normalizeToolEventArgs(event models.ToolEvent) (map[string]any, error) {
+	if event.Args == nil {
+		return map[string]any{}, nil
+	}
+	data, err := json.Marshal(event.Args)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling tool event args: %w", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshaling tool event args as object: %w", err)
+	}
+	if raw == nil {
+		return map[string]any{}, nil
+	}
+	return raw, nil
+}
+
 // evaluateArgMatchers returns a slice of human-readable failures describing
 // any matcher in `matchers` whose key was absent from `args` or whose value
 // failed to match. An empty slice means every matcher passed.

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -135,7 +135,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls, gCtx.ToolEvents)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -180,10 +180,46 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall, events []models.ToolEvent) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
+	}
+
+	if len(exp.matcher) > 0 && len(events) > 0 {
+		nameMatches := 0
+		var lastReason string
+		for i, event := range events {
+			if exp.toolRe != nil && !exp.toolRe.MatchString(event.ToolName) {
+				continue
+			}
+			nameMatches++
+			args, err := normalizeToolEventArgs(event)
+			if err != nil {
+				lastReason = err.Error()
+				continue
+			}
+			failures := evaluateArgMatchers(exp.matcher, args)
+			if len(failures) == 0 {
+				if event.Sequence > 0 {
+					detail["matched_call_index"] = event.Sequence - 1
+				} else {
+					detail["matched_call_index"] = i
+				}
+				detail["matched_tool_event_index"] = i
+				detail["matched_call_id"] = event.ToolCallID
+				return true, detail
+			}
+			lastReason = strings.Join(failures, "; ")
+		}
+		if nameMatches > 0 {
+			if lastReason != "" {
+				detail["reason"] = lastReason
+			} else {
+				detail["reason"] = "no matching call"
+			}
+			return false, detail
+		}
 	}
 
 	nameMatches := 0

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -2,6 +2,7 @@ package graders
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/microsoft/waza/internal/graders/argmatcher"
@@ -492,6 +493,51 @@ func TestToolCallsGrader_Expect_ArgKeyMissing_Fails(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.False(t, res.Passed)
+}
+
+func TestToolCallsGrader_Expect_ArgsUsesToolEventsAfterResultsRoundTrip(t *testing.T) {
+	const toolName = "nessie-candidate-entity_search_clients"
+	original := models.RunResult{
+		SessionDigest: models.SessionDigest{
+			ToolCalls: []models.ToolCall{{
+				ID:   "call-1",
+				Name: toolName,
+				Arguments: models.ToolCallArgs{
+					Extra: map[string]any{"query": "Bissell"},
+				},
+			}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			Sequence:   1,
+			ToolCallID: "call-1",
+			ToolName:   toolName,
+			Args:       map[string]any{"query": "Bissell"},
+			Success:    true,
+		}},
+	}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored models.RunResult
+	require.NoError(t, json.Unmarshal(data, &restored))
+	require.Nil(t, restored.SessionDigest.ToolCalls[0].Arguments.Extra)
+
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: toolName,
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "Bissell"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session:    &restored.SessionDigest,
+		ToolEvents: restored.ToolEvents,
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
 }
 
 func TestToolCallsGrader_Expect_PicksLatestSameNameCall(t *testing.T) {

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -2060,6 +2060,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       buildToolEvents(sdkEvents),
 		Executor:         r.engine,
 	}
 }


### PR DESCRIPTION
## Summary
- Prefer canonical `tool_events[].args` for `tool_calls` `expect[].args` matching, while preserving legacy `session_digest.tool_calls` matching as the fallback.
- Pass `ToolEvents` through grader context for both live runs and offline `waza grade --results` regrading.
- Add regressions for the `query: Bissell` MCP/custom tool arg case after `results.json` round-trip, plus offline grade coverage.

Working as @copilot (Coding Agent).

Closes #474

## Validation
- `go test ./internal/graders ./cmd/waza -run 'TestToolCallsGrader_Expect|TestGradeCommand_UsesToolEventsArgsFromResultsJSON'`\n- `go test ./internal/graders ./cmd/waza ./internal/orchestration`\n- `go test ./... && golangci-lint run`