### PR TITLE
fix: use tool_events args for expect[].args matching (#474)

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,16 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents is the canonical per-call record of tool invocations for
+	// this run, mirroring RunResult.ToolEvents. Unlike Session.ToolCalls
+	// (whose ToolCallArgs.Extra field has json:"-" and is dropped when
+	// results.json is round-tripped for offline grading), ToolEvent.Args
+	// preserves the engine's original argument payload verbatim (see
+	// #474). Graders that match on tool arguments should prefer this
+	// field, correlating by ToolCall.ID == ToolEvent.ToolCallID, and fall
+	// back to Session.ToolCalls only when no matching event is available.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -9,6 +9,45 @@ import (
 	"github.com/microsoft/waza/internal/models"
 )
 
+// resolveToolCallArgs returns the map of arguments to use for a tool call
+// when evaluating argument matchers. It prefers the canonical
+// ToolEvent.Args payload (looked up by ToolCallID) which is preserved
+// verbatim through the results.json round-trip (see #474), and falls
+// back to normalizeToolCallArgs on the ToolCall itself when no matching
+// event is available or the event's Args is not a JSON object.
+//
+// events may be nil (e.g. tests or engines that do not surface tool
+// events); in that case the fallback path is always used.
+func resolveToolCallArgs(call models.ToolCall, events []models.ToolEvent) (map[string]any, error) {
+	if len(events) > 0 && call.ID != "" {
+		for i := range events {
+			if events[i].ToolCallID != call.ID {
+				continue
+			}
+			if m, ok := toolEventArgsMap(events[i].Args); ok {
+				return m, nil
+			}
+			break
+		}
+	}
+	return normalizeToolCallArgs(call)
+}
+
+// toolEventArgsMap coerces a ToolEvent.Args value into a map[string]any
+// when possible. Args is stored as an untyped any so it may hold any
+// JSON-compatible value; only object-shaped payloads carry addressable
+// argument keys for matcher evaluation. Returns (nil, false) for nil,
+// scalars, and arrays so the caller can fall back to the legacy path.
+func toolEventArgsMap(v any) (map[string]any, bool) {
+	switch t := v.(type) {
+	case nil:
+		return nil, false
+	case map[string]any:
+		return t, true
+	}
+	return nil, false
+}
+
 // normalizeToolCallArgs returns the tool call's arguments as a generic
 // map[string]any suitable for argument matchers. Known fields recognized by
 // ToolCallArgs (path, file_text, command, description, skill) are merged with
@@ -17,6 +56,11 @@ import (
 // argument keys (e.g. `query`, `limit`) are visible to matchers. Empty-valued
 // known fields are omitted to avoid spurious matches on the zero value;
 // keys in Extra are passed through as-is.
+//
+// Note: ToolCallArgs.Extra has json:"-" so it does NOT survive a
+// results.json round-trip. For offline grading, resolveToolCallArgs
+// prefers ToolEvent.Args (which is JSON-persisted verbatim) and only
+// falls back to this function when no matching event is available.
 func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	data, err := json.Marshal(call.Arguments)
 	if err != nil {

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -135,7 +135,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls, gCtx.ToolEvents)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -180,7 +180,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall, events []models.ToolEvent) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
@@ -198,7 +198,7 @@ func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool
 			detail["matched_call_id"] = call.ID
 			return true, detail
 		}
-		args, err := normalizeToolCallArgs(call)
+		args, err := resolveToolCallArgs(call, events)
 		if err != nil {
 			lastReason = err.Error()
 			continue

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -529,3 +529,95 @@ func TestToolCallsGrader_Expect_InvalidMatcher_ConstructError(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+// TestToolCallsGrader_Expect_UsesToolEventsWhenExtraMissing is a regression
+// test for #474. When results.json is round-tripped through disk (or an
+// engine surfaces canonical args only via tool_events), ToolCallArgs.Extra
+// is empty because it carries json:"-". The grader must fall back to the
+// per-call ToolEvent.Args payload, correlating by ToolCall.ID ==
+// ToolEvent.ToolCallID, so that expect[].args matchers keep working for
+// MCP/custom tool arguments (e.g. `query`) that don't map to any typed
+// ToolCallArgs field.
+func TestToolCallsGrader_Expect_UsesToolEventsWhenExtraMissing(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "Bissell"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	// Simulate a call reconstructed from results.json: the typed
+	// arguments struct is empty and Extra (json:"-") is nil, but the
+	// canonical args are preserved in the parallel ToolEvent record.
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{ID: "call-1", Name: "search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "call-1",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "Bissell"},
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+// TestToolCallsGrader_Expect_ToolNameOnly_StillMatchesWithoutEvents is a
+// regression guard for #474 ensuring the ToolEvents plumbing doesn't
+// break the common case where an expectation has no `args` and no
+// ToolEvents are provided (legacy callers, tests).
+func TestToolCallsGrader_Expect_ToolNameOnly_StillMatchesWithoutEvents(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "search"}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{Name: "search"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+// TestToolCallsGrader_Expect_ArgsFallBackToNormalizedWhenNoEvent covers
+// the case where ToolEvents is populated but has no matching ToolCallID
+// (or the matching event's Args isn't a map). The grader must fall back
+// to normalizeToolCallArgs so live runs with populated Extra still work.
+func TestToolCallsGrader_Expect_ArgsFallBackToNormalizedWhenNoEvent(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "Bissell"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{
+				ID:   "call-1",
+				Name: "search",
+				Arguments: models.ToolCallArgs{
+					Extra: map[string]any{"query": "Bissell"},
+				},
+			}},
+		},
+		// Event with a non-matching ID — should be ignored, forcing
+		// the fallback to normalizeToolCallArgs on Extra.
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "call-other",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "wrong"},
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}

--- a/internal/graders/tool_constraint_grader.go
+++ b/internal/graders/tool_constraint_grader.go
@@ -108,8 +108,8 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 
 		var failures []string
 
-		failures = append(failures, tc.checkExpectTools(session)...)
-		failures = append(failures, tc.checkRejectTools(session)...)
+		failures = append(failures, tc.checkExpectTools(session, gradingContext.ToolEvents)...)
+		failures = append(failures, tc.checkRejectTools(session, gradingContext.ToolEvents)...)
 
 		totalChecks := tc.countTotalChecks()
 		passedChecks := totalChecks - len(failures)
@@ -147,7 +147,7 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 
 // matchesToolCall returns true if spec matches the given tool call constraints.
 // NOTE: this function assumes that the regexes have already been validated.
-func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool {
+func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall, events []models.ToolEvent) bool {
 	checkPattern := func(pattern, text string) bool {
 		// empty pattern automatically passes - we validate that they have passed at least one check in
 		// validateToolSpecs().
@@ -177,7 +177,7 @@ func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool 
 	}
 
 	if len(spec.Args) > 0 {
-		args, err := normalizeToolCallArgs(call)
+		args, err := resolveToolCallArgs(call, events)
 		if err != nil {
 			return false
 		}
@@ -227,7 +227,7 @@ func describeToolSpecs(specs []models.ToolSpecParameters) []string {
 	return out
 }
 
-func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest, events []models.ToolEvent) []string {
 	if len(tc.expectTools) == 0 {
 		return nil
 	}
@@ -237,7 +237,7 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 		found := false
 
 		for _, call := range session.ToolCalls {
-			if matchesToolCall(spec, call) {
+			if matchesToolCall(spec, call, events) {
 				found = true
 				break
 			}
@@ -250,7 +250,7 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 	return failures
 }
 
-func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest, events []models.ToolEvent) []string {
 	if len(tc.rejectTools) == 0 {
 		return nil
 	}
@@ -260,7 +260,7 @@ func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) 
 		found := false
 
 		for _, call := range session.ToolCalls {
-			if matchesToolCall(spec, call) {
+			if matchesToolCall(spec, call, events) {
 				found = true
 				break
 			}

--- a/internal/graders/tool_constraint_grader_test.go
+++ b/internal/graders/tool_constraint_grader_test.go
@@ -608,3 +608,55 @@ func TestToolConstraintGrader_ExpectTools_MissingExtraArg(t *testing.T) {
 }
 
 func float64Ptr(v float64) *float64 { return &v }
+
+// TestToolConstraintGrader_ExpectTools_UsesToolEventsWhenExtraMissing is
+// a regression test for #474: the parallel bug on the tool_constraint
+// grader. ToolCallArgs.Extra is not persisted (json:"-") so after a
+// results.json round-trip, expect_tools matchers keyed on MCP args (e.g.
+// `query`) miss unless we fall back to the ToolEvent.Args payload.
+func TestToolConstraintGrader_ExpectTools_UsesToolEventsWhenExtraMissing(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "Bissell"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"search"},
+			ToolCalls: []models.ToolCall{
+				// Reconstructed from results.json: typed args empty, Extra nil.
+				{ID: "call-1", Name: "search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "call-1",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "Bissell vacuum"},
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+// TestToolConstraintGrader_ExpectTools_ToolNameOnly_NoEvents guards that
+// tool-name-only matching still works when no ToolEvents are supplied
+// (backward compat for callers that don't populate the new field).
+func TestToolConstraintGrader_ExpectTools_ToolNameOnly_NoEvents(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{Tool: "search"}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"search"},
+			ToolCalls: []models.ToolCall{{Name: "search"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -2060,6 +2060,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       buildToolEvents(sdkEvents),
 		Executor:         r.engine,
 	}
 }


### PR DESCRIPTION
Fixes #474.

## Problem

`tool_calls` and `tool_constraint` graders evaluate `expect[].args` matchers against `SessionDigest.ToolCalls[].Arguments`. MCP/custom args land in `ToolCallArgs.Extra`, which carries `json:"-"` and is dropped when `results.json` is round-tripped for offline grading via `waza grade`. `normalizeToolCallArgs` reassembled the arg map from `Arguments.Extra`, so after reload the map came back empty and matchers keyed on args like `query` always missed — even though `RunResult.ToolEvents[].Args` still held the canonical payload.

## Fix

Additive change — no schema break.

- New `graders.Context.ToolEvents []models.ToolEvent` field carries the canonical, JSON-persisted per-call args.
- New `resolveToolCallArgs(call, events)` helper prefers `ToolEvent.Args` (correlated by `ToolCallID == ToolCall.ID`, only when map-shaped) and falls back to `normalizeToolCallArgs` for missing IDs, non-map payloads, or callers that don't populate `ToolEvents`.
- Both graders (`tool_calls_grader.go`, `tool_constraint_grader.go`) route args resolution through the new helper.
- Both `Context` construction sites populate `ToolEvents`:
  - Live path: `runner.buildGraderContext` uses `buildToolEvents(sdkEvents)`.
  - Offline grade path: `cmd_grade.gradeRun` uses `run.ToolEvents` (survives round-trip).

## Backward compatibility

- `ToolCallArgs.Extra` JSON tag unchanged (schema contract preserved).
- `ToolEvent` wire format unchanged.
- Tool-name-only expectations (no `args`) still match; no `ToolEvents` needed.
- Callers that don't populate `Context.ToolEvents` fall back to the previous `normalizeToolCallArgs` behavior — live runs with populated `Extra` continue to work.

## Tests

Added focused regression tests:

- `TestToolCallsGrader_Expect_UsesToolEventsWhenExtraMissing` — reproduces the failing `query` arg case with empty `Extra` + populated `ToolEvents`; passes after fix.
- `TestToolCallsGrader_Expect_ToolNameOnly_StillMatchesWithoutEvents` — backward-compat guard for tool-name-only matching without `ToolEvents`.
- `TestToolCallsGrader_Expect_ArgsFallBackToNormalizedWhenNoEvent` — verifies fallback to `normalizeToolCallArgs` when `ToolEvents` has no matching ID.
- Mirrored `TestToolConstraintGrader_ExpectTools_UsesToolEventsWhenExtraMissing` and `_ToolNameOnly_NoEvents` on the constraint grader.

## Verification

```
go fmt ./...
go test ./internal/graders/... ./internal/orchestration/... ./internal/models/... ./cmd/...   # all pass
golangci-lint run                                                                              # 0 issues
```

Closes #474