### PR TITLE
fix(graders): tool_calls reads args from tool_events for round-trip reliability

### DIFF
--- a/cmd/waza/cmd_grade.go
+++ b/cmd/waza/cmd_grade.go
@@ -267,6 +267,7 @@ func gradeRun(ctx context.Context, spec *models.EvalSpec, tc *models.TestCase, r
 		Output:           run.FinalOutput,
 		Transcript:       run.Transcript,
 		Session:          &run.SessionDigest,
+		ToolEvents:       run.ToolEvents,
 		DurationMS:       run.DurationMs,
 		SessionID:        run.SessionDigest.SessionID,
 		WorkspaceDir:     workspace,

--- a/internal/graders/grader.go
+++ b/internal/graders/grader.go
@@ -50,6 +50,17 @@ type Context struct {
 	// Used by the behavior grader to validate agent behavior constraints.
 	Session *models.SessionDigest
 
+	// ToolEvents is the canonical, replay-safe record of tool calls emitted
+	// during the run (schema 1.1+). Its Args field preserves the full raw
+	// argument payload — including MCP/custom tool arguments — across
+	// results.json round-trips, which SessionDigest.ToolCalls does not
+	// (ToolCallArgs.Extra is json:"-" and drops after unmarshal). When
+	// non-empty, graders that inspect tool arguments should prefer this
+	// over Session.ToolCalls; when nil/empty they must fall back to
+	// Session.ToolCalls for backward compatibility with pre-1.1 records
+	// and engines that don't emit tool events.
+	ToolEvents []models.ToolEvent
+
 	// SkillInvocations is a chronological list of skills invoked during the session.
 	// Used by the skill_invocation grader to verify orchestration workflows.
 	SkillInvocations []execution.SkillInvocation

--- a/internal/graders/tool_args.go
+++ b/internal/graders/tool_args.go
@@ -9,7 +9,94 @@ import (
 	"github.com/microsoft/waza/internal/models"
 )
 
-// normalizeToolCallArgs returns the tool call's arguments as a generic
+// normalizedCall is a per-call view used by the tool_calls grader that
+// unifies the two possible sources of arguments (canonical ToolEvents vs.
+// legacy SessionDigest.ToolCalls). Args is the fully normalized argument
+// bag suitable for argmatchers; ArgsErr is set only when normalization
+// of the source data failed and no args map could be produced.
+type normalizedCall struct {
+	Name    string
+	ID      string
+	Args    map[string]any
+	ArgsErr error
+}
+
+// buildNormalizedCalls returns the list of tool calls the grader should
+// consider, preferring the canonical tool_events record when present.
+//
+// tool_events (schema 1.1+) is the source of truth: its Args is a raw
+// JSON value that preserves MCP/custom tool arguments across
+// results.json round-trips. SessionDigest.ToolCalls does not — its
+// ToolCallArgs.Extra field is json:"-" and drops after unmarshal —
+// so we only fall back to it when tool_events is empty (pre-1.1
+// records, or engines that don't emit tool events).
+func buildNormalizedCalls(gCtx *Context) []normalizedCall {
+	if gCtx == nil {
+		return nil
+	}
+
+	if len(gCtx.ToolEvents) > 0 {
+		out := make([]normalizedCall, 0, len(gCtx.ToolEvents))
+		for _, ev := range gCtx.ToolEvents {
+			args, err := coerceEventArgs(ev.Args)
+			out = append(out, normalizedCall{
+				Name:    ev.ToolName,
+				ID:      ev.ToolCallID,
+				Args:    args,
+				ArgsErr: err,
+			})
+		}
+		return out
+	}
+
+	if gCtx.Session == nil {
+		return nil
+	}
+	out := make([]normalizedCall, 0, len(gCtx.Session.ToolCalls))
+	for _, call := range gCtx.Session.ToolCalls {
+		args, err := normalizeToolCallArgs(call)
+		out = append(out, normalizedCall{
+			Name:    call.Name,
+			ID:      call.ID,
+			Args:    args,
+			ArgsErr: err,
+		})
+	}
+	return out
+}
+
+// coerceEventArgs converts the raw ToolEvent.Args value into a
+// map[string]any suitable for argmatchers. It accepts either a
+// map[string]any directly, or a JSON-marshalable value that
+// unmarshals into an object; scalar / array payloads return nil map
+// with no error (matchers on named keys will simply report "not
+// present"). A nil input yields an empty map.
+func coerceEventArgs(v any) (map[string]any, error) {
+	if v == nil {
+		return map[string]any{}, nil
+	}
+	if m, ok := v.(map[string]any); ok {
+		return m, nil
+	}
+	// Round-trip through JSON so any concrete type (struct, map with
+	// non-string keys, etc.) that marshals to a JSON object is still
+	// usable by matchers. Non-object payloads (arrays, scalars, null)
+	// intentionally return an empty map so key-based matchers cleanly
+	// report "not present" instead of erroring out.
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling tool_event args: %w", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return map[string]any{}, nil
+	}
+	if out == nil {
+		return map[string]any{}, nil
+	}
+	return out, nil
+}
+
 // map[string]any suitable for argument matchers. Known fields recognized by
 // ToolCallArgs (path, file_text, command, description, skill) are merged with
 // any engine-specific extras captured under ToolCallArgs.Extra (populated by

--- a/internal/graders/tool_calls_grader.go
+++ b/internal/graders/tool_calls_grader.go
@@ -75,7 +75,7 @@ func (g *ToolCallsGrader) Kind() models.GraderKind { return models.GraderKindToo
 
 func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.GraderResults, error) {
 	return measureTime(func() (*models.GraderResults, error) {
-		if gCtx.Session == nil {
+		if gCtx.Session == nil && len(gCtx.ToolEvents) == 0 {
 			return &models.GraderResults{
 				Name:     g.name,
 				Passed:   false,
@@ -84,11 +84,18 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 			}, nil
 		}
 
-		calledSet := make(map[string]bool, len(gCtx.Session.ToolCalls))
-		for _, tc := range gCtx.Session.ToolCalls {
-			calledSet[tc.Name] = true
+		// Prefer the canonical tool_events record (schema 1.1+) whose
+		// Args survives results.json round-trips. Fall back to the
+		// SessionDigest.ToolCalls path for pre-1.1 records or engines
+		// that don't emit tool_events. See graders.Context.ToolEvents
+		// for background (issue #474).
+		calls := buildNormalizedCalls(gCtx)
+
+		calledSet := make(map[string]bool, len(calls))
+		for _, nc := range calls {
+			calledSet[nc.Name] = true
 		}
-		totalCalls := len(gCtx.Session.ToolCalls)
+		totalCalls := len(calls)
 
 		var totalChecks, passedChecks int
 		var failures []string
@@ -135,7 +142,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 		expectResults := make([]map[string]any, 0, len(g.compiledExpect))
 		for _, exp := range g.compiledExpect {
 			totalChecks++
-			matched, detail := evaluateExpectation(exp, gCtx.Session.ToolCalls)
+			matched, detail := evaluateExpectation(exp, calls)
 			expectResults = append(expectResults, detail)
 			if matched {
 				passedChecks++
@@ -180,7 +187,7 @@ func (g *ToolCallsGrader) Grade(_ context.Context, gCtx *Context) (*models.Grade
 // evaluateExpectation returns whether any of the calls satisfies the
 // expectation, and a structured detail record describing the best-effort
 // reason on failure (or the index of the satisfying call on success).
-func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool, map[string]any) {
+func evaluateExpectation(exp compiledExpectation, calls []normalizedCall) (bool, map[string]any) {
 	detail := map[string]any{"tool": exp.raw.Tool}
 	if len(exp.matcher) > 0 {
 		detail["args"] = exp.raw.Args
@@ -198,12 +205,11 @@ func evaluateExpectation(exp compiledExpectation, calls []models.ToolCall) (bool
 			detail["matched_call_id"] = call.ID
 			return true, detail
 		}
-		args, err := normalizeToolCallArgs(call)
-		if err != nil {
-			lastReason = err.Error()
+		if call.ArgsErr != nil {
+			lastReason = call.ArgsErr.Error()
 			continue
 		}
-		failures := evaluateArgMatchers(exp.matcher, args)
+		failures := evaluateArgMatchers(exp.matcher, call.Args)
 		if len(failures) == 0 {
 			detail["matched_call_index"] = i
 			detail["matched_call_id"] = call.ID

--- a/internal/graders/tool_calls_grader_test.go
+++ b/internal/graders/tool_calls_grader_test.go
@@ -2,6 +2,7 @@ package graders
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/microsoft/waza/internal/graders/argmatcher"
@@ -528,4 +529,140 @@ func TestToolCallsGrader_Expect_InvalidMatcher_ConstructError(t *testing.T) {
 		}},
 	})
 	require.Error(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// Regression tests for issue #474.
+//
+// When a run is graded offline (waza grade run.json), SessionDigest.ToolCalls
+// loses MCP/custom arguments because ToolCallArgs.Extra is json:"-". The grader
+// must instead consume gCtx.ToolEvents (schema 1.1+) whose Args survives the
+// JSON round-trip. These tests assert:
+//   - args expectations match against ToolEvents even when SessionDigest.ToolCalls
+//     is empty or has a stripped Extra map (offline / round-trip case).
+//   - tool-name-only expectations still match via ToolEvents.
+//   - The legacy fallback still works when only SessionDigest is available.
+//   - A JSON round-trip of RunResult.ToolEvents preserves matching.
+// -----------------------------------------------------------------------------
+
+func TestToolCallsGrader_Expect_ArgsFromToolEvents_SurvivesRoundTrip(t *testing.T) {
+	// Simulates an offline grade of results.json where SessionDigest has been
+	// stripped of Extra but tool_events still carries the canonical `query`
+	// argument for an MCP tool call.
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "Bissell"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		// Digest present but with no arg detail — mirrors what remains after a
+		// results.json round-trip strips ToolCallArgs.Extra.
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{{Name: "search"}},
+		},
+		ToolEvents: []models.ToolEvent{{
+			ToolName:   "search",
+			ToolCallID: "call_1",
+			Args:       map[string]any{"query": "Bissell"},
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ToolNameOnly_FromToolEvents(t *testing.T) {
+	// Tool-name-only expectations must still work when we're driven off
+	// tool_events with no SessionDigest at all.
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{Tool: "search"}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		ToolEvents: []models.ToolEvent{{
+			ToolName:   "search",
+			ToolCallID: "call_1",
+			Args:       map[string]any{"query": "anything"},
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_RequiredTools_FromToolEvents(t *testing.T) {
+	// required_tools should be satisfied by tool_events without a session digest.
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		RequiredTools: []string{"search"},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		ToolEvents: []models.ToolEvent{{ToolName: "search", ToolCallID: "call_1"}},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_LegacyFallback_UsesSessionDigest(t *testing.T) {
+	// When ToolEvents is absent (pre-1.1 record, or engine that doesn't emit
+	// tool_events), the grader must still fall back to SessionDigest.ToolCalls
+	// so existing evals keep working.
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "view",
+			Args: map[string]argmatcher.Matcher{
+				"path": {Kind: argmatcher.KindEquals, Equals: "/etc/hosts"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{
+		Session: &models.SessionDigest{
+			ToolCalls: []models.ToolCall{
+				{Name: "view", Arguments: models.ToolCallArgs{Path: "/etc/hosts"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
+}
+
+func TestToolCallsGrader_Expect_ArgsFromToolEvents_JSONRoundTrip(t *testing.T) {
+	// End-to-end: build a RunResult.ToolEvents slice, JSON-encode and decode
+	// it (as `waza grade` would when loading results.json), then verify the
+	// arg matcher still fires. This is the exact scenario in issue #474.
+	src := []models.ToolEvent{{
+		Sequence:   1,
+		Turn:       1,
+		ToolCallID: "call_abc",
+		ToolName:   "search",
+		Args:       map[string]any{"query": "Bissell"},
+		Success:    true,
+	}}
+
+	raw, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	var round []models.ToolEvent
+	require.NoError(t, json.Unmarshal(raw, &round))
+
+	g, err := NewToolCallsGrader("tc", models.ToolCallsGraderParameters{
+		Expect: []models.ToolExpectation{{
+			Tool: "search",
+			Args: map[string]argmatcher.Matcher{
+				"query": {Kind: argmatcher.KindEquals, Equals: "Bissell"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	res, err := g.Grade(context.Background(), &Context{ToolEvents: round})
+	require.NoError(t, err)
+	require.True(t, res.Passed, "feedback: %s", res.Feedback)
 }

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -2047,6 +2047,12 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 	transcriptEntries := transcript.BuildFromSessionEvents(sdkEvents)
 
 	sessionDigest := r.buildSessionDigest(resp)
+	// Canonical tool call record. Grader consumers (notably tool_calls)
+	// prefer this over sessionDigest.ToolCalls because ToolEvent.Args
+	// preserves the raw MCP/custom argument payload across
+	// results.json round-trips. See internal/graders/grader.go for
+	// details.
+	toolEvents := buildToolEvents(sdkEvents)
 
 	return &graders.Context{
 		TestCase:         tc,
@@ -2060,6 +2066,7 @@ func (r *EvalRunner) buildGraderContext(tc *models.TestCase, resp *execution.Exe
 		SkillInvocations: resp.SkillInvocations,
 		SessionID:        resp.SessionID,
 		Session:          &sessionDigest,
+		ToolEvents:       toolEvents,
 		Executor:         r.engine,
 	}
 }


### PR DESCRIPTION
Closes #474

## Problem

The `tool_calls` grader evaluated `expect[].args` against
`SessionDigest.ToolCalls[].Arguments`. That struct's `ToolCallArgs.Extra`
field is tagged `json:"-"`, so any MCP / custom tool argument that lands
there is dropped when a run is round-tripped through `results.json`.

Concretely, an `expect` block like:

```yaml
- tool: search
  args:
    query:
      equals: "Bissell"
```

would silently fail during offline grading (`waza grade results.json`)
because the digest that reaches the grader no longer contains `query`,
even though `tool_events[].args` in the same file still has it.

## Fix

Prefer the canonical `RunResult.ToolEvents` (schema 1.1+) as the source
of tool arguments. Its `Args any` field survives JSON round-trip. Fall
back to `SessionDigest.ToolCalls` so pre-1.1 records and engines that
don't emit `tool_events` keep working.

- Add `graders.Context.ToolEvents` and populate it from both the live
  runner (`internal/orchestration/runner.go`) and the offline `waza
  grade` path (`cmd/waza/cmd_grade.go`) so both call sites feed the
  grader the same canonical arguments.
- Introduce `normalizedCall` + `buildNormalizedCalls` in
  `internal/graders/tool_args.go` so `evaluateExpectation` works from
  either input transparently.
- Tool-name-only expectations and `required_tools` still resolve
  against either source.

## Tests

Added five regression tests in `internal/graders/tool_calls_grader_test.go`:

- `Expect_ArgsFromToolEvents_SurvivesRoundTrip` — reproduces #474: the
  `query: "Bissell"` expectation fails against a stripped digest and
  passes against `tool_events`.
- `Expect_ToolNameOnly_FromToolEvents` — name-only expectations still
  work when driven purely from `tool_events`.
- `RequiredTools_FromToolEvents` — `required_tools` satisfied by
  `tool_events` alone.
- `Expect_LegacyFallback_UsesSessionDigest` — pre-1.1 records with only
  a digest still grade correctly.
- `Expect_ArgsFromToolEvents_JSONRoundTrip` — end-to-end: marshal /
  unmarshal `[]ToolEvent` and confirm the matcher still fires (exact
  #474 scenario).

## Backward compatibility

- Results-schema and tool contracts are unchanged (no changes to
  `ToolCall`, `ToolCallArgs`, or `ToolEvent`).
- Runs without `tool_events` (older schema, or engines that don't emit
  them) continue to grade against `SessionDigest.ToolCalls`.
- Tool-name-only matching and `required_tools` behavior are preserved.

## Verify

```
go test ./internal/graders/... -run ToolCallsGrader -count=1
golangci-lint run ./internal/graders/... ./internal/orchestration/... ./cmd/waza/...
```

Both pass locally.