### PR TITLE
fix: preserve ToolCallArgs.Extra through results.json round-trip

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -257,6 +257,13 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		return &gradedRun, nil
 	}
 
+	// Backfill MCP-style arguments (e.g. `query`) onto SessionDigest.ToolCalls
+	// from the canonical tool_events entries for `results.json` files written
+	// before ToolCallArgs.MarshalJSON inlined Extra keys (#474). The helper is
+	// a no-op when SessionDigest already carries the args or when ToolEvents
+	// is absent (legacy schema versions < 1.1).
+	gradedRun.HydrateToolCallArgsFromEvents()
+
 	skillInvocations := make([]execution.SkillInvocation, len(run.SkillInvocations))
 	for i, si := range run.SkillInvocations {
 		skillInvocations[i] = execution.SkillInvocation{Name: si.Name, Path: si.Path}
@@ -266,7 +273,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		TestCase:         tc,
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
-		Session:          &run.SessionDigest,
+		Session:          &gradedRun.SessionDigest,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/internal/graders/tool_constraint_grader_test.go
+++ b/internal/graders/tool_constraint_grader_test.go
@@ -2,6 +2,7 @@ package graders
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -608,3 +609,80 @@ func TestToolConstraintGrader_ExpectTools_MissingExtraArg(t *testing.T) {
 }
 
 func float64Ptr(v float64) *float64 { return &v }
+
+// TestToolConstraintGrader_ExpectTools_ArgsRoundTripThroughJSON reproduces
+// issue #474: after a live run, `session_digest.tool_calls[]` is written
+// to results.json and later reloaded by `waza grade`. MCP-style argument
+// keys (e.g. `query`) live on ToolCallArgs.Extra, which used to be tagged
+// `json:"-"` and was therefore dropped across the round-trip, causing
+// argument matchers to fail during offline grading even when the live run
+// matched. This test bakes in the fix by marshaling / unmarshaling the
+// call before running the grader.
+func TestToolConstraintGrader_ExpectTools_ArgsRoundTripThroughJSON(t *testing.T) {
+	original := models.ToolCall{
+		ID:   "call-1",
+		Name: "search",
+		Arguments: models.ToolCallArgs{
+			Extra: map[string]any{
+				"query": "find auth bypass",
+				"limit": 5,
+			},
+		},
+	}
+
+	// Emulate the results.json round-trip.
+	buf, err := json.Marshal(original)
+	require.NoError(t, err)
+	var restored models.ToolCall
+	require.NoError(t, json.Unmarshal(buf, &restored))
+	require.Equal(t, "find auth bypass", restored.Arguments.Extra["query"],
+		"regression guard: Extra must survive JSON round-trip")
+
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+				"limit": {
+					Kind:  argmatcher.KindRange,
+					Range: &argmatcher.RangeSpec{GTE: float64Ptr(1), LTE: float64Ptr(10)},
+				},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"search"},
+			ToolCalls: []models.ToolCall{restored},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+// TestToolConstraintGrader_ExpectTools_NameOnlyStillMatchesAfterRoundTrip
+// guards the backward-compat contract: a tool spec that names a tool
+// without any args must still pass when the round-tripped call has no
+// Extra entries. Nothing in the fix should shift name-only matching.
+func TestToolConstraintGrader_ExpectTools_NameOnlyStillMatchesAfterRoundTrip(t *testing.T) {
+	buf, err := json.Marshal(models.ToolCall{Name: "bash"})
+	require.NoError(t, err)
+	var restored models.ToolCall
+	require.NoError(t, json.Unmarshal(buf, &restored))
+
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{Tool: "bash"}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"bash"},
+			ToolCalls: []models.ToolCall{restored},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}

--- a/internal/models/events.go
+++ b/internal/models/events.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -39,12 +40,115 @@ type ToolCallArgs struct {
 	// ",remain" support so argument matchers in tool_calls /
 	// tool_constraint graders can see the full argument bag.
 	//
-	// Excluded from JSON marshaling: callers consuming arguments as a
-	// generic map should use graders.normalizeToolCallArgs, which merges
-	// Extra into the known fields. Persisting the raw bag in results.json
-	// happens through RunResult.ToolEvents instead, which preserves the
-	// engine's original argument value verbatim.
+	// Serialized inline alongside the fixed fields via [ToolCallArgs.MarshalJSON]
+	// / [ToolCallArgs.UnmarshalJSON] so that MCP-style keys (e.g. `query`)
+	// survive a round-trip through `results.json` and are visible to graders
+	// during offline `waza grade` runs. Known-field keys always win — a
+	// collision (unusual, since mapstructure only populates Extra with keys
+	// it could not place) is silently dropped from Extra during unmarshal.
 	Extra map[string]any `json:"-" mapstructure:",remain"`
+}
+
+// toolCallArgsKnownFields lists the JSON keys owned by ToolCallArgs's fixed
+// struct fields. Kept as a package-level var so MarshalJSON and UnmarshalJSON
+// share a single source of truth and can quickly discriminate Extra keys.
+var toolCallArgsKnownFields = map[string]struct{}{
+	"path":        {},
+	"file_text":   {},
+	"command":     {},
+	"description": {},
+	"skill":       {},
+}
+
+// MarshalJSON emits the fixed fields (preserving the historical shape —
+// every known key is always present, even when the value is the zero
+// string) and inlines any [ToolCallArgs.Extra] entries at the same level.
+//
+// Inlining Extra fixes issue #474: previously `Extra` had `json:"-"`, so
+// MCP tool arguments such as `query` and `limit` were dropped when
+// `session_digest.tool_calls[].arguments` was written to `results.json`,
+// which made the `tool_calls` grader's `expect[].args` matcher fail during
+// offline grading (`waza grade`) even though the live run had matched.
+//
+// This change is additive to the wire format: existing consumers still see
+// the same known keys with the same values; new keys are simply also
+// present when the engine supplied them.
+func (a ToolCallArgs) MarshalJSON() ([]byte, error) {
+	// Alias suppresses the receiver's custom MarshalJSON to reuse the
+	// default reflection-based marshaller for the fixed fields.
+	type alias ToolCallArgs
+	base, err := json.Marshal(alias(a))
+	if err != nil {
+		return nil, err
+	}
+	if len(a.Extra) == 0 {
+		return base, nil
+	}
+
+	// Decode the known-field object, splice Extra in, re-encode. This is
+	// simpler than string manipulation and keeps encoding/json responsible
+	// for escaping and ordering.
+	merged := make(map[string]json.RawMessage, len(toolCallArgsKnownFields)+len(a.Extra))
+	if err := json.Unmarshal(base, &merged); err != nil {
+		return nil, err
+	}
+	for k, v := range a.Extra {
+		if _, isKnown := toolCallArgsKnownFields[k]; isKnown {
+			// Should not happen under normal mapstructure usage, but if
+			// it does, defer to the known field's value.
+			continue
+		}
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling ToolCallArgs.Extra[%q]: %w", k, err)
+		}
+		merged[k] = raw
+	}
+	return json.Marshal(merged)
+}
+
+// UnmarshalJSON reads the fixed fields and captures every other top-level
+// key into [ToolCallArgs.Extra]. This is the read side of the inlining
+// contract documented on MarshalJSON: it lets `waza grade` reconstitute
+// full MCP argument bags from a serialized `session_digest.tool_calls[]`.
+func (a *ToolCallArgs) UnmarshalJSON(data []byte) error {
+	// Empty-object / null are common in older captures; treat them as a
+	// zero value rather than an error.
+	if len(data) == 0 || string(data) == "null" {
+		*a = ToolCallArgs{}
+		return nil
+	}
+
+	// Reuse the reflection-based unmarshaller for the known fields.
+	type alias ToolCallArgs
+	var fixed alias
+	if err := json.Unmarshal(data, &fixed); err != nil {
+		return err
+	}
+
+	// Second pass: collect anything that isn't a known field into Extra.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var extra map[string]any
+	for k, v := range raw {
+		if _, isKnown := toolCallArgsKnownFields[k]; isKnown {
+			continue
+		}
+		var decoded any
+		if err := json.Unmarshal(v, &decoded); err != nil {
+			return fmt.Errorf("unmarshaling ToolCallArgs.Extra[%q]: %w", k, err)
+		}
+		if extra == nil {
+			extra = make(map[string]any, len(raw))
+		}
+		extra[k] = decoded
+	}
+
+	*a = ToolCallArgs(fixed)
+	a.Extra = extra
+	return nil
 }
 
 type TranscriptEvent struct {

--- a/internal/models/events_test.go
+++ b/internal/models/events_test.go
@@ -97,3 +97,63 @@ func TestTranscriptEventRoundTripPreservesUncoveredType(t *testing.T) {
 		})
 	}
 }
+
+// TestToolCallArgs_ExtraRoundTripsThroughJSON reproduces the round-trip issue
+// from #474: MCP tool arguments captured into ToolCallArgs.Extra (e.g. `query`)
+// must survive marshaling into results.json and unmarshaling back, so that the
+// tool_calls grader's expect[].args matcher works during offline grading.
+//
+// The default `json:"-"` behavior used to drop Extra silently.
+func TestToolCallArgs_ExtraRoundTripsThroughJSON(t *testing.T) {
+	original := ToolCallArgs{
+		Extra: map[string]any{
+			"query": "hello world",
+			"limit": float64(5),
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// Extra keys must appear at the top level, not nested under a wrapper.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.Equal(t, "hello world", raw["query"])
+	require.EqualValues(t, 5, raw["limit"])
+	// Known fields are still emitted (backward compat with wire format).
+	_, hasPath := raw["path"]
+	require.True(t, hasPath, "known fields must remain in the wire format")
+
+	var restored ToolCallArgs
+	require.NoError(t, json.Unmarshal(data, &restored))
+	require.Equal(t, "hello world", restored.Extra["query"])
+	require.EqualValues(t, 5, restored.Extra["limit"])
+}
+
+// TestToolCallArgs_UnmarshalPreservesKnownFields ensures the custom
+// UnmarshalJSON does not regress mapping of the fixed fields onto the struct.
+func TestToolCallArgs_UnmarshalPreservesKnownFields(t *testing.T) {
+	input := `{"path":"/tmp/f","file_text":"hi","command":"ls","description":"list","skill":"web","query":"needle"}`
+	var got ToolCallArgs
+	require.NoError(t, json.Unmarshal([]byte(input), &got))
+	require.Equal(t, "/tmp/f", got.Path)
+	require.Equal(t, "hi", got.FileText)
+	require.Equal(t, "ls", got.Command)
+	require.Equal(t, "list", got.Description)
+	require.Equal(t, "web", got.Skill)
+	require.Equal(t, "needle", got.Extra["query"])
+}
+
+// TestToolCallArgs_UnmarshalHandlesNullAndEmpty exercises the null/empty
+// short-circuit so legacy captures that omitted the arguments object don't
+// error out.
+func TestToolCallArgs_UnmarshalHandlesNullAndEmpty(t *testing.T) {
+	var got ToolCallArgs
+	require.NoError(t, json.Unmarshal([]byte("null"), &got))
+	require.Empty(t, got.Extra)
+
+	got = ToolCallArgs{Path: "leftover", Extra: map[string]any{"stale": true}}
+	require.NoError(t, json.Unmarshal([]byte("null"), &got))
+	require.Empty(t, got.Path, "null should reset to zero value")
+	require.Empty(t, got.Extra)
+}

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -470,3 +470,66 @@ func ComputeStdDev(values []float64) float64 {
 	}
 	return math.Sqrt(variance / float64(n))
 }
+
+// HydrateToolCallArgsFromEvents fills in missing MCP-style arguments on
+// the run's SessionDigest.ToolCalls by copying them from the canonical
+// ToolEvents (matched on ToolCallID). This is a no-op for tool calls
+// whose Arguments.Extra is already populated and for events whose Args
+// value isn't a JSON object.
+//
+// Motivation (#474): older `results.json` files were written before
+// [ToolCallArgs.MarshalJSON] inlined Extra, so the persisted
+// `session_digest.tool_calls[].arguments` object lost MCP-specific keys
+// such as `query`. The tool_calls grader's `expect[].args` matcher then
+// failed during offline grading (`waza grade`) even though the same run
+// had graded green in the original invocation. ToolEvents was added in
+// schema 1.1 and preserves the argument bag verbatim, so we can
+// reconstruct Extra from there.
+//
+// The hydration is intentionally conservative:
+//   - only tool calls whose Extra is empty are touched (never overwrite
+//     data supplied directly by the engine on a live run),
+//   - matching requires a non-empty ToolCallID on both sides,
+//   - keys that collide with known ToolCallArgs fields are skipped so we
+//     don't shadow the struct-native values.
+func (r *RunResult) HydrateToolCallArgsFromEvents() {
+	if r == nil || len(r.ToolEvents) == 0 || len(r.SessionDigest.ToolCalls) == 0 {
+		return
+	}
+
+	byID := make(map[string]map[string]any, len(r.ToolEvents))
+	for _, ev := range r.ToolEvents {
+		if ev.ToolCallID == "" {
+			continue
+		}
+		args, ok := ev.Args.(map[string]any)
+		if !ok || len(args) == 0 {
+			continue
+		}
+		byID[ev.ToolCallID] = args
+	}
+	if len(byID) == 0 {
+		return
+	}
+
+	for i := range r.SessionDigest.ToolCalls {
+		call := &r.SessionDigest.ToolCalls[i]
+		if len(call.Arguments.Extra) > 0 || call.ID == "" {
+			continue
+		}
+		args, ok := byID[call.ID]
+		if !ok {
+			continue
+		}
+		extra := make(map[string]any, len(args))
+		for k, v := range args {
+			if _, isKnown := toolCallArgsKnownFields[k]; isKnown {
+				continue
+			}
+			extra[k] = v
+		}
+		if len(extra) > 0 {
+			call.Arguments.Extra = extra
+		}
+	}
+}

--- a/internal/models/outcome_test.go
+++ b/internal/models/outcome_test.go
@@ -247,3 +247,62 @@ func TestResponderInfoSerializes(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, string(data2), `"responder"`)
 }
+
+// TestHydrateToolCallArgsFromEvents_BackfillsExtra proves the offline grade
+// path recovers MCP-style args from tool_events when SessionDigest was
+// written by an older waza version that dropped ToolCallArgs.Extra
+// (issue #474).
+func TestHydrateToolCallArgsFromEvents_BackfillsExtra(t *testing.T) {
+	run := &RunResult{
+		SessionDigest: SessionDigest{
+			ToolCalls: []ToolCall{
+				{ID: "call-1", Name: "mcp_search", Arguments: ToolCallArgs{}},
+				{ID: "call-2", Name: "mcp_search", Arguments: ToolCallArgs{Extra: map[string]any{"query": "already-here"}}},
+				{ID: "", Name: "no-id", Arguments: ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []ToolEvent{
+			{ToolCallID: "call-1", ToolName: "mcp_search", Args: map[string]any{
+				"query": "hydrated",
+				"limit": float64(3),
+				// Collides with a known field: must be dropped from Extra.
+				"path": "/should/not/overwrite",
+			}},
+			{ToolCallID: "call-2", ToolName: "mcp_search", Args: map[string]any{
+				"query": "should-not-overwrite",
+			}},
+			// Args as a non-object value (some engines emit scalars) is skipped.
+			{ToolCallID: "call-3", ToolName: "scalar", Args: "raw-string"},
+		},
+	}
+
+	run.HydrateToolCallArgsFromEvents()
+
+	require.Equal(t, "hydrated", run.SessionDigest.ToolCalls[0].Arguments.Extra["query"])
+	require.EqualValues(t, 3, run.SessionDigest.ToolCalls[0].Arguments.Extra["limit"])
+	_, hasPath := run.SessionDigest.ToolCalls[0].Arguments.Extra["path"]
+	require.False(t, hasPath, "collision with known field must be dropped from Extra")
+
+	// Never overwrite when Extra is already populated (live run wins).
+	require.Equal(t, "already-here", run.SessionDigest.ToolCalls[1].Arguments.Extra["query"])
+
+	// Empty ID => no hydration attempted.
+	require.Empty(t, run.SessionDigest.ToolCalls[2].Arguments.Extra)
+}
+
+// TestHydrateToolCallArgsFromEvents_NoOpWhenEmpty guards the fast paths so
+// live runs and pre-1.1 results.json files aren't perturbed.
+func TestHydrateToolCallArgsFromEvents_NoOpWhenEmpty(t *testing.T) {
+	// Nil receiver must not panic.
+	var nilRun *RunResult
+	nilRun.HydrateToolCallArgsFromEvents()
+
+	// No ToolEvents => nothing to hydrate from.
+	run := &RunResult{SessionDigest: SessionDigest{ToolCalls: []ToolCall{{ID: "x"}}}}
+	run.HydrateToolCallArgsFromEvents()
+	require.Empty(t, run.SessionDigest.ToolCalls[0].Arguments.Extra)
+
+	// No ToolCalls => nothing to update.
+	run2 := &RunResult{ToolEvents: []ToolEvent{{ToolCallID: "x", Args: map[string]any{"a": 1}}}}
+	require.NotPanics(t, func() { run2.HydrateToolCallArgsFromEvents() })
+}


### PR DESCRIPTION
Closes #474

## Problem

The `tool_calls` / `tool_constraint` graders read MCP-style argument keys (e.g. `query`) from `ToolCallArgs.Extra`, which is populated at runtime via the mapstructure `,remain` tag. Because `Extra` was tagged `json:"-"`, those keys were silently dropped when the session digest was serialized into `results.json`. As a result, `waza grade` (offline) reported

```
argument "query": not present on tool call
```

for runs whose live grading had passed against the exact same expectation. `tool_events[].args` preserved the canonical arguments, but the grader read from `session_digest.tool_calls[]`.

## Fix (two parts, both additive)

**1. `ToolCallArgs.MarshalJSON` / `UnmarshalJSON`** (`internal/models/events.go`)

Extra keys are now inlined at the top level of the JSON object next to the fixed fields (`path`, `file_text`, `command`, `description`, `skill`). Known-field names always win, so shape and back-compat are preserved and JSON round-trips are lossless. This is the primary fix for future runs.

**2. `(*RunResult).HydrateToolCallArgsFromEvents`** (`internal/models/outcome.go`, wired into `cmd/waza/cmd_grade.go:gradeRun`)

Backfills empty `Extra` maps from `RunResult.ToolEvents` (matched by `ToolCallID`) so **legacy `results.json` files produced before fix #1 still grade correctly**. Only touches calls with an empty `Extra` and a non-empty ID, and runs on a local copy of the RunResult so the caller is never mutated in place.

## Backward compatibility

- No schema version bump — the change is purely additive.
- Known fields are still emitted with the same names and shape.
- Tool-name-only expectations (`expect: [{tool: search}]` without an `args` block) short-circuit before args are inspected and are unaffected.
- Collision rule: if a hypothetical Extra key ever matched a known field name, the known field wins on both marshal and unmarshal.

## Tests added

- `TestToolCallArgs_ExtraRoundTripsThroughJSON`, `TestToolCallArgs_UnmarshalPreservesKnownFields`, `TestToolCallArgs_UnmarshalHandlesNullAndEmpty` — Marshal/Unmarshal round-trip semantics.
- `TestHydrateToolCallArgsFromEvents_BackfillsExtra`, `TestHydrateToolCallArgsFromEvents_NoOpWhenEmpty` — hydration guardrails (only empty Extra, only non-empty ID, only map[string]any event args, known-field collisions dropped, nil-receiver safe).
- `TestToolConstraintGrader_ExpectTools_ArgsRoundTripThroughJSON` — the reproducer requested in triage: builds a `ToolCall` with `Extra: {query: "find auth bypass"}`, marshals + unmarshals to simulate `results.json`, runs the grader with `args: {query: {contains: "auth"}}` and asserts pass.
- `TestToolConstraintGrader_ExpectTools_NameOnlyStillMatchesAfterRoundTrip` — guards the name-only expectation contract.

## Verification

```
go fmt ./...
go test ./...        # full suite passes
golangci-lint run    # 0 issues
```