### PR TITLE
fix: use tool_events args for tool call grading

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -262,11 +262,12 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		skillInvocations[i] = execution.SkillInvocation{Name: si.Name, Path: si.Path}
 	}
 
+	sessionDigest := models.SessionDigestWithToolEvents(run.SessionDigest, run.ToolEvents)
 	gradingCtx := &graders.Context{
 		TestCase:         tc,
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
-		Session:          &run.SessionDigest,
+		Session:          &sessionDigest,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/cmd/waza/cmd_grade_test.go
+++ b/cmd/waza/cmd_grade_test.go
@@ -209,6 +209,55 @@ func TestGradeCommand_SingleTask_Passing(t *testing.T) {
 	require.Contains(t, tasks, "task-001")
 }
 
+func TestGradeCommand_ToolCallsArgsUseToolEventsAfterResultsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	specPath := gradeSpec(t, dir, minimalSpec)
+	writeTaskFile(t, dir, "task.yaml", `id: task-001
+name: Tool Search
+inputs:
+  prompt: "Search for auth docs"
+graders:
+  - name: search_query
+    type: tool_calls
+    config:
+      expect:
+        - tool: mcp_search
+          args:
+            query: {contains: "auth"}
+`)
+
+	results := gradeResultsFile(t, dir, outcomeWithTasks(models.TestOutcome{
+		TestID: "task-001",
+		Runs: []models.RunResult{{
+			FinalOutput: "done",
+			DurationMs:  1000,
+			SessionDigest: models.SessionDigest{
+				SessionID:     "s-task-001",
+				ToolCallCount: 1,
+				ToolsUsed:     []string{"mcp_search"},
+				ToolCalls: []models.ToolCall{{
+					ID:      "call-1",
+					Name:    "mcp_search",
+					Success: true,
+				}},
+			},
+			ToolEvents: []models.ToolEvent{{
+				ToolCallID: "call-1",
+				ToolName:   "mcp_search",
+				Args:       map[string]any{"query": "find auth docs"},
+				Success:    true,
+			}},
+		}},
+	}))
+
+	output, err := executeGrade(t, specPath, "--task", "task-001", "--results", results)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	require.Equal(t, true, parsed["passed"])
+}
+
 func TestGradeCommand_SingleTask_Failing(t *testing.T) {
 	dir := t.TempDir()
 	specPath := gradeSpec(t, dir, minimalSpec)

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -373,6 +373,54 @@ func TestToolCallsGrader_Expect_NoArgs_Passes(t *testing.T) {
 	require.True(t, res.Passed, "feedback: %s", res.Feedback)
 }
 
+func TestToolCallsGrader_Expect_NoArgsMatchesToolEvents(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "mcp_search"}},
+	})
+	require.NoError(t, err)
+
+	session := models.SessionDigestWithToolEvents(models.SessionDigest{}, []models.ToolEvent{{
+		ToolCallID: "call-1",
+		ToolName:   "mcp_search",
+		Args:       map[string]any{"query": "find auth docs"},
+		Success:    true,
+	}})
+	res, err := g.Grade(context.Background(), &Context{Session: &session})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ArgsFromToolEvents(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	staleDigest := models.SessionDigest{
+		ToolCallCount: 1,
+		ToolsUsed:     []string{"mcp_search"},
+		ToolCalls: []models.ToolCall{{
+			ID:      "call-1",
+			Name:    "mcp_search",
+			Success: true,
+		}},
+	}
+	session := models.SessionDigestWithToolEvents(staleDigest, []models.ToolEvent{{
+		ToolCallID: "call-1",
+		ToolName:   "mcp_search",
+		Args:       map[string]any{"query": "find auth bypass guidance"},
+		Success:    true,
+	}})
+	res, err := g.Grade(context.Background(), &Context{Session: &session})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
 func TestToolCallsGrader_Expect_MissingTool_Fails(t *testing.T) {
 	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
 		Expect: []models.ToolExpectation{{Tool: "bash"}, {Tool: "view"}},

--- a/internal/models/tool_event.go
+++ b/internal/models/tool_event.go
@@ -1,5 +1,7 @@
 package models
 
+import "encoding/json"
+
 // ToolEvent is the normalized, engine-agnostic record of a single tool call
 // emitted during an agent session. It is the canonical per-task tool record
 // surfaced in `results.json` under `runs[].tool_events` (schema version 1.1+).
@@ -55,4 +57,108 @@ type ToolEvent struct {
 	// DurationMs is the wall-clock time between the tool-start and
 	// tool-complete events when available. 0 when timing is unavailable.
 	DurationMs int64 `json:"duration_ms,omitempty"`
+}
+
+// SessionDigestWithToolEvents returns a copy of digest whose ToolCalls are
+// hydrated from canonical ToolEvents when they are available. The legacy
+// SessionDigest.ToolCalls field intentionally stays in results.json for
+// backward compatibility, but ToolCallArgs.Extra is not serialized there; this
+// adapter lets graders use the replay-friendly tool_events[].args payload
+// without changing the public schema.
+func SessionDigestWithToolEvents(digest SessionDigest, events []ToolEvent) SessionDigest {
+	if len(events) == 0 {
+		return digest
+	}
+
+	calls := toolCallsFromToolEvents(digest.ToolCalls, events)
+	digest.ToolCalls = calls
+	digest.ToolCallCount = len(calls)
+	digest.ToolsUsed = make([]string, 0, len(calls))
+	for _, call := range calls {
+		if call.Name == "" {
+			continue
+		}
+		digest.ToolsUsed = append(digest.ToolsUsed, call.Name)
+	}
+	return digest
+}
+
+func toolCallsFromToolEvents(fallback []ToolCall, events []ToolEvent) []ToolCall {
+	byID := make(map[string]ToolCall, len(fallback))
+	for _, call := range fallback {
+		if call.ID != "" {
+			byID[call.ID] = call
+		}
+	}
+
+	calls := make([]ToolCall, 0, len(events))
+	for i, event := range events {
+		call := ToolCall{}
+		if event.ToolCallID != "" {
+			call = byID[event.ToolCallID]
+		}
+		if call.Name == "" && i < len(fallback) {
+			call = fallback[i]
+		}
+
+		if event.ToolCallID != "" {
+			call.ID = event.ToolCallID
+		}
+		if event.ToolName != "" {
+			call.Name = event.ToolName
+		}
+		if event.Args != nil {
+			call.Arguments = toolCallArgsFromEventArgs(event.Args)
+		}
+		call.Success = event.Success
+
+		if call.Name == "" {
+			continue
+		}
+		calls = append(calls, call)
+	}
+	return calls
+}
+
+func toolCallArgsFromEventArgs(args any) ToolCallArgs {
+	raw, ok := jsonObject(args)
+	if !ok {
+		return ToolCallArgs{}
+	}
+
+	out := ToolCallArgs{
+		Path:        stringArg(raw, "path"),
+		FileText:    stringArg(raw, "file_text"),
+		Command:     stringArg(raw, "command"),
+		Description: stringArg(raw, "description"),
+		Skill:       stringArg(raw, "skill"),
+		Extra:       make(map[string]any, len(raw)),
+	}
+	for key, value := range raw {
+		out.Extra[key] = value
+	}
+	if len(out.Extra) == 0 {
+		out.Extra = nil
+	}
+	return out
+}
+
+func jsonObject(value any) (map[string]any, bool) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, false
+	}
+	return raw, true
+}
+
+func stringArg(args map[string]any, key string) string {
+	value, ok := args[key].(string)
+	if !ok {
+		return ""
+	}
+	return value
 }

--- a/internal/orchestration/checkpoints.go
+++ b/internal/orchestration/checkpoints.go
@@ -79,7 +79,8 @@ func (cr *checkpointRunner) runForTurn(ctx context.Context, turn int, resp *exec
 		return false
 	}
 
-	gCtx := cr.runner.buildGraderContext(cr.tc, resp, copilotevents.ToSDK(resp.Events))
+	sdkEvents := copilotevents.ToSDK(resp.Events)
+	gCtx := cr.runner.buildGraderContext(cr.tc, resp, sdkEvents, buildToolEvents(sdkEvents))
 
 	// Run only the checkpoint's graders. Reuse graders.RunAll by passing a
 	// synthetic TestCase whose Validators field carries the checkpoint

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1246,8 +1246,10 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 	// buildToolEvents.
 	sdkEvents := copilotevents.ToSDK(resp.Events)
 
+	toolEvents := buildToolEvents(sdkEvents)
+
 	// Build validation context
-	vCtx := r.buildGraderContext(tc, resp, sdkEvents)
+	vCtx := r.buildGraderContext(tc, resp, sdkEvents, toolEvents)
 
 	var gradersResults map[string]models.GraderResults
 	if r.skipGraders {
@@ -1344,7 +1346,7 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		WorkspaceDir:     resp.WorkspaceDir,
 		Responder:        responderInfo,
 		Checkpoints:      checkpointOutcomes,
-		ToolEvents:       buildToolEvents(sdkEvents),
+		ToolEvents:       toolEvents,
 	}
 	r.captureSnapshot(tc, req, resp, &run)
 	return returnWithArtifacts(run)
@@ -2040,13 +2042,13 @@ func convertMCPServers(serverConfigs map[string]any, mocks []models.MCPMockConfi
 	})
 }
 
-func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse, sdkEvents []copilot.SessionEvent) *graders.Context {
+func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse, sdkEvents []copilot.SessionEvent, toolEvents []models.ToolEvent) *graders.Context {
 	// Reuse the shared transcript builder so the conversion is preallocated
 	// (entries := make([]TranscriptEvent, 0, len(events))) and produced in a
 	// single place.
 	transcriptEntries := transcript.BuildFromSessionEvents(sdkEvents)
 
-	sessionDigest := r.buildSessionDigest(resp)
+	sessionDigest := models.SessionDigestWithToolEvents(r.buildSessionDigest(resp), toolEvents)
 
 	return &graders.Context{
 		TestCase:         tc,

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -392,7 +392,8 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 		}),
 	}
 
-	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp, copilotevents.ToSDK(resp.Events))
+	sdkEvents := copilotevents.ToSDK(resp.Events)
+	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp, sdkEvents, buildToolEvents(sdkEvents))
 	require.Len(t, graderCtx.Transcript, 1)
 	assert.Equal(t, "final output", graderCtx.Output)
 	assert.Equal(t, int64(42), graderCtx.DurationMS)


### PR DESCRIPTION
Closes #474

## Summary
- Hydrate grader-visible tool calls from canonical `tool_events[].args` when available, preserving the legacy `session_digest.tool_calls` schema while making MCP/custom tool args reliable.
- Use the same hydrated session digest in live runs, checkpoint grading, and offline `waza grade --results` regrading.
- Add regressions for `expect[].args.query` matching after results.json round-trip and tool-name-only expectations backed by tool events.

## Validation
- `go test ./internal/models ./internal/graders ./internal/orchestration ./cmd/waza -run 'TestToolCallsGrader_Expect_(NoArgsMatchesToolEvents|ArgsFromToolEvents)|TestGradeCommand_ToolCallsArgsUseToolEventsAfterResultsRoundTrip|TestBuildGraderContextAndScoreHelpers'`\n- `go test ./internal/models ./internal/graders ./internal/orchestration ./cmd/waza`\n- `go test ./...`\n- `golangci-lint run`