### PR TITLE
Fix tool_calls grader args source from tool_events (#474)

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,14 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents is the canonical per-call event stream (RunResult.ToolEvents,
+	// schema v1.1+). Prefer it as the args source for argmatcher-based
+	// expectations, because SessionDigest.ToolCalls[].Arguments.Extra is
+	// marked json:"-" and is dropped across a results.json round-trip. When
+	// nil or empty, graders fall back to Session.ToolCalls[].Arguments (the
+	// live-run in-memory bag), preserving existing behavior.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/microsoft/waza/internal/graders/argmatcher"
 	"github.com/microsoft/waza/internal/models"
@@ -17,7 +18,14 @@ import (
 // argument keys (e.g. `query`, `limit`) are visible to matchers. Empty-valued
 // known fields are omitted to avoid spurious matches on the zero value;
 // keys in Extra are passed through as-is.
-func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
+//
+// `override` is an optional canonical args map (typically sourced from the
+// matching RunResult.ToolEvents[].Args record). It is layered underneath
+// ToolCallArgs.Extra so that offline grading from results.json — where
+// ToolCallArgs.Extra is empty because it is not JSON-persisted — still sees
+// MCP-specific keys like `query`. Typed non-empty fields (path/command/etc.)
+// always win to preserve the tool-specific matcher behavior.
+func normalizeToolCallArgs(call models.ToolCall, override map[string]any) (map[string]any, error) {
 	data, err := json.Marshal(call.Arguments)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling tool args: %w", err)
@@ -26,25 +34,100 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("unmarshaling tool args: %w", err)
 	}
-	out := make(map[string]any, len(raw)+len(call.Arguments.Extra))
+	out := make(map[string]any, len(raw)+len(call.Arguments.Extra)+len(override))
 	for k, v := range raw {
 		if s, ok := v.(string); ok && s == "" {
 			continue
 		}
 		out[k] = v
 	}
-	// Merge engine-specific extras last so they win over zero-valued known
-	// fields. Known-field collisions (e.g. an MCP tool that happens to
-	// declare a `path` arg with extra metadata) keep the typed value from
-	// ToolCallArgs since it has already been written above and Extra by
-	// construction holds only keys mapstructure could not place.
+	// Merge engine-specific extras and the ToolEvent override. Typed fields
+	// (already written above) win; between the remaining two, we prefer the
+	// live in-memory Extra bag because it matches historical behavior. The
+	// override fills any keys the Extra bag lacks (which is the offline
+	// results.json round-trip case, where Extra is empty).
 	for k, v := range call.Arguments.Extra {
 		if _, present := out[k]; present {
 			continue
 		}
 		out[k] = v
 	}
+	for k, v := range override {
+		if _, present := out[k]; present {
+			continue
+		}
+		out[k] = v
+	}
 	return out, nil
+}
+
+// toolEventArgsFor returns the canonical args map for a specific tool call by
+// consulting the ToolEvents slice. It correlates by:
+//
+//  1. exact match on ToolCallID when both call.ID and event.ToolCallID are
+//     non-empty; else
+//  2. positional match by tool name — the n-th event whose ToolName equals
+//     call.Name (case-insensitive) that has not already been consumed by an
+//     earlier same-name call.
+//
+// Returns nil when no correlation can be established, or when the correlated
+// event's Args is not a JSON object (arrays / scalars are not addressable by
+// argmatcher keys).
+//
+// callsSoFar counts how many previous calls share the same case-insensitive
+// name — pass the caller's positional index within its same-name run.
+func toolEventArgsFor(call models.ToolCall, callsSoFar int, events []models.ToolEvent) map[string]any {
+	if len(events) == 0 {
+		return nil
+	}
+	if call.ID != "" {
+		for _, ev := range events {
+			if ev.ToolCallID == "" {
+				continue
+			}
+			if ev.ToolCallID == call.ID {
+				return coerceArgsToMap(ev.Args)
+			}
+		}
+	}
+	// Positional fallback: pick the (callsSoFar)-th event with a matching
+	// name. Only consider events whose ToolCallID is empty, so we don't
+	// steal args from a call that had an unrelated non-matching ID.
+	target := strings.ToLower(call.Name)
+	seen := 0
+	for _, ev := range events {
+		if !strings.EqualFold(ev.ToolName, target) {
+			continue
+		}
+		if call.ID != "" && ev.ToolCallID != "" && ev.ToolCallID != call.ID {
+			// Different explicit IDs — not the same call.
+			continue
+		}
+		if seen == callsSoFar {
+			return coerceArgsToMap(ev.Args)
+		}
+		seen++
+	}
+	return nil
+}
+
+// coerceArgsToMap normalises a ToolEvent.Args value into a keyed map suitable
+// for argmatcher lookup. Object-shaped values are returned as-is; anything
+// else (arrays, scalars, nil) returns nil so callers can fall back to the
+// in-memory ToolCallArgs shape.
+func coerceArgsToMap(v any) map[string]any {
+	switch a := v.(type) {
+	case map[string]any:
+		return a
+	case map[string]string:
+		out := make(map[string]any, len(a))
+		for k, s := range a {
+			out[k] = s
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 // evaluateArgMatchers returns a slice of human-readable failures describing

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -135,7 +135,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls, gCtx.ToolEvents)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -180,15 +180,30 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+//
+// `events` is the canonical RunResult.ToolEvents slice used to reconstitute
+// engine-specific argument keys (e.g. MCP `query`) that are dropped when the
+// live in-memory ToolCallArgs.Extra bag is not JSON-persisted — i.e. when
+// grading offline from results.json. When empty, matching falls back to the
+// previous behavior of consulting only ToolCallArgs.
+func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall, events []models.ToolEvent) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
 	}
 
+	// Track how many prior calls share each case-insensitive name so we
+	// can positionally correlate to ToolEvents when no explicit ID is
+	// available.
+	sameNameSeen := make(map[string]int, len(calls))
+
 	nameMatches := 0
 	var lastReason string
 	for i, call := range calls {
+		nameKey := strings.ToLower(call.Name)
+		callsSoFar := sameNameSeen[nameKey]
+		sameNameSeen[nameKey] = callsSoFar + 1
+
 		if exp.toolRe != nil && !exp.toolRe.MatchString(call.Name) {
 			continue
 		}
@@ -198,7 +213,8 @@ func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool
 			detail["matched_call_id"] = call.ID
 			return true, detail
 		}
-		args, err := normalizeToolCallArgs(call)
+		override := toolEventArgsFor(call, callsSoFar, events)
+		args, err := normalizeToolCallArgs(call, override)
 		if err != nil {
 			lastReason = err.Error()
 			continue

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -529,3 +529,131 @@ func TestToolCallsGrader_Expect_InvalidMatcher_ConstructError(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+// Regression tests for issue #474: tool_calls grader must be able to match
+// custom/MCP tool args after a results.json round-trip, where
+// ToolCallArgs.Extra (json:"-") is dropped, by falling back to canonical
+// tool_events[].args.
+
+func TestToolCallsGrader_Expect_ArgFromToolEvent_RoundTripPasses(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "hello world"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	// Simulate an offline grade from results.json: ToolCallArgs.Extra is
+	// empty (dropped by JSON round-trip), but tool_events[].args has the
+	// canonical arguments.
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{ID: "call-1", Name: "mcp_search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{ToolCallID: "call-1", ToolName: "mcp_search", Args: map[string]any{"query": "hello world"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ArgFromExtra_LiveStillPasses(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "hello world"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	// Live run parity: Extra is populated in-memory; no ToolEvents needed.
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "mcp_search", Arguments: models.ToolCallArgs{Extra: map[string]any{"query": "hello world"}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ToolNameOnly_NoToolEventsNeeded(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "mcp_search"}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "mcp_search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ArgMismatch_StillFails(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "hello world"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{ID: "call-1", Name: "mcp_search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{ToolCallID: "call-1", ToolName: "mcp_search", Args: map[string]any{"query": "goodbye"}},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+	require.Contains(t, res.Feedback, "query")
+}
+
+func TestToolCallsGrader_Expect_ArgFromToolEvent_PositionalCorrelation(t *testing.T) {
+	// Both ToolCallID fields are empty on ToolCalls and events; correlation
+	// must fall back to positional-by-name.
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "second"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "mcp_search", Arguments: models.ToolCallArgs{}},
+				{Name: "mcp_search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{ToolName: "mcp_search", Args: map[string]any{"query": "first"}},
+			{ToolName: "mcp_search", Args: map[string]any{"query": "second"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}

--- a/internal/graders/tool_constraint_grader.go
+++ b/internal/graders/tool_constraint_grader.go
@@ -108,8 +108,8 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 
 		var failures []string
 
-		failures = append(failures, tc.checkExpectTools(session)...)
-		failures = append(failures, tc.checkRejectTools(session)...)
+		failures = append(failures, tc.checkExpectTools(session, gradingContext.ToolEvents)...)
+		failures = append(failures, tc.checkRejectTools(session, gradingContext.ToolEvents)...)
 
 		totalChecks := tc.countTotalChecks()
 		passedChecks := totalChecks - len(failures)
@@ -146,8 +146,9 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 }
 
 // matchesToolCall returns true if spec matches the given tool call constraints.
+// `override` is an optional canonical args map (see normalizeToolCallArgs).
 // NOTE: this function assumes that the regexes have already been validated.
-func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool {
+func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall, override map[string]any) bool {
 	checkPattern := func(pattern, text string) bool {
 		// empty pattern automatically passes - we validate that they have passed at least one check in
 		// validateToolSpecs().
@@ -177,7 +178,7 @@ func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool 
 	}
 
 	if len(spec.Args) > 0 {
-		args, err := normalizeToolCallArgs(call)
+		args, err := normalizeToolCallArgs(call, override)
 		if err != nil {
 			return false
 		}
@@ -227,7 +228,7 @@ func describeToolSpecs(specs []models.ToolSpecParameters) []string {
 	return out
 }
 
-func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest, events []models.ToolEvent) []string {
 	if len(tc.expectTools) == 0 {
 		return nil
 	}
@@ -236,8 +237,13 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 	for _, spec := range tc.expectTools {
 		found := false
 
+		sameNameSeen := make(map[string]int, len(session.ToolCalls))
 		for _, call := range session.ToolCalls {
-			if matchesToolCall(spec, call) {
+			nameKey := strings.ToLower(call.Name)
+			callsSoFar := sameNameSeen[nameKey]
+			sameNameSeen[nameKey] = callsSoFar + 1
+			override := toolEventArgsFor(call, callsSoFar, events)
+			if matchesToolCall(spec, call, override) {
 				found = true
 				break
 			}
@@ -250,7 +256,7 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 	return failures
 }
 
-func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest, events []models.ToolEvent) []string {
 	if len(tc.rejectTools) == 0 {
 		return nil
 	}
@@ -259,8 +265,13 @@ func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) 
 	for _, spec := range tc.rejectTools {
 		found := false
 
+		sameNameSeen := make(map[string]int, len(session.ToolCalls))
 		for _, call := range session.ToolCalls {
-			if matchesToolCall(spec, call) {
+			nameKey := strings.ToLower(call.Name)
+			callsSoFar := sameNameSeen[nameKey]
+			sameNameSeen[nameKey] = callsSoFar + 1
+			override := toolEventArgsFor(call, callsSoFar, events)
+			if matchesToolCall(spec, call, override) {
 				found = true
 				break
 			}

--- a/internal/graders/tool_constraint_grader_test.go
+++ b/internal/graders/tool_constraint_grader_test.go
@@ -608,3 +608,108 @@ func TestToolConstraintGrader_ExpectTools_MissingExtraArg(t *testing.T) {
 }
 
 func float64Ptr(v float64) *float64 { return &v }
+
+// Regression tests for issue #474: tool_constraint grader must be able to
+// match custom/MCP tool args after a results.json round-trip via
+// tool_events[].args fallback.
+
+func TestToolConstraintGrader_ExpectTools_ArgFromToolEvent_RoundTripPasses(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "hello world"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"mcp_search"},
+			ToolCalls: []models.ToolCall{
+				{ID: "call-1", Name: "mcp_search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{ToolCallID: "call-1", ToolName: "mcp_search", Args: map[string]any{"query": "hello world"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolConstraintGrader_ExpectTools_ArgFromExtra_LiveStillPasses(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "hello world"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"mcp_search"},
+			ToolCalls: []models.ToolCall{
+				{Name: "mcp_search", Arguments: models.ToolCallArgs{Extra: map[string]any{"query": "hello world"}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolConstraintGrader_ExpectTools_ArgMismatch_ToolEvent_Fails(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "hello world"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"mcp_search"},
+			ToolCalls: []models.ToolCall{
+				{ID: "call-1", Name: "mcp_search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{ToolCallID: "call-1", ToolName: "mcp_search", Args: map[string]any{"query": "goodbye"}},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed)
+}
+
+func TestToolConstraintGrader_RejectTools_ArgFromToolEvent_MatchesReject(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		RejectTools: []models.ToolSpecParameters{{
+			Tool: "mcp_search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "forbidden"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"mcp_search"},
+			ToolCalls: []models.ToolCall{
+				{ID: "call-1", Name: "mcp_search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{ToolCallID: "call-1", ToolName: "mcp_search", Args: map[string]any{"query": "forbidden"}},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Passed, "reject_tools should have matched via tool_events fallback")
+}

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -2060,6 +2060,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       buildToolEvents(sdkEvents),
 		Executor:         r.engine,
 	}
 }


### PR DESCRIPTION
Closes #474

## Problem

The `tool_calls` and `tool_constraint` graders evaluated `expect[].args` against `SessionDigest.ToolCalls[].Arguments`, whose `ToolCallArgs.Extra` field is `json:"-"` (`internal/models/events.go:47`). `Extra` is populated live via `mapstructure`, so MCP/custom argument keys (e.g. `query`) match during a live run — but they are dropped when results are round-tripped through `results.json`, so the same expectation fails during offline `waza grade`.

## Fix

Thread `RunResult.ToolEvents` (canonical, JSON-persisted args, additive schema v1.1) into the internal `graders.Context` and use them as a fallback source in `normalizeToolCallArgs`.

- **Merge order:** typed non-empty fields > `call.Arguments.Extra` (live in-memory) > `override` (from tool_events). Live behavior is preserved; offline runs fall through to the canonical events source.
- **Correlation:** prefer exact `ToolCallID` match; fall back to positional-by-name so engines that don't emit stable IDs still work.
- **Tool-name-only** expectations are unchanged (short-circuit path).

## Compatibility

No wire-schema changes:
- `ToolCallArgs.Extra` stays `json:"-"`.
- `SessionDigest.ToolCalls[].arguments` wire shape is unchanged.
- `RunResult.ToolEvents` is already schema v1.1.
- `graders.Context` is internal; adding a field is safe.

## Tests

Added regression tests in both `tool_calls_grader_test.go` and `tool_constraint_grader_test.go` covering:

- Empty `Extra`, args resolved from `ToolEvents` — passes (the reported case).
- Populated `Extra`, no `ToolEvents` — still passes (live parity).
- Tool-name-only expectation with no events needed.
- Argument mismatch surfaced from `ToolEvents` — still fails as expected.
- Positional-by-name correlation when both `ToolCallID` values are empty.
- `reject_tools` matches via `ToolEvents` fallback.

Verified:

```
go fmt ./...
go test ./...
golangci-lint run ./internal/graders/... ./internal/orchestration/... ./cmd/waza/...
```

All targeted and full-suite tests pass; 0 lint issues.