### PR TITLE
fix(graders): read tool_calls expect[].args from tool_events (#474)

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,16 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents is the canonical, JSON-stable record of tool invocations for
+	// this run. Unlike Session.ToolCalls (whose ToolCallArgs.Extra is tagged
+	// json:"-" and is therefore lost across a results.json round-trip),
+	// ToolEvent.Args is preserved verbatim, so it is the authoritative source
+	// for MCP and other engine-specific tool arguments (e.g. `query`,
+	// `limit`). Graders that match on tool arguments should prefer this over
+	// Session.ToolCalls[].Arguments when both are available. Populated in
+	// both the live execution path and the offline `waza grade` path.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -47,6 +47,95 @@ func normalizeToolCallArgs(call models.ToolCall) (map[string]any, error) {
 	return out, nil
 }
 
+// toolEventArgsByCallID indexes ToolEvent.Args by ToolCallID for O(1) lookup
+// from a graders.Context. Only entries whose Args deserialise to a JSON
+// object are included; scalar or nil args are skipped because argument
+// matchers key on named fields. Duplicate IDs are resolved by keeping the
+// first entry (start events precede complete events; both carry the same
+// arg payload after buildToolEvents normalisation).
+func toolEventArgsByCallID(events []models.ToolEvent) map[string]map[string]any {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]any, len(events))
+	for _, ev := range events {
+		if ev.ToolCallID == "" {
+			continue
+		}
+		if _, exists := out[ev.ToolCallID]; exists {
+			continue
+		}
+		m, ok := coerceArgsToMap(ev.Args)
+		if !ok {
+			continue
+		}
+		out[ev.ToolCallID] = m
+	}
+	return out
+}
+
+// coerceArgsToMap best-effort converts a ToolEvent.Args value (which is
+// `any` and may arrive as map[string]any from a JSON round-trip, or as a
+// typed struct from a live in-memory build) into a map[string]any. Returns
+// false when the payload isn't object-shaped.
+func coerceArgsToMap(args any) (map[string]any, bool) {
+	if args == nil {
+		return nil, false
+	}
+	if m, ok := args.(map[string]any); ok {
+		return m, true
+	}
+	// Fall back to a JSON round-trip so typed structs (or map[string]string
+	// etc.) also normalise to a plain map. This mirrors how buildToolEvents
+	// canonicalises args, but is defensive for future callers.
+	data, err := json.Marshal(args)
+	if err != nil {
+		return nil, false
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// normalizeToolCallArgsWithEvents returns the tool call's arguments as a
+// map[string]any, preferring keys from a matching ToolEvent (looked up by
+// call.ID in eventArgs) over the typed ToolCallArgs. This is the offline-
+// safe path: ToolCallArgs.Extra is `json:"-"` and is dropped when a
+// results.json is written and reloaded for `waza grade`, whereas
+// ToolEvent.Args is JSON-preserving. When no matching event exists, this
+// falls back to normalizeToolCallArgs (the live-run behavior).
+//
+// Behavior on collision: the typed ToolCallArgs values win over
+// ToolEvent.Args, matching normalizeToolCallArgs's original semantics
+// (typed known fields > Extra). ToolEvent keys only fill entries missing
+// from the typed base — restoring MCP args like `query` that would
+// otherwise be absent after a round-trip.
+func normalizeToolCallArgsWithEvents(call models.ToolCall, eventArgs map[string]map[string]any) (map[string]any, error) {
+	base, err := normalizeToolCallArgs(call)
+	if err != nil {
+		return nil, err
+	}
+	if len(eventArgs) == 0 || call.ID == "" {
+		return base, nil
+	}
+	evArgs, ok := eventArgs[call.ID]
+	if !ok || len(evArgs) == 0 {
+		return base, nil
+	}
+	for k, v := range evArgs {
+		if _, present := base[k]; present {
+			continue
+		}
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		base[k] = v
+	}
+	return base, nil
+}
+
 // evaluateArgMatchers returns a slice of human-readable failures describing
 // any matcher in `matchers` whose key was absent from `args` or whose value
 // failed to match. An empty slice means every matcher passed.

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -132,10 +132,15 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		// Per-expectation checks: each expectation contributes one check;
 		// it passes when at least one recorded tool call matches the tool
 		// name regex AND all configured arg matchers pass on that call.
+		//
+		// Prefer per-call args from ToolEvents (canonical, JSON-stable)
+		// over Session.ToolCalls[].Arguments.Extra, which is dropped on
+		// results.json round-trip (issue #474).
+		eventArgs := toolEventArgsByCallID(gCtx.ToolEvents)
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls, eventArgs)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -180,7 +185,14 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+//
+// eventArgs is an optional lookup keyed by ToolCall.ID that provides
+// canonical, JSON-stable arguments captured from ToolEvents. When present,
+// its entries are preferred over Session.ToolCalls[].Arguments.Extra so
+// arg matching works after a results.json round-trip (issue #474). Pass
+// nil (or an empty map) to fall back to the original ToolCallArgs-only
+// behavior, which is what live in-memory grading has always done.
+func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall, eventArgs map[string]map[string]any) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
@@ -198,7 +210,7 @@ func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool
 			detail["matched_call_id"] = call.ID
 			return true, detail
 		}
-		args, err := normalizeToolCallArgs(call)
+		args, err := normalizeToolCallArgsWithEvents(call, eventArgs)
 		if err != nil {
 			lastReason = err.Error()
 			continue

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -2,6 +2,7 @@ package graders
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/microsoft/waza/internal/graders/argmatcher"
@@ -528,4 +529,127 @@ func TestToolCallsGrader_Expect_InvalidMatcher_ConstructError(t *testing.T) {
 		}},
 	})
 	require.Error(t, err)
+}
+
+// --- Regression tests for #474 -------------------------------------------------
+//
+// ToolCallArgs.Extra uses `json:"-"`, so MCP/custom tool args (e.g. `query`)
+// are dropped when a RunResult is round-tripped through results.json. The
+// tool_calls grader must therefore fall back to the canonical args carried
+// by RunResult.ToolEvents when offline-grading a persisted results file.
+//
+// These tests exercise the paths described in issue #474:
+//   1. Round-tripped results.json — Extra is gone, ToolEvents rescues match.
+//   2. Live in-memory results — behavior unchanged when ToolEvents is empty.
+//   3. Tool-name-only expectations — still pass without any args plumbing.
+
+func TestToolCallsGrader_Expect_ArgsFromToolEventsAfterRoundTrip(t *testing.T) {
+	// Simulate a live RunResult where the MCP `search` tool was called with
+	// {query: "foo"} — captured in both the digest's ToolCallArgs.Extra and
+	// the canonical ToolEvents slice.
+	live := models.RunResult{
+		SessionDigest: models.SessionDigest{
+			ToolCalls: []models.ToolCall{{
+				ID:   "c1",
+				Name: "search",
+				Arguments: models.ToolCallArgs{
+					Extra: map[string]any{"query": "foo"},
+				},
+			}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "c1",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "foo"},
+		}},
+	}
+
+	// Round-trip through JSON — this is what `waza grade` does when loading
+	// a results.json off disk. Extra has `json:"-"` and is dropped.
+	data, err := json.Marshal(&live)
+	require.NoError(t, err)
+	var decoded models.RunResult
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Empty(t, decoded.SessionDigest.ToolCalls[0].Arguments.Extra,
+		"sanity check: Extra should be dropped across json round-trip")
+	require.NotEmpty(t, decoded.ToolEvents[0].Args,
+		"sanity check: ToolEvents.Args should survive the round-trip")
+
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "foo"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session:    &decoded.SessionDigest,
+		ToolEvents: decoded.ToolEvents,
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed,
+		"expectation on `query` should match via ToolEvents fallback; feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_LivePath_UnchangedWhenNoToolEvents(t *testing.T) {
+	// Live run path: Extra is populated in memory, ToolEvents intentionally
+	// left empty. This is the pre-#474 behavior and must keep passing so
+	// engines that don't emit ToolEvents (or older callers of Context) are
+	// unaffected.
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "foo"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{
+				Name: "search",
+				Arguments: models.ToolCallArgs{
+					Extra: map[string]any{"query": "foo"},
+				},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ToolNameOnly_MatchesAfterRoundTrip(t *testing.T) {
+	// Tool-name-only expectations must remain trivially satisfied — the
+	// ToolEvents overlay code path should never be consulted for them.
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "search"}},
+	})
+	require.NoError(t, err)
+
+	live := models.RunResult{
+		SessionDigest: models.SessionDigest{
+			ToolCalls: []models.ToolCall{{ID: "c1", Name: "search"}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "c1",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "foo"},
+		}},
+	}
+	data, err := json.Marshal(&live)
+	require.NoError(t, err)
+	var decoded models.RunResult
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session:    &decoded.SessionDigest,
+		ToolEvents: decoded.ToolEvents,
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
 }

--- a/internal/graders/tool_constraint_grader.go
+++ b/internal/graders/tool_constraint_grader.go
@@ -108,8 +108,10 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 
 		var failures []string
 
-		failures = append(failures, tc.checkExpectTools(session)...)
-		failures = append(failures, tc.checkRejectTools(session)...)
+		eventArgs := toolEventArgsByCallID(gradingContext.ToolEvents)
+
+		failures = append(failures, tc.checkExpectTools(session, eventArgs)...)
+		failures = append(failures, tc.checkRejectTools(session, eventArgs)...)
 
 		totalChecks := tc.countTotalChecks()
 		passedChecks := totalChecks - len(failures)
@@ -147,7 +149,13 @@ func (tc *toolConstraintGrader) Grade(ctx context.Context, gradingContext *Conte
 
 // matchesToolCall returns true if spec matches the given tool call constraints.
 // NOTE: this function assumes that the regexes have already been validated.
-func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool {
+//
+// eventArgs is an optional lookup keyed by ToolCall.ID that provides
+// canonical, JSON-stable arguments captured from ToolEvents. When present,
+// its entries are preferred over ToolCallArgs.Extra so arg matching works
+// after a results.json round-trip (issue #474). Pass nil for the original
+// live-run behavior.
+func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall, eventArgs map[string]map[string]any) bool {
 	checkPattern := func(pattern, text string) bool {
 		// empty pattern automatically passes - we validate that they have passed at least one check in
 		// validateToolSpecs().
@@ -177,7 +185,7 @@ func matchesToolCall(spec models.ToolSpecParameters, call models.ToolCall) bool 
 	}
 
 	if len(spec.Args) > 0 {
-		args, err := normalizeToolCallArgs(call)
+		args, err := normalizeToolCallArgsWithEvents(call, eventArgs)
 		if err != nil {
 			return false
 		}
@@ -227,7 +235,7 @@ func describeToolSpecs(specs []models.ToolSpecParameters) []string {
 	return out
 }
 
-func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest, eventArgs map[string]map[string]any) []string {
 	if len(tc.expectTools) == 0 {
 		return nil
 	}
@@ -237,7 +245,7 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 		found := false
 
 		for _, call := range session.ToolCalls {
-			if matchesToolCall(spec, call) {
+			if matchesToolCall(spec, call, eventArgs) {
 				found = true
 				break
 			}
@@ -250,7 +258,7 @@ func (tc *toolConstraintGrader) checkExpectTools(session *models.SessionDigest) 
 	return failures
 }
 
-func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) []string {
+func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest, eventArgs map[string]map[string]any) []string {
 	if len(tc.rejectTools) == 0 {
 		return nil
 	}
@@ -260,7 +268,7 @@ func (tc *toolConstraintGrader) checkRejectTools(session *models.SessionDigest) 
 		found := false
 
 		for _, call := range session.ToolCalls {
-			if matchesToolCall(spec, call) {
+			if matchesToolCall(spec, call, eventArgs) {
 				found = true
 				break
 			}

--- a/internal/graders/tool_constraint_grader_test.go
+++ b/internal/graders/tool_constraint_grader_test.go
@@ -2,6 +2,7 @@ package graders
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -608,3 +609,51 @@ func TestToolConstraintGrader_ExpectTools_MissingExtraArg(t *testing.T) {
 }
 
 func float64Ptr(v float64) *float64 { return &v }
+
+// TestToolConstraintGrader_ExpectTools_ArgsFromToolEventsAfterRoundTrip is
+// the tool_constraint mirror of the tool_calls #474 regression test.
+// tool_constraint's expect_tools[].args matcher walks the same
+// SessionDigest.ToolCalls slice and therefore loses MCP arg keys (Extra is
+// json:"-") when a results.json is loaded off disk. It must consult
+// RunResult.ToolEvents via the graders.Context so offline grading behaves
+// like the live in-memory path.
+func TestToolConstraintGrader_ExpectTools_ArgsFromToolEventsAfterRoundTrip(t *testing.T) {
+	live := models.RunResult{
+		SessionDigest: models.SessionDigest{
+			ToolCalls: []models.ToolCall{{
+				ID:   "c1",
+				Name: "search",
+				Arguments: models.ToolCallArgs{
+					Extra: map[string]any{"query": "foo"},
+				},
+			}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			ToolCallID: "c1",
+			ToolName:   "search",
+			Args:       map[string]any{"query": "foo"},
+		}},
+	}
+	data, err := json.Marshal(&live)
+	require.NoError(t, err)
+	var decoded models.RunResult
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Empty(t, decoded.SessionDigest.ToolCalls[0].Arguments.Extra)
+
+	g, err := NewToolConstraintGrader("tc", models.ToolConstraintGraderParameters{
+		ExpectTools: []models.ToolSpecParameters{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "foo"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session:    &decoded.SessionDigest,
+		ToolEvents: decoded.ToolEvents,
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -2047,6 +2047,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 	transcriptEntries := transcript.BuildFromSessionEvents(sdkEvents)
 
 	sessionDigest := r.buildSessionDigest(resp)
+	toolEvents := buildToolEvents(sdkEvents)
 
 	return &graders.Context{
 		TestCase:         tc,
@@ -2060,6 +2061,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       toolEvents,
 		Executor:         r.engine,
 	}
 }


### PR DESCRIPTION
Closes #474

## Root cause

The `tool_calls` (and `tool_constraint`) grader's `expect[].args` matching reads arguments from `SessionDigest.ToolCalls[].Args`. `ToolCallArgs.Extra` is tagged `json:"-"` (with `mapstructure:",remain"`), so MCP / custom tool arguments (e.g. `query`) live in memory during a live run but are dropped when results are round-tripped through `results.json`. Offline grading via `waza grade` then reports `argument "query": not present on tool call`, even though the args were actually captured.

`RunResult.ToolEvents[].Args` (built by `internal/orchestration/tool_events.go::buildToolEvents` via a JSON marshal/unmarshal) preserves the canonical argument JSON in both live and offline paths, and events are correlated to tool calls by `ToolCallID`.

## Fix

- Add `ToolEvents []models.ToolEvent` to `graders.Context`.
- Populate it at both construction sites: `internal/orchestration/runner.go::buildGraderContext` (live) and `cmd/waza/cmd_grade.go::gradeRun` (offline).
- New helpers in `internal/graders/tool_args.go`:
  - `toolEventArgsByCallID` — build `map[callID]map[string]any` from ToolEvents.
  - `coerceArgsToMap` — handle `map[string]any` and typed structs (JSON round-trip fallback).
  - `normalizeToolCallArgsWithEvents` — start from the base normalized args and fill in *missing* keys from the matching ToolEvent. Typed `ToolCallArgs` values always win over event args; empty-string overrides are skipped.
- Both `tool_calls_grader.go` and `tool_constraint_grader.go` thread `eventArgs` through their expectation/reject matching paths and use the new helper.

## Backward compatibility

- `results.json` schema is unchanged.
- `ToolCallArgs.Extra json:"-"` is preserved.
- Tool-name-only matching (no `args`) is untouched.
- When `Context.ToolEvents` is empty (older callers or no events), behavior is byte-identical to the pre-#474 code path.

## Tests

Added focused regression tests:

- `internal/graders/tool_calls_grader_test.go`
  - `TestToolCallsGrader_Expect_ArgsFromToolEventsAfterRoundTrip` — reproduces the failing `query` expectation after JSON round-trip; passes with the fix.
  - `TestToolCallsGrader_Expect_LivePath_UnchangedWhenNoToolEvents` — asserts pre-#474 behavior when `ToolEvents` is empty.
  - `TestToolCallsGrader_Expect_ToolNameOnly_MatchesAfterRoundTrip` — tool-name-only match still works.
- `internal/graders/tool_constraint_grader_test.go`
  - `TestToolConstraintGrader_ExpectTools_ArgsFromToolEventsAfterRoundTrip` — mirror for the constraint grader.

## Validation

- `go build ./...` — clean.
- `go test ./...` — all packages pass.
- `golangci-lint run` — 0 issues.