### PR TITLE
Fix tool_calls arg matching from tool_events

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/cmd/waza/cmd_grade_test.go
+++ b/cmd/waza/cmd_grade_test.go
@@ -648,3 +648,55 @@ graders:
 	require.True(t, ok)
 	require.True(t, passed)
 }
+
+func TestGradeCommand_ToolCallsExpectArgsUsesToolEventsAfterResultsRoundTrip(t *testing.T) {
+	const taskWithToolCallsQuery = `id: task-tool-query
+name: Tool Query Task
+inputs:
+  prompt: "Search for waza"
+graders:
+  - name: search_query
+    type: tool_calls
+    config:
+      expect:
+        - tool: "search"
+          args:
+            query: { equals: "waza" }
+`
+	dir := t.TempDir()
+	specPath := gradeSpec(t, dir, minimalSpec)
+	writeTaskFile(t, dir, "task.yaml", taskWithToolCallsQuery)
+
+	outcome := outcomeWithTasks(models.TestOutcome{
+		TestID: "task-tool-query",
+		Runs: []models.RunResult{{
+			RunNumber:   1,
+			FinalOutput: "searched",
+			DurationMs:  1000,
+			SessionDigest: models.SessionDigest{
+				ToolCallCount: 1,
+				ToolsUsed:     []string{"search"},
+				ToolCalls:     []models.ToolCall{{ID: "call-search", Name: "search"}},
+				SessionID:     "s-1",
+			},
+			ToolEvents: []models.ToolEvent{{
+				ToolCallID: "call-search",
+				ToolName:   "search",
+				Args:       map[string]any{"query": "waza"},
+				Success:    true,
+			}},
+		}},
+	})
+	resultsPath := gradeResultsFile(t, dir, outcome)
+
+	out, err := executeGrade(t, specPath, "--results", resultsPath)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.Equal(t, true, result["passed"])
+
+	tasks := parseMap(t, result, "tasks")
+	task := parseMap(t, tasks, "task-tool-query")
+	require.Equal(t, true, task["passed"])
+}

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,11 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents holds the canonical per-call tool event stream when available.
+	// It preserves arbitrary MCP/custom tool arguments that legacy
+	// SessionDigest.ToolCalls cannot round-trip through results.json.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -47,6 +47,25 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	return out, nil
 }
 
+func normalizeToolEventArgs(event models.ToolEvent) (map[string]any, error) {
+	if event.Args == nil {
+		return map[string]any{}, nil
+	}
+	data, err := json.Marshal(event.Args)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling tool event args: %w", err)
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshaling tool event args: %w", err)
+	}
+	args, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("tool event args for %q are not a JSON object", event.ToolName)
+	}
+	return args, nil
+}
+
 // evaluateArgMatchers returns a slice of human-readable failures describing
 // any matcher in `matchers` whose key was absent from `args` or whose value
 // failed to match. An empty slice means every matcher passed.

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -24,6 +24,13 @@ type compiledExpectation struct {
 	matcher map[string]argmatcher.Matcher
 }
 
+type evaluatedToolCall struct {
+	ID      string
+	Name    string
+	Args    map[string]any
+	ArgsErr error
+}
+
 // NewToolCallsGrader creates a new ToolCallsGrader, returning an error if the
 // parameters are invalid (e.g. no constraints defined, negative bounds, or
 // min > max).
@@ -75,7 +82,8 @@ func (g *ToolCallsGrader) Kind() models.GraderKind { return models.GraderKindToo
 
 func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.GraderResults, error) {
 	return measureTime(func() (*models.GraderResults, error) {
-		if gCtx.Session == nil {
+		calls := toolCallsForGrading(gCtx)
+		if len(calls) == 0 && (gCtx == nil || gCtx.Session == nil) {
 			return &models.GraderResults{
 				Name:     g.name,
 				Passed:   false,
@@ -84,11 +92,11 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 			}, nil
 		}
 
-		calledSet := make(map[string]bool, len(gCtx.Session.ToolCalls))
-		for _, tc := range gCtx.Session.ToolCalls {
+		calledSet := make(map[string]bool, len(calls))
+		for _, tc := range calls {
 			calledSet[tc.Name] = true
 		}
-		totalCalls := len(gCtx.Session.ToolCalls)
+		totalCalls := len(calls)
 
 		var totalChecks, passedChecks int
 		var failures []string
@@ -135,7 +143,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, calls)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -177,10 +185,46 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 	})
 }
 
+func toolCallsForGrading(gCtx *Context) []evaluatedToolCall {
+	if gCtx == nil {
+		return nil
+	}
+	if len(gCtx.ToolEvents) > 0 {
+		calls := make([]evaluatedToolCall, 0, len(gCtx.ToolEvents))
+		for _, event := range gCtx.ToolEvents {
+			if event.ToolName == "" {
+				continue
+			}
+			args, err := normalizeToolEventArgs(event)
+			calls = append(calls, evaluatedToolCall{
+				ID:      event.ToolCallID,
+				Name:    event.ToolName,
+				Args:    args,
+				ArgsErr: err,
+			})
+		}
+		return calls
+	}
+	if gCtx.Session == nil {
+		return nil
+	}
+	calls := make([]evaluatedToolCall, 0, len(gCtx.Session.ToolCalls))
+	for _, call := range gCtx.Session.ToolCalls {
+		args, err := normalizeToolCallArgs(call)
+		calls = append(calls, evaluatedToolCall{
+			ID:      call.ID,
+			Name:    call.Name,
+			Args:    args,
+			ArgsErr: err,
+		})
+	}
+	return calls
+}
+
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+func evaluateExpectation(exp compiledExpectation, calls []evaluatedToolCall) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
@@ -198,12 +242,11 @@ func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool
 			detail["matched_call_id"] = call.ID
 			return true, detail
 		}
-		args, err := normalizeToolCallArgs(call)
-		if err != nil {
-			lastReason = err.Error()
+		if call.ArgsErr != nil {
+			lastReason = call.ArgsErr.Error()
 			continue
 		}
-		failures := evaluateArgMatchers(exp.matcher, args)
+		failures := evaluateArgMatchers(exp.matcher, call.Args)
 		if len(failures) == 0 {
 			detail["matched_call_index"] = i
 			detail["matched_call_id"] = call.ID

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -373,6 +373,52 @@ func TestToolCallsGrader_Expect_NoArgs_Passes(t *testing.T) {
 	require.True(t, res.Passed, "feedback: %s", res.Feedback)
 }
 
+func TestToolCallsGrader_Expect_NoArgs_PassesWithToolEventsOnly(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "search"}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "call-search",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "waza"},
+			Success:    true,
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_UsesToolEventsArgsWhenDigestArgsStale(t *testing.T) {
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "waza"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCallCount: 1,
+			ToolsUsed:     []string{"search"},
+			ToolCalls:     []models.ToolCall{{ID: "call-search", Name: "search"}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "call-search",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "waza"},
+			Success:    true,
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
 func TestToolCallsGrader_Expect_MissingTool_Fails(t *testing.T) {
 	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
 		Expect: []models.ToolExpectation{{Tool: "bash"}, {Tool: "view"}},

--- a/internal/orchestration/checkpoints.go
+++ b/internal/orchestration/checkpoints.go
@@ -79,7 +79,8 @@ func (cr *checkpointRunner) runForTurn(ctx context.Context, turn int, resp *exec
 		return false
 	}
 
-	gCtx := cr.runner.buildGraderContext(cr.tc, resp, copilotevents.ToSDK(resp.Events))
+	sdkEvents := copilotevents.ToSDK(resp.Events)
+	gCtx := cr.runner.buildGraderContext(cr.tc, resp, sdkEvents, buildToolEvents(sdkEvents))
 
 	// Run only the checkpoint's graders. Reuse graders.RunAll by passing a
 	// synthetic TestCase whose Validators field carries the checkpoint

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -1245,9 +1245,10 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 	// event slice in buildGraderContext, buildTranscript, and
 	// buildToolEvents.
 	sdkEvents := copilotevents.ToSDK(resp.Events)
+	toolEvents := buildToolEvents(sdkEvents)
 
 	// Build validation context
-	vCtx := r.buildGraderContext(tc, resp, sdkEvents)
+	vCtx := r.buildGraderContext(tc, resp, sdkEvents, toolEvents)
 
 	var gradersResults map[string]models.GraderResults
 	if r.skipGraders {
@@ -1344,7 +1345,7 @@ func (r *EvalRunner) executeRun(ctx context.Context, tc *models.TestCase, runNum
 		WorkspaceDir:     resp.WorkspaceDir,
 		Responder:        responderInfo,
 		Checkpoints:      checkpointOutcomes,
-		ToolEvents:       buildToolEvents(sdkEvents),
+		ToolEvents:       toolEvents,
 	}
 	r.captureSnapshot(tc, req, resp, &run)
 	return returnWithArtifacts(run)
@@ -2040,7 +2041,7 @@ func convertMCPServers(serverConfigs map[string]any, mocks []models.MCPMockConfi
 	})
 }
 
-func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse, sdkEvents []copilot.SessionEvent) *graders.Context {
+func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.ExecutionResponse, sdkEvents []copilot.SessionEvent, toolEvents []models.ToolEvent) *graders.Context {
 	// Reuse the shared transcript builder so the conversion is preallocated
 	// (entries := make([]TranscriptEvent, 0, len(events))) and produced in a
 	// single place.
@@ -2060,6 +2061,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       toolEvents,
 		Executor:         r.engine,
 	}
 }

--- a/internal/orchestration/runner_orchestration_test.go
+++ b/internal/orchestration/runner_orchestration_test.go
@@ -392,7 +392,8 @@ func TestBuildGraderContextAndScoreHelpers(t *testing.T) {
 		}),
 	}
 
-	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp, copilotevents.ToSDK(resp.Events))
+	sdkEvents := copilotevents.ToSDK(resp.Events)
+	graderCtx := runner.buildGraderContext(&models.TestCase{TestID: "tc"}, resp, sdkEvents, buildToolEvents(sdkEvents))
 	require.Len(t, graderCtx.Transcript, 1)
 	assert.Equal(t, "final output", graderCtx.Output)
 	assert.Equal(t, int64(42), graderCtx.DurationMS)


### PR DESCRIPTION
Closes #474

## Summary
- Add canonical `tool_events` to grader contexts for live runs, checkpoints, and `waza grade` offline regrading.
- Make `tool_calls.expect[].args` prefer `tool_events[].args` when available, falling back to legacy `session_digest.tool_calls[].arguments` for older results.
- Add focused regressions for MCP/custom `query` arg expectations after a results.json round-trip and for tool-name-only matching from tool events.

## Validation
- `go test ./internal/graders ./cmd/waza -run 'TestToolCallsGrader_Expect|TestGradeCommand_ToolCallsExpectArgsUsesToolEventsAfterResultsRoundTrip'`
- `go test ./...`
- `golangci-lint run`