### PR TITLE
fix: use tool events for tool call arg grading

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/cmd/waza/cmd_grade_test.go
+++ b/cmd/waza/cmd_grade_test.go
@@ -111,6 +111,21 @@ graders:
       contains:
         - "hello"
 `
+
+	taskWithToolCallsQueryGrader = `id: task-001
+name: Tool Calls Query
+inputs:
+  prompt: "Search for auth docs"
+graders:
+  - name: search_args
+    type: tool_calls
+    config:
+      expect:
+        - tool: search
+          args:
+            query:
+              contains: auth
+`
 )
 
 func TestGradeCommand_NoArgs(t *testing.T) {
@@ -207,6 +222,46 @@ func TestGradeCommand_SingleTask_Passing(t *testing.T) {
 	require.Equal(t, true, parsed["passed"])
 	tasks := parseMap(t, parsed, "tasks")
 	require.Contains(t, tasks, "task-001")
+}
+
+func TestGradeCommand_ToolCallsExpectArgsUsesToolEventsFromResults(t *testing.T) {
+	dir := t.TempDir()
+	specPath := gradeSpec(t, dir, minimalSpec)
+	writeTaskFile(t, dir, "task.yaml", taskWithToolCallsQueryGrader)
+
+	results := gradeResultsFile(t, dir, outcomeWithTasks(models.TestOutcome{
+		TestID: "task-001",
+		Runs: []models.RunResult{{
+			RunNumber:   1,
+			FinalOutput: "searched",
+			DurationMs:  1000,
+			SessionDigest: models.SessionDigest{
+				SessionID: "s-task-001",
+				ToolCalls: []models.ToolCall{{
+					ID:   "call-1",
+					Name: "search",
+				}},
+			},
+			ToolEvents: []models.ToolEvent{{
+				Sequence:   1,
+				ToolCallID: "call-1",
+				ToolName:   "search",
+				Args:       map[string]any{"query": "auth configuration"},
+				Success:    true,
+			}},
+		}},
+	}))
+
+	output, err := executeGrade(t, specPath, "--task", "task-001", "--results", results)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	require.Equal(t, true, parsed["passed"])
+
+	tasks := parseMap(t, parsed, "tasks")
+	task := parseMap(t, tasks, "task-001")
+	require.Equal(t, true, task["passed"])
 }
 
 func TestGradeCommand_SingleTask_Failing(t *testing.T) {

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,11 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents holds the canonical per-tool-call records from results.json
+	// schema v1.1+. Tool-call argument graders should prefer this over
+	// Session.ToolCalls because ToolEvents preserves arbitrary MCP/custom args.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -47,6 +47,75 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	return out, nil
 }
 
+func normalizeToolEventArgs(event models.ToolEvent) (map[string]any, error) {
+	if event.Args == nil {
+		return map[string]any{}, nil
+	}
+	data, err := json.Marshal(event.Args)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling tool event args: %w", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshaling tool event args: %w", err)
+	}
+	return raw, nil
+}
+
+type toolCallRecord struct {
+	id      string
+	name    string
+	args    map[string]any
+	argsErr error
+}
+
+func toolCallRecordsForMatching(gCtx *Context) []toolCallRecord {
+	if gCtx == nil {
+		return nil
+	}
+	var records []toolCallRecord
+	seenIDs := make(map[string]struct{}, len(gCtx.ToolEvents))
+	if len(gCtx.ToolEvents) > 0 {
+		records = make([]toolCallRecord, 0, len(gCtx.ToolEvents))
+		for _, event := range gCtx.ToolEvents {
+			if event.ToolName == "" {
+				continue
+			}
+			if event.ToolCallID != "" {
+				seenIDs[event.ToolCallID] = struct{}{}
+			}
+			args, err := normalizeToolEventArgs(event)
+			records = append(records, toolCallRecord{
+				id:      event.ToolCallID,
+				name:    event.ToolName,
+				args:    args,
+				argsErr: err,
+			})
+		}
+	}
+	if gCtx.Session == nil {
+		return records
+	}
+	if records == nil {
+		records = make([]toolCallRecord, 0, len(gCtx.Session.ToolCalls))
+	}
+	for _, call := range gCtx.Session.ToolCalls {
+		if call.ID != "" {
+			if _, ok := seenIDs[call.ID]; ok {
+				continue
+			}
+		}
+		args, err := normalizeToolCallArgs(call)
+		records = append(records, toolCallRecord{
+			id:      call.ID,
+			name:    call.Name,
+			args:    args,
+			argsErr: err,
+		})
+	}
+	return records
+}
+
 // evaluateArgMatchers returns a slice of human-readable failures describing
 // any matcher in `matchers` whose key was absent from `args` or whose value
 // failed to match. An empty slice means every matcher passed.

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -133,9 +133,10 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		// it passes when at least one recorded tool call matches the tool
 		// name regex AND all configured arg matchers pass on that call.
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
+		expectCalls := toolCallRecordsForMatching(gCtx)
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, expectCalls)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -180,7 +181,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+func evaluateExpectation(exp compiledExpectation, calls []toolCallRecord) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
@@ -189,24 +190,23 @@ func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool
 	nameMatches := 0
 	var lastReason string
 	for i, call := range calls {
-		if exp.toolRe != nil && !exp.toolRe.MatchString(call.Name) {
+		if exp.toolRe != nil && !exp.toolRe.MatchString(call.name) {
 			continue
 		}
 		nameMatches++
 		if len(exp.matcher) == 0 {
 			detail["matched_call_index"] = i
-			detail["matched_call_id"] = call.ID
+			detail["matched_call_id"] = call.id
 			return true, detail
 		}
-		args, err := normalizeToolCallArgs(call)
-		if err != nil {
-			lastReason = err.Error()
+		if call.argsErr != nil {
+			lastReason = call.argsErr.Error()
 			continue
 		}
-		failures := evaluateArgMatchers(exp.matcher, args)
+		failures := evaluateArgMatchers(exp.matcher, call.args)
 		if len(failures) == 0 {
 			detail["matched_call_index"] = i
-			detail["matched_call_id"] = call.ID
+			detail["matched_call_id"] = call.id
 			return true, detail
 		}
 		lastReason = strings.Join(failures, "; ")

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -2,6 +2,7 @@ package graders
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/microsoft/waza/internal/graders/argmatcher"
@@ -373,6 +374,24 @@ func TestToolCallsGrader_Expect_NoArgs_Passes(t *testing.T) {
 	require.True(t, res.Passed, "feedback: %s", res.Feedback)
 }
 
+func TestToolCallsGrader_Expect_NoArgsUsesToolEvents_Passes(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "search"}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{ID: "call-1", Name: "search"}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			Sequence: 1, ToolCallID: "call-1", ToolName: "search",
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
 func TestToolCallsGrader_Expect_MissingTool_Fails(t *testing.T) {
 	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
 		Expect: []models.ToolExpectation{{Tool: "bash"}, {Tool: "view"}},
@@ -405,6 +424,50 @@ func TestToolCallsGrader_Expect_RegexArgMatch_Passes(t *testing.T) {
 				{Name: "bash", Arguments: models.ToolCallArgs{Command: "ls -la"}},
 			},
 		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_UsesToolEventArgsAfterResultsRoundTrip(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	original := models.RunResult{
+		SessionDigest: models.SessionDigest{
+			ToolCalls: []models.ToolCall{{
+				ID:   "call-1",
+				Name: "search",
+				Arguments: models.ToolCallArgs{
+					Extra: map[string]any{"query": "find auth configuration"},
+				},
+			}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			Sequence:   1,
+			ToolCallID: "call-1",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "find auth configuration"},
+			Success:    true,
+		}},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	var restored models.RunResult
+	require.NoError(t, json.Unmarshal(data, &restored))
+	require.Empty(t, restored.SessionDigest.ToolCalls[0].Arguments.Extra, "ToolCallArgs.Extra is intentionally not serialized")
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session:    &restored.SessionDigest,
+		ToolEvents: restored.ToolEvents,
 	})
 	require.NoError(t, err)
 	require.True(t, res.Passed, "feedback: %s", res.Feedback)

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -2060,6 +2060,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       buildToolEvents(sdkEvents),
 		Executor:         r.engine,
 	}
 }


### PR DESCRIPTION
Closes #474

## Summary
- prefer canonical `tool_events[].args` when evaluating `tool_calls.expect[].args`
- carry `ToolEvents` through live and offline grading contexts
- keep legacy `SessionDigest.ToolCalls` fallback for backward compatibility
- add regressions for JSON round-trip arg loss and `waza grade --results`

## Validation
- `go test ./internal/graders ./cmd/waza ./internal/orchestration`
- `go test ./...` (initial run had unrelated `internal/version` flake; targeted rerun passed)
- `go test ./internal/version -run TestCheck_InvalidCacheJSON -count=1 -v`
- `golangci-lint run --allow-parallel-runners`