### PR TITLE
fix(graders): use tool_events args to survive results.json round-trip

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,15 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents is the canonical, JSON-preserved record of tool calls
+	// emitted during the run (schema v1.1+). Graders that inspect tool
+	// call arguments (tool_calls, tool_constraint) should prefer this
+	// over Session.ToolCalls because ToolCallArgs.Extra is intentionally
+	// excluded from JSON (`json:"-"`) and therefore lost across
+	// results.json round-trips. Correlated with Session.ToolCalls by
+	// ToolCallID (falling back to positional index when IDs are missing).
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -17,7 +17,17 @@ import (
 // argument keys (e.g. `query`, `limit`) are visible to matchers. Empty-valued
 // known fields are omitted to avoid spurious matches on the zero value;
 // keys in Extra are passed through as-is.
-func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
+//
+// canonical, when non-nil and shaped as a map[string]any, is the
+// JSON-preserved args payload from the corresponding tool_event (schema
+// v1.1+). It is used as a fallback source for arg keys that are absent
+// from both the typed ToolCallArgs fields and Extra. This matters for
+// offline grading (`waza grade`) because ToolCallArgs.Extra is
+// json:"-" and therefore dropped across a results.json round-trip,
+// while tool_events[].args preserves the full engine payload. Typed
+// fields on ToolCallArgs take precedence when both are populated;
+// canonical fills in only what would otherwise be missing.
+func normalizeToolCallArgs(call models.ToolCall, canonical any) (map[string]any, error) {
 	data, err := json.Marshal(call.Arguments)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling tool args: %w", err)
@@ -26,14 +36,15 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("unmarshaling tool args: %w", err)
 	}
-	out := make(map[string]any, len(raw)+len(call.Arguments.Extra))
+	canonicalMap, _ := canonical.(map[string]any)
+	out := make(map[string]any, len(raw)+len(call.Arguments.Extra)+len(canonicalMap))
 	for k, v := range raw {
 		if s, ok := v.(string); ok && s == "" {
 			continue
 		}
 		out[k] = v
 	}
-	// Merge engine-specific extras last so they win over zero-valued known
+	// Merge engine-specific extras next so they win over zero-valued known
 	// fields. Known-field collisions (e.g. an MCP tool that happens to
 	// declare a `path` arg with extra metadata) keep the typed value from
 	// ToolCallArgs since it has already been written above and Extra by
@@ -44,7 +55,53 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 		}
 		out[k] = v
 	}
+	// Finally, fall back to the canonical tool_event args payload for any
+	// keys still missing. This restores engine-specific arg keys that
+	// were dropped when SessionDigest was written to disk and re-read for
+	// offline grading. Typed fields and Extra take precedence when they
+	// carry a value, so live-run behavior is unchanged.
+	for k, v := range canonicalMap {
+		if _, present := out[k]; present {
+			continue
+		}
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		out[k] = v
+	}
 	return out, nil
+}
+
+// toolEventArgsByCall builds a lookup that returns the canonical args
+// payload for a given ToolCall from the run's tool_events. Correlation
+// prefers ToolCallID (schema v1.1+ populates it for every event); when
+// IDs are missing on either side the lookup falls back to positional
+// order, which matches how buildToolEvents derives events from the SDK
+// session stream (same source, same order as SessionDigest.ToolCalls).
+// A nil or empty events slice yields a lookup that always returns nil,
+// preserving pre-fix behavior for graders that don't receive tool
+// events.
+func toolEventArgsByCall(events []models.ToolEvent) func(idx int, call models.ToolCall) any {
+	if len(events) == 0 {
+		return func(int, models.ToolCall) any { return nil }
+	}
+	byID := make(map[string]any, len(events))
+	for i := range events {
+		if id := events[i].ToolCallID; id != "" {
+			byID[id] = events[i].Args
+		}
+	}
+	return func(idx int, call models.ToolCall) any {
+		if call.ID != "" {
+			if v, ok := byID[call.ID]; ok {
+				return v
+			}
+		}
+		if idx >= 0 && idx < len(events) {
+			return events[idx].Args
+		}
+		return nil
+	}
 }
 
 // evaluateArgMatchers returns a slice of human-readable failures describing

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -132,10 +132,11 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		// Per-expectation checks: each expectation contributes one check;
 		// it passes when at least one recorded tool call matches the tool
 		// name regex AND all configured arg matchers pass on that call.
+		canonicalArgs := toolEventArgsByCall(gCtx.ToolEvents)
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls, canonicalArgs)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -180,7 +181,11 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+// canonicalArgs looks up the JSON-preserved args payload for each call
+// (from tool_events) so that arg matchers survive a results.json
+// round-trip; pass a no-op (from toolEventArgsByCall(nil)) when no
+// tool_events are available.
+func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall, canonicalArgs func(int, models.ToolCall) any) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
@@ -198,7 +203,7 @@ func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool
 			detail["matched_call_id"] = call.ID
 			return true, detail
 		}
-		args, err := normalizeToolCallArgs(call)
+		args, err := normalizeToolCallArgs(call, canonicalArgs(i, call))
 		if err != nil {
 			lastReason = err.Error()
 			continue

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -529,3 +529,98 @@ func TestToolCallsGrader_Expect_InvalidMatcher_ConstructError(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+// TestToolCallsGrader_Expect_ArgsFromToolEventsAfterRoundTrip reproduces
+// issue #474: an offline `waza grade` reads SessionDigest.ToolCalls from
+// results.json, but ToolCallArgs.Extra is json:"-" so custom/MCP arg
+// keys like `query` are dropped. The canonical arg payload survives on
+// tool_events[].args (schema v1.1+), which we thread onto Context so
+// argument matchers still work.
+func TestToolCallsGrader_Expect_ArgsFromToolEventsAfterRoundTrip(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{
+					ID:        "call_1",
+					Name:      "search",
+					Arguments: models.ToolCallArgs{}, // Extra dropped across JSON round-trip.
+				},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{
+				ToolCallID: "call_1",
+				ToolName:   "search",
+				Args:       map[string]any{"query": "find auth bypass"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+// TestToolCallsGrader_Expect_ArgsFromToolEvents_PositionalFallback covers
+// runs where ToolCall.ID is missing on both sides — correlation falls
+// back to positional order, which matches how buildToolEvents and the
+// SessionDigest builder both derive from the same SDK event stream.
+func TestToolCallsGrader_Expect_ArgsFromToolEvents_PositionalFallback(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{ToolName: "search", Args: map[string]any{"query": "find auth bypass"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+// TestToolCallsGrader_Expect_TypedFieldsPrecedenceOverToolEvents guards
+// backwards compatibility: when the typed ToolCallArgs already carries a
+// value, we don't silently swap it for the canonical payload.
+func TestToolCallsGrader_Expect_TypedFieldsPrecedenceOverToolEvents(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "bash",
+			Args: map[string]argmatcher.Matcher{
+				"command": {Kind: argmatcher.KindRegex, Regex: `^ls .*`},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{ID: "call_1", Name: "bash", Arguments: models.ToolCallArgs{Command: "ls -la"}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			// A malicious/replayed events blob shouldn't override the
+			// typed command that came from the live SessionDigest.
+			{ToolCallID: "call_1", ToolName: "bash", Args: map[string]any{"command": "rm -rf /"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}

--- a/internal/graders/tool_constraint_grader.go
+++ b/internal/graders/tool_constraint_grader.go
@@ -108,8 +108,9 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 
 		var failures []string
 
-		failures = append(failures, tc.checkExpectTools(session)...)
-		failures = append(failures, tc.checkRejectTools(session)...)
+		canonicalArgs := toolEventArgsByCall(gradingContext.ToolEvents)
+		failures = append(failures, tc.checkExpectTools(session, canonicalArgs)...)
+		failures = append(failures, tc.checkRejectTools(session, canonicalArgs)...)
 
 		totalChecks := tc.countTotalChecks()
 		passedChecks := totalChecks - len(failures)
@@ -147,7 +148,10 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 
 // matchesToolCall returns true if spec matches the given tool call constraints.
 // NOTE: this function assumes that the regexes have already been validated.
-func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool {
+// canonical, when non-nil, is the JSON-preserved args payload for this
+// call (from tool_events); it is used as a fallback source for arg keys
+// that were stripped from SessionDigest across a results.json round-trip.
+func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall, canonical any) bool {
 	checkPattern := func(pattern, text string) bool {
 		// empty pattern automatically passes - we validate that they have passed at least one check in
 		// validateToolSpecs().
@@ -177,7 +181,7 @@ func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool 
 	}
 
 	if len(spec.Args) > 0 {
-		args, err := normalizeToolCallArgs(call)
+		args, err := normalizeToolCallArgs(call, canonical)
 		if err != nil {
 			return false
 		}
@@ -227,7 +231,7 @@ func describeToolSpecs(specs []models.ToolSpecParameters) []string {
 	return out
 }
 
-func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest, canonicalArgs func(int, models.ToolCall) any) []string {
 	if len(tc.expectTools) == 0 {
 		return nil
 	}
@@ -236,8 +240,8 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 	for _, spec := range tc.expectTools {
 		found := false
 
-		for _, call := range session.ToolCalls {
-			if matchesToolCall(spec, call) {
+		for i, call := range session.ToolCalls {
+			if matchesToolCall(spec, call, canonicalArgs(i, call)) {
 				found = true
 				break
 			}
@@ -250,7 +254,7 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 	return failures
 }
 
-func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest, canonicalArgs func(int, models.ToolCall) any) []string {
 	if len(tc.rejectTools) == 0 {
 		return nil
 	}
@@ -259,8 +263,8 @@ func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) 
 	for _, spec := range tc.rejectTools {
 		found := false
 
-		for _, call := range session.ToolCalls {
-			if matchesToolCall(spec, call) {
+		for i, call := range session.ToolCalls {
+			if matchesToolCall(spec, call, canonicalArgs(i, call)) {
 				found = true
 				break
 			}

--- a/internal/graders/tool_constraint_grader_test.go
+++ b/internal/graders/tool_constraint_grader_test.go
@@ -608,3 +608,74 @@ func TestToolConstraintGrader_ExpectTools_MissingExtraArg(t *testing.T) {
 }
 
 func float64Ptr(v float64) *float64 { return &v }
+
+// TestToolConstraintGrader_ExpectTools_ArgsFromToolEventsAfterRoundTrip
+// reproduces issue #474: after a results.json round-trip the
+// ToolCallArgs.Extra map is dropped (json:"-"), but tool_events[].args
+// preserves the canonical payload. The grader must fall back to
+// ToolEvents on Context so MCP/custom arg keys like `query` remain
+// matchable during offline grading.
+func TestToolConstraintGrader_ExpectTools_ArgsFromToolEventsAfterRoundTrip(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"search"},
+			ToolCalls: []models.ToolCall{
+				{
+					ID:   "call_1",
+					Name: "search",
+					// Simulates offline grading path: Extra was dropped
+					// on JSON round-trip, so ToolCallArgs is bare.
+					Arguments: models.ToolCallArgs{},
+				},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{
+				ToolCallID: "call_1",
+				ToolName:   "search",
+				Args:       map[string]any{"query": "find auth bypass"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+// TestToolConstraintGrader_ExpectTools_ToolEventPositionalFallback covers the
+// case where correlation by ID fails (blank IDs on both sides) and the
+// lookup must fall back to positional order.
+func TestToolConstraintGrader_ExpectTools_ToolEventPositionalFallback(t *testing.T) {
+	g, err := NewToolConstraintGrader("test", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindContains, Contains: "auth"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolsUsed: []string{"search"},
+			ToolCalls: []models.ToolCall{
+				{Name: "search", Arguments: models.ToolCallArgs{}},
+			},
+		},
+		ToolEvents: []models.ToolEvent{
+			{ToolName: "search", Args: map[string]any{"query": "find auth bypass"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -2048,6 +2048,12 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 
 	sessionDigest := r.buildSessionDigest(resp)
 
+	// Preserve canonical, JSON-safe tool-call args so graders that inspect
+	// arguments (tool_calls, tool_constraint) can survive a results.json
+	// round-trip. ToolCallArgs.Extra is intentionally excluded from JSON
+	// so we mirror the same builder used for RunResult.ToolEvents.
+	toolEvents := buildToolEvents(sdkEvents)
+
 	return &graders.Context{
 		TestCase:         tc,
 		Transcript:       transcriptEntries,
@@ -2060,6 +2066,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       toolEvents,
 		Executor:         r.engine,
 	}
 }


### PR DESCRIPTION
Closes #474

## Root cause

The `tool_calls` and `tool_constraint` graders read `expect[].args` from
`SessionDigest.ToolCalls[].Arguments`. `models.ToolCallArgs.Extra` is
tagged `json:"-"` (with `mapstructure:",remain"`), so custom/MCP args
like `query` or `limit` land in `Extra` at runtime but disappear when
`results.json` is written and re-read.

- **Live runs** worked because mapstructure populated `Extra` in-memory.
- **Offline grading** (`waza grade` on `results.json`) received a
  stripped `SessionDigest`, so `expect[].args: { query: ... }` reported
  the arg as "not present on tool call".

Meanwhile, `RunResult.ToolEvents[].Args` (schema v1.1, #366) preserves
the canonical per-call args as `json:"args"` and survives round-trip.

## Fix

Thread canonical args through the graders and use them as a fallback:

- Add `ToolEvents []models.ToolEvent` to `graders.Context`.
- `normalizeToolCallArgs(call, canonical any)` merges canonical args
  from the matching `ToolEvent` for any key not already covered by typed
  fields or `Extra`. Typed fields and `Extra` still win when present,
  preserving live-run behavior.
- `toolEventArgsByCall` correlates by `tool_call_id`, with a positional
  index fallback for cases where the ID is blank on either side (both
  slices are derived from the same SDK event stream in the same order).
- `tool_calls_grader` and `tool_constraint_grader` pass a `canonicalArgs`
  lookup through their expectation loops.
- Populate `ToolEvents` on both paths:
  - Live: `internal/orchestration/runner.go` `buildGraderContext`
  - Offline: `cmd/waza/cmd_grade.go` `gradeRun`

## Backward compatibility

- `ToolCallArgs.Extra` json tag unchanged.
- `ToolEvent` wire schema unchanged.
- `graders.Context` is internal; adding a field is safe.
- Tool-name-only matching (no `args` clause) is untouched.
- When typed fields or `Extra` provide the key, canonical is ignored, so
  live-run behavior is byte-identical to before.

## Tests

Added focused reproductions in `internal/graders`:

- `TestToolCallsGrader_Expect_ArgsFromToolEventsAfterRoundTrip` &mdash;
  reproduces #474: `Extra` stripped, `query` matcher passes via
  `ToolEvents`.
- `TestToolCallsGrader_Expect_ArgsFromToolEvents_PositionalFallback`
  &mdash; blank `tool_call_id`; positional fallback still matches.
- `TestToolCallsGrader_Expect_TypedFieldsPrecedenceOverToolEvents`
  &mdash; typed field wins over a conflicting `ToolEvent` value.
- `TestToolConstraintGrader_ExpectTools_ArgsFromToolEventsAfterRoundTrip`
  and `TestToolConstraintGrader_ExpectTools_ToolEventPositionalFallback`
  &mdash; same for `tool_constraint`.

## Verification

- `go fmt ./...` clean
- `go test ./internal/graders/...` &mdash; PASS
- `go test ./...` &mdash; all packages pass except a flaky, network-
  dependent `internal/version` test unrelated to this change
- `golangci-lint run ./internal/graders/... ./internal/orchestration/... ./cmd/waza/...` &mdash; 0 issues