### PR TITLE
ci: validate site builds on pull requests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'site/**'
+      - '.github/workflows/pages.yml'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_run:
     workflows: ['Release']
     types: [completed]
@@ -13,6 +17,7 @@ on:
 permissions:
   contents: read
   pages: write
+  pull-requests: read
   id-token: write
 
 concurrency:
@@ -20,8 +25,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    name: Site change filter
+    outputs:
+      site: ${{ steps.filter.outputs.site || steps.default.outputs.site }}
+    steps:
+      - name: Check changed paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            site:
+              - 'site/**'
+              - '.github/workflows/pages.yml'
+
+      - name: Mark non-PR events for build
+        id: default
+        if: github.event_name != 'pull_request'
+        run: echo "site=true" >> "$GITHUB_OUTPUT"
+
   build:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    needs: changes
+    if: needs.changes.outputs.site == 'true' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     name: Build
     steps:
@@ -42,12 +69,14 @@ jobs:
         run: cd site && npm run build
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v5
         with:
           path: site/dist
 
   deploy:
     needs: build
+    if: github.event_name != 'pull_request' && needs.build.result == 'success'
     runs-on: ubuntu-latest
     name: Deploy
     environment:


### PR DESCRIPTION
## Summary
- Add pull_request coverage to the Pages workflow so docs-site changes run the existing `cd site && npm ci && npm run build` validation before merge.
- Add an in-workflow path filter for `site/**` and `.github/workflows/pages.yml` so non-site PRs still get a completed/skipped check instead of a pending required check.
- Keep Pages artifact upload and deployment disabled for pull_request events while preserving existing push/release deployment behavior.

Closes #473

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pages.yml')"`
- PR #481 checks: Pages `Site change filter` passed, Pages `Build` passed, Pages `Deploy` skipped on pull_request as intended, and all other PR checks passed or skipped.