### PR TITLE
feat: add registry CLI search and add

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ waza check skills/my-skill
 waza suggest skills/my-skill --dry-run
 waza suggest skills/my-skill --apply
 
+# Discover shared registry graders and add one to an eval
+waza registry search factual --kind grader
+waza registry add github.com/waza-evals/fact#factuality@v1.0.0 --eval eval.yaml --name factuality
+
 # Verify eval coverage against SKILL.md requirements
 waza spec verify skills/my-skill evals/my-skill/eval.yaml
 waza spec verify skills/my-skill evals/my-skill/eval.yaml --fail --format github-actions
@@ -569,6 +573,27 @@ Clear all cached evaluation results to force re-execution on the next run.
 | Flag | Description |
 |------|-------------|
 | `--cache-dir <dir>` | Cache directory to clear (default: `.waza-cache`) |
+
+### `waza registry search <query>`
+
+Search configured registry indexes for reusable graders, eval bundles, and datasets. The default public registry source is `https://github.com/waza-evals`; project-level `.waza.yaml` can override sources with a top-level `registries:` list.
+
+| Flag | Description |
+|------|-------------|
+| `--kind <kind>` | Filter by `grader`, `eval`, or `dataset` |
+| `--registry <name>` | Search only the named registry source |
+| `--format <format>` | Output `table` or `json` (default: `table`) |
+
+### `waza registry add <ref>`
+
+Append a remote grader preset reference to `eval.yaml` and update `waza.lock`. Full resolver-backed expansion depends on the shared resolver from issue #15; the Phase 1 command writes minimal `ref:` entries.
+
+| Flag | Description |
+|------|-------------|
+| `--eval <path>` | Eval file to update (default: `eval.yaml`) |
+| `--name <alias>` | Local alias for the grader |
+| `--set key=value` | Add a local override, repeatable (for example, `--set config.threshold=0.9`) |
+| `--allow-exec` | Allow remote program graders without interactive confirmation |
 
 ### `waza dev [skill-path]`
 

--- a/README.md
+++ b/README.md
@@ -578,6 +578,8 @@ Clear all cached evaluation results to force re-execution on the next run.
 
 Search configured registry indexes for reusable graders, eval bundles, and datasets. The default public registry source is `https://github.com/waza-evals`; project-level `.waza.yaml` can override sources with a top-level `registries:` list.
 
+Registry search currently returns bundled sample metadata while live index integration is pending.
+
 | Flag | Description |
 |------|-------------|
 | `--kind <kind>` | Filter by `grader`, `eval`, or `dataset` |
@@ -586,7 +588,7 @@ Search configured registry indexes for reusable graders, eval bundles, and datas
 
 ### `waza registry add <ref>`
 
-Append a remote grader preset reference to `eval.yaml` and update `waza.lock`. Full resolver-backed expansion depends on the shared resolver from issue #15; the Phase 1 command writes minimal `ref:` entries.
+Append a remote grader preset reference to `eval.yaml`, resolve it with the same remote grader resolver as `waza get`, and update `waza.lock` with the pinned commit SHA and `sha256:` content digest.
 
 | Flag | Description |
 |------|-------------|
@@ -1157,7 +1159,7 @@ tasks:
 
 `schemaVersion` uses `MAJOR.MINOR` format. Missing values are interpreted as the current schema version (currently `1.2`). Readers allow same-major minor additions with warnings for unknown fields, but reject different majors with a hint to run `waza migrate <file>`.
 
-Remote grader refs use Go-module-style paths: `<host>/<owner>/<repo>[/path][#export]@<version>`. The remote module must provide a `waza.registry.yaml` manifest and export a config-only grader preset that expands to a built-in grader type. Run `waza get eval.yaml` after adding or changing refs so `waza.lock` records the resolved commit and digest.
+Remote grader refs use Go-module-style paths: `<host>/<owner>/<repo>[/path][#export]@<version>`. The remote module must provide a `waza.registry.yaml` manifest and export a grader preset. Config-only grader presets expand to built-in grader types by default; remote program graders require explicit trust with `waza registry add --allow-exec` or interactive confirmation. Run `waza get eval.yaml` after manually adding or changing refs so `waza.lock` records the resolved commit and digest.
 
 `results.json` is currently emitted at `schemaVersion` `1.2`. Version `1.1` added per-turn checkpoints (`runs[].checkpoints[]`, see #358) and the normalized `runs[].tool_events[]` array (`turn`, `sequence`, `tool_call_id`, `tool_name`, `args`, `result`, `success`, `error`, `duration_ms`; see #366). Version `1.2` adds `runs[].snapshot_path` for `waza run --snapshot` artifacts (#367) and the eval-level `adversarial:` block consumed by `waza adversarial --spec` (#365). See [docs/PRD](docs/PRD.md) and [schema-changes](site/src/content/docs/reference/schema-changes.md) for details.
 

--- a/cmd/waza/cmd_registry.go
+++ b/cmd/waza/cmd_registry.go
@@ -10,8 +10,8 @@ func newRegistryCommand() *cobra.Command {
 presets to eval.yaml.
 
 Registry search uses configured index sources for discovery. Registry add writes
-minimal ref entries and a lock file scaffold; full module resolution is wired in
-when the shared resolver from issue #15 lands.`,
+ref entries and resolves them into waza.lock using the shared remote grader
+resolver.`,
 	}
 
 	cmd.AddCommand(newRegistrySearchCommand())

--- a/cmd/waza/cmd_registry.go
+++ b/cmd/waza/cmd_registry.go
@@ -1,0 +1,21 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func newRegistryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry",
+		Short: "Discover and add shared eval registry artifacts",
+		Long: `Discover shared Waza eval registry artifacts and add remote grader
+presets to eval.yaml.
+
+Registry search uses configured index sources for discovery. Registry add writes
+minimal ref entries and a lock file scaffold; full module resolution is wired in
+when the shared resolver from issue #15 lands.`,
+	}
+
+	cmd.AddCommand(newRegistrySearchCommand())
+	cmd.AddCommand(newRegistryAddCommand())
+
+	return cmd
+}

--- a/cmd/waza/cmd_registry_add.go
+++ b/cmd/waza/cmd_registry_add.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type registryAddOptions struct {
+	evalPath  string
+	name      string
+	setValues []string
+	allowExec bool
+}
+
+type resolvedRegistryRef struct {
+	Ref          string
+	Module       string
+	Version      string
+	Kind         string
+	Commit       string
+	Digest       string
+	Dependencies []string
+}
+
+func newRegistryAddCommand() *cobra.Command {
+	opts := registryAddOptions{evalPath: "eval.yaml"}
+
+	cmd := &cobra.Command{
+		Use:   "add <ref>",
+		Short: "Add a registry artifact to eval.yaml",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRegistryAdd(cmd, args[0], opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.evalPath, "eval", "eval.yaml", "Path to eval.yaml")
+	cmd.Flags().StringVar(&opts.name, "name", "", "Local alias for the added grader")
+	cmd.Flags().StringArrayVar(&opts.setValues, "set", nil, "Set a local override as key=value (repeatable)")
+	cmd.Flags().BoolVar(&opts.allowExec, "allow-exec", false, "Allow adding remote program graders without prompting")
+
+	return cmd
+}
+
+func runRegistryAdd(cmd *cobra.Command, ref string, opts registryAddOptions) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return errors.New("ref must not be empty")
+	}
+
+	resolved, err := resolveRegistryRef(cmd, ref)
+	if err != nil {
+		return err
+	}
+
+	trusted := opts.allowExec
+	if resolved.Kind == "program-grader" {
+		if !opts.allowExec {
+			confirmed, err := confirmRemoteProgramGrader(cmd.InOrStdin(), cmd.OutOrStdout(), ref)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return errors.New("remote program grader was not added")
+			}
+			trusted = true
+		}
+	}
+
+	entry, err := buildRegistryGraderEntry(ref, opts.name, opts.setValues)
+	if err != nil {
+		return err
+	}
+	if err := appendRegistryGrader(opts.evalPath, entry); err != nil {
+		return err
+	}
+	if err := updateRegistryLock(opts.evalPath, resolved, trusted); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Added %s to %s\n", ref, opts.evalPath) //nolint:errcheck
+	return nil
+}
+
+func resolveRegistryRef(_ *cobra.Command, ref string) (resolvedRegistryRef, error) {
+	// TODO: call the shared resolver from issue #15 and use its resolved module metadata.
+	module, version := splitRegistryRef(ref)
+	kind := "grader-preset"
+	if strings.Contains(strings.ToLower(ref), "program") || strings.Contains(strings.ToLower(ref), "exec") {
+		kind = "program-grader"
+	}
+	return resolvedRegistryRef{
+		Ref:     ref,
+		Module:  module,
+		Version: version,
+		Kind:    kind,
+		Commit:  "resolver-pending",
+		Digest:  "resolver-pending",
+	}, nil
+}
+
+func splitRegistryRef(ref string) (string, string) {
+	module := ref
+	if hash := strings.Index(module, "#"); hash >= 0 {
+		module = module[:hash]
+	}
+	version := ""
+	if at := strings.LastIndex(ref, "@"); at >= 0 && at < len(ref)-1 {
+		version = ref[at+1:]
+	}
+	if at := strings.LastIndex(module, "@"); at >= 0 {
+		module = module[:at]
+	}
+	return module, version
+}
+
+func confirmRemoteProgramGrader(in io.Reader, out io.Writer, ref string) (bool, error) {
+	if _, err := fmt.Fprintf(out, "Remote program grader %s can execute local commands. Add it? [y/N]: ", ref); err != nil {
+		return false, err
+	}
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("reading confirmation: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func buildRegistryGraderEntry(ref, name string, setValues []string) (*yaml.Node, error) {
+	entry := &yaml.Node{Kind: yaml.MappingNode}
+	setMappingScalar(entry, "ref", ref)
+	if strings.TrimSpace(name) != "" {
+		setMappingScalar(entry, "name", strings.TrimSpace(name))
+	}
+	for _, raw := range setValues {
+		key, value, ok := strings.Cut(raw, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("invalid --set %q: expected key=value", raw)
+		}
+		setNestedValue(entry, strings.Split(strings.TrimSpace(key), "."), scalarNode(strings.TrimSpace(value)))
+	}
+	return entry, nil
+}
+
+func appendRegistryGrader(evalPath string, entry *yaml.Node) error {
+	data, err := os.ReadFile(evalPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", evalPath, err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parsing %s: %w", evalPath, err)
+	}
+	root := documentMapping(&doc)
+	if root == nil {
+		return fmt.Errorf("%s must contain a YAML mapping", evalPath)
+	}
+	graders := mappingValue(root, "graders")
+	if graders == nil {
+		graders = &yaml.Node{Kind: yaml.SequenceNode}
+		appendMappingPair(root, "graders", graders)
+	}
+	if graders.Kind != yaml.SequenceNode {
+		return fmt.Errorf("%s field graders must be a list", evalPath)
+	}
+	graders.Content = append(graders.Content, entry)
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		return fmt.Errorf("encoding %s: %w", evalPath, err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("encoding %s: %w", evalPath, err)
+	}
+	return os.WriteFile(evalPath, buf.Bytes(), 0o644)
+}
+
+func updateRegistryLock(evalPath string, resolved resolvedRegistryRef, trusted bool) error {
+	lockPath := filepath.Join(filepath.Dir(evalPath), "waza.lock")
+	var root *yaml.Node
+	if data, err := os.ReadFile(lockPath); err == nil {
+		var doc yaml.Node
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parsing %s: %w", lockPath, err)
+		}
+		root = documentMapping(&doc)
+		if root == nil {
+			return fmt.Errorf("%s must contain a YAML mapping", lockPath)
+		}
+	} else if errors.Is(err, os.ErrNotExist) {
+		root = &yaml.Node{Kind: yaml.MappingNode}
+		setMappingScalar(root, "schema_version", "1")
+	} else {
+		return fmt.Errorf("reading %s: %w", lockPath, err)
+	}
+
+	modules := mappingValue(root, "modules")
+	if modules == nil {
+		modules = &yaml.Node{Kind: yaml.SequenceNode}
+		appendMappingPair(root, "modules", modules)
+	}
+	if modules.Kind != yaml.SequenceNode {
+		return fmt.Errorf("%s field modules must be a list", lockPath)
+	}
+
+	modules.Content = append(modules.Content, registryLockEntry(resolved, trusted))
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		return fmt.Errorf("encoding %s: %w", lockPath, err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("encoding %s: %w", lockPath, err)
+	}
+	return os.WriteFile(lockPath, buf.Bytes(), 0o644)
+}
+
+func registryLockEntry(resolved resolvedRegistryRef, trusted bool) *yaml.Node {
+	entry := &yaml.Node{Kind: yaml.MappingNode}
+	setMappingScalar(entry, "ref", resolved.Ref)
+	setMappingScalar(entry, "module", resolved.Module)
+	if resolved.Version != "" {
+		setMappingScalar(entry, "version", resolved.Version)
+	}
+	setMappingScalar(entry, "commit", resolved.Commit)
+	setMappingScalar(entry, "digest", resolved.Digest)
+	setMappingScalar(entry, "resolved_at", time.Now().UTC().Format(time.RFC3339))
+	if trusted && resolved.Kind == "program-grader" {
+		appendMappingPair(entry, "trusted", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"})
+	}
+	return entry
+}
+
+func documentMapping(doc *yaml.Node) *yaml.Node {
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		if doc.Content[0].Kind == yaml.MappingNode {
+			return doc.Content[0]
+		}
+		return nil
+	}
+	if doc.Kind == yaml.MappingNode {
+		return doc
+	}
+	return nil
+}
+
+func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func appendMappingPair(mapping *yaml.Node, key string, value *yaml.Node) {
+	mapping.Content = append(mapping.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, value)
+}
+
+func setMappingScalar(mapping *yaml.Node, key, value string) {
+	setNestedValue(mapping, []string{key}, scalarNode(value))
+}
+
+func setNestedValue(mapping *yaml.Node, path []string, value *yaml.Node) {
+	if len(path) == 0 {
+		return
+	}
+	if len(path) == 1 {
+		for i := 0; i+1 < len(mapping.Content); i += 2 {
+			if mapping.Content[i].Value == path[0] {
+				mapping.Content[i+1] = value
+				return
+			}
+		}
+		appendMappingPair(mapping, path[0], value)
+		return
+	}
+	child := mappingValue(mapping, path[0])
+	if child == nil || child.Kind != yaml.MappingNode {
+		child = &yaml.Node{Kind: yaml.MappingNode}
+		setNestedValue(mapping, []string{path[0]}, child)
+	}
+	setNestedValue(child, path[1:], value)
+}
+
+func scalarNode(value string) *yaml.Node {
+	lower := strings.ToLower(value)
+	if lower == "true" || lower == "false" {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: lower}
+	}
+	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: value}
+	}
+	if _, err := strconv.ParseFloat(value, 64); err == nil && strings.ContainsAny(value, ".eE") {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: value}
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}

--- a/cmd/waza/cmd_registry_add.go
+++ b/cmd/waza/cmd_registry_add.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,8 +11,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
+	"github.com/microsoft/waza/internal/models"
+	"github.com/microsoft/waza/internal/registry"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -23,14 +25,12 @@ type registryAddOptions struct {
 	allowExec bool
 }
 
-type resolvedRegistryRef struct {
-	Ref          string
-	Module       string
-	Version      string
-	Kind         string
-	Commit       string
-	Digest       string
-	Dependencies []string
+type registryAddResolver interface {
+	ResolveRefWithOptions(context.Context, string, registry.ResolveOptions) (models.LockfileGrader, error)
+}
+
+var newRegistryAddResolver = func() (registryAddResolver, error) {
+	return registry.NewResolver()
 }
 
 func newRegistryAddCommand() *cobra.Command {
@@ -59,23 +59,13 @@ func runRegistryAdd(cmd *cobra.Command, ref string, opts registryAddOptions) err
 		return errors.New("ref must not be empty")
 	}
 
-	resolved, err := resolveRegistryRef(cmd, ref)
+	resolver, err := newRegistryAddResolver()
 	if err != nil {
 		return err
 	}
-
-	trusted := opts.allowExec
-	if resolved.Kind == "program-grader" {
-		if !opts.allowExec {
-			confirmed, err := confirmRemoteProgramGrader(cmd.InOrStdin(), cmd.OutOrStdout(), ref)
-			if err != nil {
-				return err
-			}
-			if !confirmed {
-				return errors.New("remote program grader was not added")
-			}
-			trusted = true
-		}
+	resolved, err := resolveRegistryRef(cmd, resolver, ref, opts.allowExec)
+	if err != nil {
+		return err
 	}
 
 	entry, err := buildRegistryGraderEntry(ref, opts.name, opts.setValues)
@@ -94,7 +84,7 @@ func runRegistryAdd(cmd *cobra.Command, ref string, opts registryAddOptions) err
 	if err := appendRegistryGrader(opts.evalPath, entry); err != nil {
 		return err
 	}
-	if err := updateRegistryLock(opts.evalPath, resolved, trusted); err != nil {
+	if err := updateRegistryLock(opts.evalPath, resolved); err != nil {
 		// The eval and lock file form one logical update. Restore the original
 		// eval when the lock cannot be written so the repository is not left
 		// with a grader entry that has no corresponding resolution metadata.
@@ -108,36 +98,28 @@ func runRegistryAdd(cmd *cobra.Command, ref string, opts registryAddOptions) err
 	return nil
 }
 
-func resolveRegistryRef(_ *cobra.Command, ref string) (resolvedRegistryRef, error) {
-	// TODO: call the shared resolver from issue #15 and use its resolved module metadata.
-	module, version := splitRegistryRef(ref)
-	kind := "grader-preset"
-	if strings.Contains(strings.ToLower(ref), "program") || strings.Contains(strings.ToLower(ref), "exec") {
-		kind = "program-grader"
+func resolveRegistryRef(
+	cmd *cobra.Command,
+	resolver registryAddResolver,
+	ref string,
+	allowExec bool,
+) (models.LockfileGrader, error) {
+	opts := registry.ResolveOptions{AllowProgram: allowExec}
+	resolved, err := resolver.ResolveRefWithOptions(cmd.Context(), ref, opts)
+	if err == nil {
+		return resolved, nil
 	}
-	return resolvedRegistryRef{
-		Ref:     ref,
-		Module:  module,
-		Version: version,
-		Kind:    kind,
-		Commit:  "resolver-pending",
-		Digest:  "resolver-pending",
-	}, nil
-}
-
-func splitRegistryRef(ref string) (string, string) {
-	module := ref
-	if hash := strings.Index(module, "#"); hash >= 0 {
-		module = module[:hash]
+	if allowExec || !registry.IsProgramGraderTrustError(err) {
+		return models.LockfileGrader{}, err
 	}
-	version := ""
-	if at := strings.LastIndex(ref, "@"); at >= 0 && at < len(ref)-1 {
-		version = ref[at+1:]
+	confirmed, confirmErr := confirmRemoteProgramGrader(cmd.InOrStdin(), cmd.OutOrStdout(), ref)
+	if confirmErr != nil {
+		return models.LockfileGrader{}, confirmErr
 	}
-	if at := strings.LastIndex(module, "@"); at >= 0 {
-		module = module[:at]
+	if !confirmed {
+		return models.LockfileGrader{}, errors.New("remote program grader was not added")
 	}
-	return module, version
+	return resolver.ResolveRefWithOptions(cmd.Context(), ref, registry.ResolveOptions{AllowProgram: true})
 }
 
 func confirmRemoteProgramGrader(in io.Reader, out io.Writer, ref string) (bool, error) {
@@ -213,80 +195,31 @@ func appendRegistryGrader(evalPath string, entry *yaml.Node) error {
 	if err := enc.Close(); err != nil {
 		return fmt.Errorf("encoding %s: %w", evalPath, err)
 	}
-	return os.WriteFile(evalPath, buf.Bytes(), 0o644)
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(evalPath); err == nil {
+		mode = info.Mode().Perm()
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("reading metadata for %s: %w", evalPath, err)
+	}
+	return os.WriteFile(evalPath, buf.Bytes(), mode)
 }
 
-func updateRegistryLock(evalPath string, resolved resolvedRegistryRef, trusted bool) error {
+func updateRegistryLock(evalPath string, resolved models.LockfileGrader) error {
 	lockPath := filepath.Join(filepath.Dir(evalPath), "waza.lock")
-	var root *yaml.Node
-	if data, err := os.ReadFile(lockPath); err == nil {
-		var doc yaml.Node
-		if err := yaml.Unmarshal(data, &doc); err != nil {
-			return fmt.Errorf("parsing %s: %w", lockPath, err)
-		}
-		root = documentMapping(&doc)
-		if root == nil {
-			return fmt.Errorf("%s must contain a YAML mapping", lockPath)
-		}
+	var lock *models.Lockfile
+	if existing, err := models.LoadLockfile(lockPath); err == nil {
+		lock = existing
 	} else if errors.Is(err, os.ErrNotExist) {
-		root = &yaml.Node{Kind: yaml.MappingNode}
-		setMappingScalar(root, "schema_version", "1")
+		lock = models.NewLockfile()
 	} else {
-		return fmt.Errorf("reading %s: %w", lockPath, err)
+		return err
 	}
 
-	modules := mappingValue(root, "modules")
-	if modules == nil {
-		modules = &yaml.Node{Kind: yaml.SequenceNode}
-		appendMappingPair(root, "modules", modules)
+	lock.UpsertGrader(resolved)
+	if err := models.WriteLockfile(lockPath, lock); err != nil {
+		return fmt.Errorf("writing %s: %w", lockPath, err)
 	}
-	if modules.Kind != yaml.SequenceNode {
-		return fmt.Errorf("%s field modules must be a list", lockPath)
-	}
-
-	lockEntry := registryLockEntry(resolved, trusted)
-	replaced := false
-	for i, module := range modules.Content {
-		if module.Kind != yaml.MappingNode {
-			continue
-		}
-		moduleRef := mappingValue(module, "ref")
-		if moduleRef != nil && moduleRef.Value == resolved.Ref {
-			modules.Content[i] = lockEntry
-			replaced = true
-			break
-		}
-	}
-	if !replaced {
-		modules.Content = append(modules.Content, lockEntry)
-	}
-
-	var buf bytes.Buffer
-	enc := yaml.NewEncoder(&buf)
-	enc.SetIndent(2)
-	if err := enc.Encode(root); err != nil {
-		return fmt.Errorf("encoding %s: %w", lockPath, err)
-	}
-	if err := enc.Close(); err != nil {
-		return fmt.Errorf("encoding %s: %w", lockPath, err)
-	}
-	return os.WriteFile(lockPath, buf.Bytes(), 0o644)
-}
-
-func registryLockEntry(resolved resolvedRegistryRef, trusted bool) *yaml.Node {
-	entry := &yaml.Node{Kind: yaml.MappingNode}
-	setMappingScalar(entry, "ref", resolved.Ref)
-	setMappingScalar(entry, "module", resolved.Module)
-	if resolved.Version != "" {
-		setMappingScalar(entry, "version", resolved.Version)
-	}
-	setMappingScalar(entry, "commit", resolved.Commit)
-	setMappingScalar(entry, "digest", resolved.Digest)
-	setMappingScalar(entry, "resolved_at", time.Now().UTC().Format(time.RFC3339))
-	if trusted && resolved.Kind == "program-grader" {
-		appendMappingPair(entry, "trusted", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"})
-	}
-	return entry
+	return nil
 }
 
 func documentMapping(doc *yaml.Node) *yaml.Node {

--- a/cmd/waza/cmd_registry_add.go
+++ b/cmd/waza/cmd_registry_add.go
@@ -82,10 +82,25 @@ func runRegistryAdd(cmd *cobra.Command, ref string, opts registryAddOptions) err
 	if err != nil {
 		return err
 	}
+
+	originalEval, err := os.ReadFile(opts.evalPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", opts.evalPath, err)
+	}
+	evalInfo, err := os.Stat(opts.evalPath)
+	if err != nil {
+		return fmt.Errorf("reading metadata for %s: %w", opts.evalPath, err)
+	}
 	if err := appendRegistryGrader(opts.evalPath, entry); err != nil {
 		return err
 	}
 	if err := updateRegistryLock(opts.evalPath, resolved, trusted); err != nil {
+		// The eval and lock file form one logical update. Restore the original
+		// eval when the lock cannot be written so the repository is not left
+		// with a grader entry that has no corresponding resolution metadata.
+		if rollbackErr := os.WriteFile(opts.evalPath, originalEval, evalInfo.Mode().Perm()); rollbackErr != nil {
+			return fmt.Errorf("updating registry lock: %w; restoring %s: %v", err, opts.evalPath, rollbackErr)
+		}
 		return err
 	}
 
@@ -152,7 +167,15 @@ func buildRegistryGraderEntry(ref, name string, setValues []string) (*yaml.Node,
 		if !ok || strings.TrimSpace(key) == "" {
 			return nil, fmt.Errorf("invalid --set %q: expected key=value", raw)
 		}
-		setNestedValue(entry, strings.Split(strings.TrimSpace(key), "."), scalarNode(strings.TrimSpace(value)))
+		path := strings.Split(strings.TrimSpace(key), ".")
+		for i := range path {
+			segment := strings.TrimSpace(path[i])
+			if segment == "" || segment != path[i] {
+				return nil, fmt.Errorf("invalid --set %q: path segments must not be empty", raw)
+			}
+			path[i] = segment
+		}
+		setNestedValue(entry, path, scalarNode(strings.TrimSpace(value)))
 	}
 	return entry, nil
 }
@@ -221,7 +244,22 @@ func updateRegistryLock(evalPath string, resolved resolvedRegistryRef, trusted b
 		return fmt.Errorf("%s field modules must be a list", lockPath)
 	}
 
-	modules.Content = append(modules.Content, registryLockEntry(resolved, trusted))
+	lockEntry := registryLockEntry(resolved, trusted)
+	replaced := false
+	for i, module := range modules.Content {
+		if module.Kind != yaml.MappingNode {
+			continue
+		}
+		moduleRef := mappingValue(module, "ref")
+		if moduleRef != nil && moduleRef.Value == resolved.Ref {
+			modules.Content[i] = lockEntry
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		modules.Content = append(modules.Content, lockEntry)
+	}
 
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)

--- a/cmd/waza/cmd_registry_search.go
+++ b/cmd/waza/cmd_registry_search.go
@@ -146,9 +146,9 @@ func renderRegistrySearchTable(cmd *cobra.Command, results []registrySearchResul
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "REF\tKIND\tDESCRIPTION\tSTARS") //nolint:errcheck
+	fmt.Fprintln(tw, "REF\tKIND\tREGISTRY\tDESCRIPTION\tSTARS") //nolint:errcheck
 	for _, result := range results {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\n", result.Ref, result.Kind, result.Description, result.Stars) //nolint:errcheck
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n", result.Ref, result.Kind, result.Registry, result.Description, result.Stars) //nolint:errcheck
 	}
 	tw.Flush() //nolint:errcheck
 }

--- a/cmd/waza/cmd_registry_search.go
+++ b/cmd/waza/cmd_registry_search.go
@@ -32,7 +32,11 @@ func newRegistrySearchCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Search configured registry indexes",
-		Args:  cobra.ExactArgs(1),
+		Long: `Search configured registry indexes.
+
+This command currently returns bundled sample registry metadata while live
+registry index integration is pending.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRegistrySearch(cmd, args[0], opts)
 		},
@@ -69,6 +73,7 @@ func runRegistrySearch(cmd *cobra.Command, query string, opts registrySearchOpti
 		return enc.Encode(results)
 	}
 
+	fmt.Fprintln(cmd.ErrOrStderr(), "Note: registry search is using bundled sample results; live index integration is pending.") //nolint:errcheck
 	renderRegistrySearchTable(cmd, results)
 	return nil
 }

--- a/cmd/waza/cmd_registry_search.go
+++ b/cmd/waza/cmd_registry_search.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	wazaconfig "github.com/microsoft/waza/internal/config"
+	"github.com/microsoft/waza/internal/projectconfig"
+	"github.com/spf13/cobra"
+)
+
+type registrySearchOptions struct {
+	kind     string
+	registry string
+	format   string
+}
+
+type registrySearchResult struct {
+	Ref         string `json:"ref"`
+	Kind        string `json:"kind"`
+	Description string `json:"description"`
+	Stars       int    `json:"stars"`
+	Registry    string `json:"registry"`
+}
+
+func newRegistrySearchCommand() *cobra.Command {
+	opts := registrySearchOptions{format: "table"}
+
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search configured registry indexes",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRegistrySearch(cmd, args[0], opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.kind, "kind", "", "Filter by artifact kind: grader, eval, or dataset")
+	cmd.Flags().StringVar(&opts.registry, "registry", "", "Search only the named registry source")
+	cmd.Flags().StringVar(&opts.format, "format", "table", "Output format: table or json")
+
+	return cmd
+}
+
+func runRegistrySearch(cmd *cobra.Command, query string, opts registrySearchOptions) error {
+	if opts.kind != "" && opts.kind != "grader" && opts.kind != "eval" && opts.kind != "dataset" {
+		return fmt.Errorf("invalid --kind %q: expected grader, eval, or dataset", opts.kind)
+	}
+	if opts.format != "table" && opts.format != "json" {
+		return fmt.Errorf("invalid --format %q: expected table or json", opts.format)
+	}
+
+	cfg, err := projectconfig.Load(".")
+	if err != nil {
+		return err
+	}
+	registries, err := selectRegistrySources(cfg.Registries, opts.registry)
+	if err != nil {
+		return err
+	}
+
+	results := searchRegistryIndexes(query, opts.kind, registries)
+	if opts.format == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+
+	renderRegistrySearchTable(cmd, results)
+	return nil
+}
+
+func selectRegistrySources(sources []wazaconfig.RegistrySource, name string) ([]wazaconfig.RegistrySource, error) {
+	if len(sources) == 0 {
+		sources = wazaconfig.DefaultRegistrySources()
+	}
+	sort.SliceStable(sources, func(i, j int) bool {
+		return sources[i].Priority > sources[j].Priority
+	})
+	if name == "" {
+		return sources, nil
+	}
+	for _, source := range sources {
+		if source.Name == name {
+			return []wazaconfig.RegistrySource{source}, nil
+		}
+	}
+	return nil, fmt.Errorf("registry %q is not configured", name)
+}
+
+func searchRegistryIndexes(query, kind string, registries []wazaconfig.RegistrySource) []registrySearchResult {
+	// TODO: call registry index API for each configured source.
+	catalog := []registrySearchResult{
+		{
+			Ref:         "github.com/waza-evals/fact#factuality@v1.0.0",
+			Kind:        "grader",
+			Description: "Prompt grader for factual grounding.",
+			Stars:       128,
+		},
+		{
+			Ref:         "github.com/waza-evals/fact#closedqa@v1.0.0",
+			Kind:        "grader",
+			Description: "Closed-question answer evaluator.",
+			Stars:       96,
+		},
+		{
+			Ref:         "github.com/waza-evals/agent-basics#repo-maintainer@v1.0.0",
+			Kind:        "eval",
+			Description: "Reusable repository-maintainer eval bundle.",
+			Stars:       54,
+		},
+		{
+			Ref:         "github.com/waza-evals/fact#factual-answering@v1.0.0",
+			Kind:        "dataset",
+			Description: "Factual answering dataset.",
+			Stars:       38,
+		},
+	}
+
+	query = strings.ToLower(strings.TrimSpace(query))
+	var results []registrySearchResult
+	for _, registry := range registries {
+		for _, result := range catalog {
+			if kind != "" && result.Kind != kind {
+				continue
+			}
+			haystack := strings.ToLower(result.Ref + " " + result.Kind + " " + result.Description)
+			if query != "" && !strings.Contains(haystack, query) {
+				continue
+			}
+			result.Registry = registry.Name
+			results = append(results, result)
+		}
+	}
+	return results
+}
+
+func renderRegistrySearchTable(cmd *cobra.Command, results []registrySearchResult) {
+	w := cmd.OutOrStdout()
+	if len(results) == 0 {
+		fmt.Fprintln(w, "No registry results found.") //nolint:errcheck
+		return
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "REF\tKIND\tDESCRIPTION\tSTARS") //nolint:errcheck
+	for _, result := range results {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\n", result.Ref, result.Kind, result.Description, result.Stars) //nolint:errcheck
+	}
+	tw.Flush() //nolint:errcheck
+}

--- a/cmd/waza/cmd_registry_test.go
+++ b/cmd/waza/cmd_registry_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRegistryCommandWiring(t *testing.T) {
+	cmd := newRootCommand()
+
+	registry, _, err := cmd.Find([]string{"registry"})
+	require.NoError(t, err)
+	require.Equal(t, "registry", registry.Name())
+
+	search, _, err := cmd.Find([]string{"registry", "search"})
+	require.NoError(t, err)
+	require.Equal(t, "search", search.Name())
+
+	add, _, err := cmd.Find([]string{"registry", "add"})
+	require.NoError(t, err)
+	require.Equal(t, "add", add.Name())
+}
+
+func TestRegistrySearchTableOutput(t *testing.T) {
+	dir := t.TempDir()
+	withWorkingDir(t, dir)
+
+	var out bytes.Buffer
+	cmd := newRegistrySearchCommand()
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"factual", "--kind", "grader"})
+
+	require.NoError(t, cmd.Execute())
+
+	output := out.String()
+	require.Contains(t, output, "REF")
+	require.Contains(t, output, "KIND")
+	require.Contains(t, output, "DESCRIPTION")
+	require.Contains(t, output, "STARS")
+	require.Contains(t, output, "github.com/waza-evals/fact#factuality@v1.0.0")
+	require.Contains(t, output, "grader")
+	require.Contains(t, output, "Prompt grader for factual grounding.")
+	require.Contains(t, output, "128")
+}
+
+func TestRegistrySearchFlagValidation(t *testing.T) {
+	cmd := newRegistrySearchCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"fact", "--kind", "plugin"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --kind")
+}
+
+func TestRegistryAddAppendsRefGraderAndWritesLock(t *testing.T) {
+	dir := t.TempDir()
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte(`name: registry-test
+skill: test-skill
+version: "1.0"
+config:
+  trials_per_task: 1
+  timeout_seconds: 30
+  executor: mock
+  model: test
+tasks:
+  - "tasks/*.yaml"
+graders:
+  - name: local
+    type: text
+`), 0o644))
+
+	var out bytes.Buffer
+	cmd := newRegistryAddCommand()
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"github.com/waza-evals/fact#factuality@v1.0.0",
+		"--eval", evalPath,
+		"--name", "factuality_strict",
+		"--set", "config.threshold=0.9",
+		"--set", "weight=2",
+	})
+
+	require.NoError(t, cmd.Execute())
+	require.Contains(t, out.String(), "Added github.com/waza-evals/fact#factuality@v1.0.0")
+
+	data, err := os.ReadFile(evalPath)
+	require.NoError(t, err)
+	var evalDoc map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &evalDoc))
+	graders, ok := evalDoc["graders"].([]any)
+	require.True(t, ok)
+	require.Len(t, graders, 2)
+	added, ok := graders[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "github.com/waza-evals/fact#factuality@v1.0.0", added["ref"])
+	require.Equal(t, "factuality_strict", added["name"])
+	require.Equal(t, 2, added["weight"])
+	config, ok := added["config"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, 0.9, config["threshold"])
+
+	lockData, err := os.ReadFile(filepath.Join(dir, "waza.lock"))
+	require.NoError(t, err)
+	lockText := string(lockData)
+	require.Contains(t, lockText, "schema_version: 1")
+	require.Contains(t, lockText, "ref: github.com/waza-evals/fact#factuality@v1.0.0")
+	require.Contains(t, lockText, "commit: resolver-pending")
+	require.Contains(t, lockText, "digest: resolver-pending")
+}
+
+func TestRegistryAddPromptsForProgramGrader(t *testing.T) {
+	dir := t.TempDir()
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte("name: registry-test\n"), 0o644))
+
+	cmd := newRegistryAddCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetArgs([]string{
+		"github.com/waza-evals/program-graders#exec@v1.0.0",
+		"--eval", evalPath,
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remote program grader was not added")
+}
+
+func TestRegistryAddInteractiveProgramGraderMarksLockTrusted(t *testing.T) {
+	dir := t.TempDir()
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte("name: registry-test\n"), 0o644))
+
+	cmd := newRegistryAddCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetIn(strings.NewReader("y\n"))
+	cmd.SetArgs([]string{
+		"github.com/waza-evals/program-graders#exec@v1.0.0",
+		"--eval", evalPath,
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	lockData, err := os.ReadFile(filepath.Join(dir, "waza.lock"))
+	require.NoError(t, err)
+	require.Contains(t, string(lockData), "trusted: true")
+}
+
+func withWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+}

--- a/cmd/waza/cmd_registry_test.go
+++ b/cmd/waza/cmd_registry_test.go
@@ -2,15 +2,58 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/microsoft/waza/internal/models"
+	"github.com/microsoft/waza/internal/registry"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+const (
+	testRegistryCommit = "0123456789abcdef0123456789abcdef01234567"
+	testRegistryDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+
+type fakeRegistryAddResolver struct {
+	programRefs map[string]bool
+	err         error
+}
+
+func (f *fakeRegistryAddResolver) ResolveRefWithOptions(
+	_ context.Context,
+	ref string,
+	opts registry.ResolveOptions,
+) (models.LockfileGrader, error) {
+	if f.err != nil {
+		return models.LockfileGrader{}, f.err
+	}
+	if f.programRefs[ref] && !opts.AllowProgram {
+		return models.LockfileGrader{}, &registry.ProgramGraderTrustError{Path: ref}
+	}
+	return models.LockfileGrader{
+		Ref:     ref,
+		Commit:  testRegistryCommit,
+		Digest:  testRegistryDigest,
+		URL:     "https://" + strings.Split(ref, "@")[0],
+		Trusted: f.programRefs[ref] && opts.AllowProgram,
+	}, nil
+}
+
+func useFakeRegistryAddResolver(t *testing.T, fake *fakeRegistryAddResolver) {
+	t.Helper()
+	original := newRegistryAddResolver
+	newRegistryAddResolver = func() (registryAddResolver, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { newRegistryAddResolver = original })
+}
 
 func TestRegistryCommandWiring(t *testing.T) {
 	cmd := newRootCommand()
@@ -65,6 +108,8 @@ func TestRegistrySearchFlagValidation(t *testing.T) {
 }
 
 func TestRegistryAddAppendsRefGraderAndWritesLock(t *testing.T) {
+	useFakeRegistryAddResolver(t, &fakeRegistryAddResolver{})
+
 	dir := t.TempDir()
 	evalPath := filepath.Join(dir, "eval.yaml")
 	require.NoError(t, os.WriteFile(evalPath, []byte(`name: registry-test
@@ -118,8 +163,9 @@ graders:
 	lockText := string(lockData)
 	require.Contains(t, lockText, "schema_version: 1")
 	require.Contains(t, lockText, "ref: github.com/waza-evals/fact#factuality@v1.0.0")
-	require.Contains(t, lockText, "commit: resolver-pending")
-	require.Contains(t, lockText, "digest: resolver-pending")
+	require.Contains(t, lockText, "commit: "+testRegistryCommit)
+	require.Contains(t, lockText, "digest: "+testRegistryDigest)
+	require.NotContains(t, lockText, "modules:")
 }
 
 func TestRegistryAddRejectsEmptySetPathSegments(t *testing.T) {
@@ -138,6 +184,8 @@ func TestRegistryAddRejectsEmptySetPathSegments(t *testing.T) {
 }
 
 func TestRegistryAddReplacesExistingLockEntry(t *testing.T) {
+	useFakeRegistryAddResolver(t, &fakeRegistryAddResolver{})
+
 	dir := t.TempDir()
 	evalPath := filepath.Join(dir, "eval.yaml")
 	require.NoError(t, os.WriteFile(evalPath, []byte("name: registry-test\n"), 0o644))
@@ -153,16 +201,15 @@ func TestRegistryAddReplacesExistingLockEntry(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 	}
 
-	lockData, err := os.ReadFile(filepath.Join(dir, "waza.lock"))
+	lock, err := models.LoadLockfile(filepath.Join(dir, "waza.lock"))
 	require.NoError(t, err)
-	var lockDoc map[string]any
-	require.NoError(t, yaml.Unmarshal(lockData, &lockDoc))
-	modules, ok := lockDoc["modules"].([]any)
-	require.True(t, ok)
-	require.Len(t, modules, 1)
+	require.Len(t, lock.Graders, 1)
+	require.Equal(t, "github.com/waza-evals/fact#factuality@v1.0.0", lock.Graders[0].Ref)
 }
 
 func TestRegistryAddRestoresEvalWhenLockWriteFails(t *testing.T) {
+	useFakeRegistryAddResolver(t, &fakeRegistryAddResolver{})
+
 	dir := t.TempDir()
 	evalPath := filepath.Join(dir, "eval.yaml")
 	original := []byte("name: registry-test\n")
@@ -184,6 +231,11 @@ func TestRegistryAddRestoresEvalWhenLockWriteFails(t *testing.T) {
 }
 
 func TestRegistryAddPromptsForProgramGrader(t *testing.T) {
+	ref := "github.com/waza-evals/program-graders#exec@v1.0.0"
+	useFakeRegistryAddResolver(t, &fakeRegistryAddResolver{
+		programRefs: map[string]bool{ref: true},
+	})
+
 	dir := t.TempDir()
 	evalPath := filepath.Join(dir, "eval.yaml")
 	require.NoError(t, os.WriteFile(evalPath, []byte("name: registry-test\n"), 0o644))
@@ -193,7 +245,7 @@ func TestRegistryAddPromptsForProgramGrader(t *testing.T) {
 	cmd.SetErr(io.Discard)
 	cmd.SetIn(strings.NewReader("n\n"))
 	cmd.SetArgs([]string{
-		"github.com/waza-evals/program-graders#exec@v1.0.0",
+		ref,
 		"--eval", evalPath,
 	})
 
@@ -203,6 +255,11 @@ func TestRegistryAddPromptsForProgramGrader(t *testing.T) {
 }
 
 func TestRegistryAddInteractiveProgramGraderMarksLockTrusted(t *testing.T) {
+	ref := "github.com/waza-evals/program-graders#exec@v1.0.0"
+	useFakeRegistryAddResolver(t, &fakeRegistryAddResolver{
+		programRefs: map[string]bool{ref: true},
+	})
+
 	dir := t.TempDir()
 	evalPath := filepath.Join(dir, "eval.yaml")
 	require.NoError(t, os.WriteFile(evalPath, []byte("name: registry-test\n"), 0o644))
@@ -212,7 +269,7 @@ func TestRegistryAddInteractiveProgramGraderMarksLockTrusted(t *testing.T) {
 	cmd.SetErr(io.Discard)
 	cmd.SetIn(strings.NewReader("y\n"))
 	cmd.SetArgs([]string{
-		"github.com/waza-evals/program-graders#exec@v1.0.0",
+		ref,
 		"--eval", evalPath,
 	})
 
@@ -221,6 +278,43 @@ func TestRegistryAddInteractiveProgramGraderMarksLockTrusted(t *testing.T) {
 	lockData, err := os.ReadFile(filepath.Join(dir, "waza.lock"))
 	require.NoError(t, err)
 	require.Contains(t, string(lockData), "trusted: true")
+}
+
+func TestRegistryAddPreservesEvalAndLockFileModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode preservation is platform-specific")
+	}
+	useFakeRegistryAddResolver(t, &fakeRegistryAddResolver{})
+
+	dir := t.TempDir()
+	evalPath := filepath.Join(dir, "eval.yaml")
+	lockPath := filepath.Join(dir, "waza.lock")
+	require.NoError(t, os.WriteFile(evalPath, []byte("name: registry-test\n"), 0o600))
+	lock := models.NewLockfile()
+	lock.UpsertGrader(models.LockfileGrader{
+		Ref:    "github.com/waza-evals/old#grader@v1.0.0",
+		Commit: testRegistryCommit,
+		Digest: testRegistryDigest,
+		URL:    "https://github.com/waza-evals/old#grader",
+	})
+	require.NoError(t, models.WriteLockfile(lockPath, lock))
+	require.NoError(t, os.Chmod(lockPath, 0o600))
+
+	cmd := newRegistryAddCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"github.com/waza-evals/fact#factuality@v1.0.0",
+		"--eval", evalPath,
+	})
+
+	require.NoError(t, cmd.Execute())
+	evalInfo, err := os.Stat(evalPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), evalInfo.Mode().Perm())
+	lockInfo, err := os.Stat(lockPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), lockInfo.Mode().Perm())
 }
 
 func withWorkingDir(t *testing.T, dir string) {

--- a/cmd/waza/cmd_registry_test.go
+++ b/cmd/waza/cmd_registry_test.go
@@ -43,10 +43,12 @@ func TestRegistrySearchTableOutput(t *testing.T) {
 	output := out.String()
 	require.Contains(t, output, "REF")
 	require.Contains(t, output, "KIND")
+	require.Contains(t, output, "REGISTRY")
 	require.Contains(t, output, "DESCRIPTION")
 	require.Contains(t, output, "STARS")
 	require.Contains(t, output, "github.com/waza-evals/fact#factuality@v1.0.0")
 	require.Contains(t, output, "grader")
+	require.Contains(t, output, "public")
 	require.Contains(t, output, "Prompt grader for factual grounding.")
 	require.Contains(t, output, "128")
 }
@@ -118,6 +120,67 @@ graders:
 	require.Contains(t, lockText, "ref: github.com/waza-evals/fact#factuality@v1.0.0")
 	require.Contains(t, lockText, "commit: resolver-pending")
 	require.Contains(t, lockText, "digest: resolver-pending")
+}
+
+func TestRegistryAddRejectsEmptySetPathSegments(t *testing.T) {
+	for _, setValue := range []string{"config..threshold=0.9", "config. threshold=0.9"} {
+		t.Run(setValue, func(t *testing.T) {
+			_, err := buildRegistryGraderEntry(
+				"github.com/waza-evals/fact#factuality@v1.0.0",
+				"",
+				[]string{setValue},
+			)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "path segments must not be empty")
+		})
+	}
+}
+
+func TestRegistryAddReplacesExistingLockEntry(t *testing.T) {
+	dir := t.TempDir()
+	evalPath := filepath.Join(dir, "eval.yaml")
+	require.NoError(t, os.WriteFile(evalPath, []byte("name: registry-test\n"), 0o644))
+
+	for range 2 {
+		cmd := newRegistryAddCommand()
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{
+			"github.com/waza-evals/fact#factuality@v1.0.0",
+			"--eval", evalPath,
+		})
+		require.NoError(t, cmd.Execute())
+	}
+
+	lockData, err := os.ReadFile(filepath.Join(dir, "waza.lock"))
+	require.NoError(t, err)
+	var lockDoc map[string]any
+	require.NoError(t, yaml.Unmarshal(lockData, &lockDoc))
+	modules, ok := lockDoc["modules"].([]any)
+	require.True(t, ok)
+	require.Len(t, modules, 1)
+}
+
+func TestRegistryAddRestoresEvalWhenLockWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	evalPath := filepath.Join(dir, "eval.yaml")
+	original := []byte("name: registry-test\n")
+	require.NoError(t, os.WriteFile(evalPath, original, 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "waza.lock"), 0o755))
+
+	cmd := newRegistryAddCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"github.com/waza-evals/fact#factuality@v1.0.0",
+		"--eval", evalPath,
+	})
+
+	require.Error(t, cmd.Execute())
+	actual, err := os.ReadFile(evalPath)
+	require.NoError(t, err)
+	require.Equal(t, original, actual)
 }
 
 func TestRegistryAddPromptsForProgramGrader(t *testing.T) {

--- a/cmd/waza/root.go
+++ b/cmd/waza/root.go
@@ -75,6 +75,7 @@ performance against predefined test cases.`,
 	cmd.AddCommand(newMCPMockCommand())
 	cmd.AddCommand(newReplayCommand())
 	cmd.AddCommand(newAdversarialCommand())
+	cmd.AddCommand(newRegistryCommand())
 
 	return cmd
 }

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -524,9 +524,9 @@ waza registry add github.com/waza-evals/fact#factuality@v1.0.0 \
   --set config.threshold=0.9
 ```
 
-`waza registry search` queries configured index sources. By default, Waza searches the public `https://github.com/waza-evals` source. Project `.waza.yaml` files can define a top-level `registries:` list with named sources, and `--registry <name>` limits search to one of them.
+`waza registry search` queries configured index sources. By default, Waza searches the public `https://github.com/waza-evals` source. Project `.waza.yaml` files can define a top-level `registries:` list with named sources, and `--registry <name>` limits search to one of them. The current implementation returns bundled sample metadata while live registry index integration is pending.
 
-`waza registry add` appends a minimal `ref:` grader entry to `eval.yaml` and updates `waza.lock`. Remote executable program graders require `--allow-exec` or interactive confirmation because they can run local commands.
+`waza registry add` appends a `ref:` grader entry to `eval.yaml`, resolves the ref with the shared remote grader resolver, and updates `waza.lock` with the pinned commit SHA and content digest. Remote executable program graders require `--allow-exec` or interactive confirmation because they can run local commands.
 
 ---
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -512,6 +512,22 @@ Specify cache location:
 waza run evals/code-explainer/eval.yaml --cache --cache-dir ./my-cache
 ```
 
+### Registry Grader Presets
+
+Use registry commands to discover shared grader presets and add them to an eval without copying full grader definitions by hand:
+
+```bash
+waza registry search factual --kind grader
+waza registry add github.com/waza-evals/fact#factuality@v1.0.0 \
+  --eval evals/code-explainer/eval.yaml \
+  --name factuality_strict \
+  --set config.threshold=0.9
+```
+
+`waza registry search` queries configured index sources. By default, Waza searches the public `https://github.com/waza-evals` source. Project `.waza.yaml` files can define a top-level `registries:` list with named sources, and `--registry <name>` limits search to one of them.
+
+`waza registry add` appends a minimal `ref:` grader entry to `eval.yaml` and updates `waza.lock`. Remote executable program graders require `--allow-exec` or interactive confirmation because they can run local commands.
+
 ---
 
 ### Testing Against a Local Git Repo

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -1,0 +1,22 @@
+package config
+
+// DefaultPublicRegistryURL is the built-in public registry index source.
+const DefaultPublicRegistryURL = "https://github.com/waza-evals"
+
+// RegistrySource describes one configured registry index source used for
+// discovery. Resolver/package content remains canonical outside the index.
+type RegistrySource struct {
+	Name     string `yaml:"name" json:"name"`
+	URL      string `yaml:"url" json:"url"`
+	Priority int    `yaml:"priority,omitempty" json:"priority,omitempty"`
+}
+
+// DefaultRegistrySources returns the built-in public registry sources.
+func DefaultRegistrySources() []RegistrySource {
+	return []RegistrySource{
+		{
+			Name: "public",
+			URL:  DefaultPublicRegistryURL,
+		},
+	}
+}

--- a/internal/models/lockfile.go
+++ b/internal/models/lockfile.go
@@ -25,10 +25,11 @@ type Lockfile struct {
 }
 
 type LockfileGrader struct {
-	Ref    string `yaml:"ref"`
-	Commit string `yaml:"commit"`
-	Digest string `yaml:"digest"`
-	URL    string `yaml:"url"`
+	Ref     string `yaml:"ref"`
+	Commit  string `yaml:"commit"`
+	Digest  string `yaml:"digest"`
+	URL     string `yaml:"url"`
+	Trusted bool   `yaml:"trusted,omitempty"`
 }
 
 func NewLockfile() *Lockfile {
@@ -71,7 +72,13 @@ func WriteLockfile(path string, lock *Lockfile) error {
 	if err != nil {
 		return fmt.Errorf("encoding lockfile: %w", err)
 	}
-	return os.WriteFile(path, data, 0o644)
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+	return os.WriteFile(path, data, mode)
 }
 
 func (l *Lockfile) Validate() error {

--- a/internal/projectconfig/config.go
+++ b/internal/projectconfig/config.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	wazaconfig "github.com/microsoft/waza/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -148,6 +149,8 @@ type ProjectConfig struct {
 	Tokens   TokensConfig   `yaml:"tokens,omitempty"`
 	Graders  GradersConfig  `yaml:"graders,omitempty"`
 	Storage  StorageConfig  `yaml:"storage,omitempty"`
+
+	Registries []wazaconfig.RegistrySource `yaml:"registries,omitempty"`
 }
 
 // New returns a ProjectConfig with all hard-coded defaults populated.
@@ -196,6 +199,7 @@ func New() *ProjectConfig {
 		Storage: StorageConfig{
 			ContainerName: DefaultStorageContainerName,
 		},
+		Registries: wazaconfig.DefaultRegistrySources(),
 	}
 }
 
@@ -367,6 +371,10 @@ func mergeConfig(dst, src *ProjectConfig) {
 		dst.Storage.ContainerName = src.Storage.ContainerName
 	}
 	dst.Storage.Enabled = src.Storage.Enabled
+
+	if len(src.Registries) > 0 {
+		dst.Registries = src.Registries
+	}
 }
 
 func validateConfig(cfg *ProjectConfig) error {
@@ -378,6 +386,14 @@ func validateConfig(cfg *ProjectConfig) error {
 	}
 	if err := validateFileSuffix("files.taskFileSuffix", cfg.Files.TaskFileSuffix); err != nil {
 		return err
+	}
+	for i, registry := range cfg.Registries {
+		if strings.TrimSpace(registry.Name) == "" {
+			return fmt.Errorf("registries[%d].name must not be empty", i)
+		}
+		if strings.TrimSpace(registry.URL) == "" {
+			return fmt.Errorf("registries[%d].url must not be empty", i)
+		}
 	}
 	return nil
 }

--- a/internal/projectconfig/config.go
+++ b/internal/projectconfig/config.go
@@ -387,13 +387,19 @@ func validateConfig(cfg *ProjectConfig) error {
 	if err := validateFileSuffix("files.taskFileSuffix", cfg.Files.TaskFileSuffix); err != nil {
 		return err
 	}
+	registryNames := make(map[string]int, len(cfg.Registries))
 	for i, registry := range cfg.Registries {
-		if strings.TrimSpace(registry.Name) == "" {
+		name := strings.TrimSpace(registry.Name)
+		if name == "" {
 			return fmt.Errorf("registries[%d].name must not be empty", i)
 		}
 		if strings.TrimSpace(registry.URL) == "" {
 			return fmt.Errorf("registries[%d].url must not be empty", i)
 		}
+		if previous, exists := registryNames[name]; exists {
+			return fmt.Errorf("registries[%d].name %q duplicates registries[%d].name", i, name, previous)
+		}
+		registryNames[name] = i
 	}
 	return nil
 }

--- a/internal/projectconfig/config_test.go
+++ b/internal/projectconfig/config_test.go
@@ -212,6 +212,25 @@ defaults:
 	}
 }
 
+func TestLoad_DuplicateRegistryNames_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".waza.yaml", `
+registries:
+  - name: public
+    url: https://github.com/waza-evals
+  - name: public
+    url: https://github.com/example/waza-evals
+`)
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("Load() should reject duplicate registry names")
+	}
+	if !strings.Contains(err.Error(), "duplicates") {
+		t.Fatalf("error %q does not report the duplicate registry name", err)
+	}
+}
+
 func TestLoad_UnknownFields_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, ".waza.yaml", `

--- a/internal/projectconfig/config_test.go
+++ b/internal/projectconfig/config_test.go
@@ -52,6 +52,12 @@ func TestNew_ReturnsAllDefaults(t *testing.T) {
 
 	// Graders
 	assertEqualInt(t, "Graders.ProgramTimeout", 30, cfg.Graders.ProgramTimeout)
+
+	if len(cfg.Registries) != 1 {
+		t.Fatalf("Registries length = %d, want 1", len(cfg.Registries))
+	}
+	assertEqual(t, "Registries[0].Name", "public", cfg.Registries[0].Name)
+	assertEqual(t, "Registries[0].URL", "https://github.com/waza-evals", cfg.Registries[0].URL)
 }
 
 func TestLoad_FullConfig(t *testing.T) {
@@ -94,6 +100,12 @@ tokens:
       gpt-4o: 8192
 graders:
   programTimeout: 60
+registries:
+  - name: public
+    url: https://github.com/waza-evals
+  - name: company
+    url: https://github.com/myorg/waza-registry
+    priority: 10
 `)
 
 	cfg, err := Load(dir)
@@ -134,6 +146,12 @@ graders:
 		t.Errorf("Tokens.Limits.Overrides[gpt-4o] = %d, want 8192", cfg.Tokens.Limits.Overrides["gpt-4o"])
 	}
 	assertEqualInt(t, "Graders.ProgramTimeout", 60, cfg.Graders.ProgramTimeout)
+	if len(cfg.Registries) != 2 {
+		t.Fatalf("Registries length = %d, want 2", len(cfg.Registries))
+	}
+	assertEqual(t, "Registries[1].Name", "company", cfg.Registries[1].Name)
+	assertEqual(t, "Registries[1].URL", "https://github.com/myorg/waza-registry", cfg.Registries[1].URL)
+	assertEqualInt(t, "Registries[1].Priority", 10, cfg.Registries[1].Priority)
 }
 
 func TestLoad_PartialConfig_LegacyTwoField(t *testing.T) {

--- a/internal/projectconfig/schema_parity_test.go
+++ b/internal/projectconfig/schema_parity_test.go
@@ -101,6 +101,20 @@ func TestSchemaDefaultsMatchGoDefaults(t *testing.T) {
 	assertStringDefault(t, getDefault("storage", "accountName"), cfg.Storage.AccountName, "storage.accountName")
 	assertStringDefault(t, getDefault("storage", "containerName"), cfg.Storage.ContainerName, "storage.containerName")
 	assertBoolDefault(t, getDefault("storage", "enabled"), cfg.Storage.Enabled, "storage.enabled")
+
+	registryDefault, ok := schema.Properties["registries"].Default.([]any)
+	if !ok {
+		t.Fatalf("registries: schema default is %T(%v), expected array", schema.Properties["registries"].Default, schema.Properties["registries"].Default)
+	}
+	if len(registryDefault) != len(cfg.Registries) {
+		t.Fatalf("registries: schema default length %d != Go default length %d", len(registryDefault), len(cfg.Registries))
+	}
+	firstRegistry, ok := registryDefault[0].(map[string]any)
+	if !ok {
+		t.Fatalf("registries[0]: schema default is %T(%v), expected object", registryDefault[0], registryDefault[0])
+	}
+	assertStringDefault(t, firstRegistry["name"], cfg.Registries[0].Name, "registries[0].name")
+	assertStringDefault(t, firstRegistry["url"], cfg.Registries[0].URL, "registries[0].url")
 }
 
 func assertStringDefault(t *testing.T, schemaVal any, goVal, field string) {

--- a/internal/registry/resolver.go
+++ b/internal/registry/resolver.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -28,6 +29,24 @@ type Resolver struct {
 }
 
 type ResolverOption func(*Resolver)
+
+// ResolveOptions controls trust-sensitive remote grader resolution.
+type ResolveOptions struct {
+	AllowProgram bool
+}
+
+type ProgramGraderTrustError struct {
+	Path string
+}
+
+func (e *ProgramGraderTrustError) Error() string {
+	return fmt.Sprintf("remote program grader %s is not supported without explicit trust", e.Path)
+}
+
+func IsProgramGraderTrustError(err error) bool {
+	var trustErr *ProgramGraderTrustError
+	return errors.As(err, &trustErr)
+}
 
 func WithCacheRoot(path string) ResolverOption {
 	return func(r *Resolver) {
@@ -103,6 +122,10 @@ func (r *Resolver) ResolveRefs(ctx context.Context, refs []string) ([]models.Loc
 }
 
 func (r *Resolver) ResolveRef(ctx context.Context, raw string) (models.LockfileGrader, error) {
+	return r.ResolveRefWithOptions(ctx, raw, ResolveOptions{})
+}
+
+func (r *Resolver) ResolveRefWithOptions(ctx context.Context, raw string, opts ResolveOptions) (models.LockfileGrader, error) {
 	ref, err := ParseRef(raw)
 	if err != nil {
 		return models.LockfileGrader{}, err
@@ -116,14 +139,16 @@ func (r *Resolver) ResolveRef(ctx context.Context, raw string) (models.LockfileG
 	if err != nil {
 		return models.LockfileGrader{}, fmt.Errorf("digesting %s: %w", cacheDir, err)
 	}
-	entry := models.LockfileGrader{
-		Ref:    raw,
-		Commit: commit,
-		Digest: digest,
-		URL:    url,
-	}
-	if _, err := r.loadGraderPreset(ref, cacheDir); err != nil {
+	preset, err := r.loadGraderPreset(ref, cacheDir, opts.AllowProgram)
+	if err != nil {
 		return models.LockfileGrader{}, fmt.Errorf("loading %s: %w", raw, err)
+	}
+	entry := models.LockfileGrader{
+		Ref:     raw,
+		Commit:  commit,
+		Digest:  digest,
+		URL:     url,
+		Trusted: opts.AllowProgram && preset.Kind == models.GraderKindProgram,
 	}
 	return entry, nil
 }
@@ -204,7 +229,7 @@ func (r *Resolver) LoadLockedGrader(ctx context.Context, ref Ref, entry models.L
 	if digest != entry.Digest {
 		return models.GraderConfig{}, fmt.Errorf("digest mismatch for ref %q: lock has %s, cache has %s", entry.Ref, entry.Digest, digest)
 	}
-	return r.loadGraderPreset(ref, cacheDir)
+	return r.loadGraderPreset(ref, cacheDir, entry.Trusted)
 }
 
 func (r *Resolver) ensureCached(ctx context.Context, ref Ref, url string) (string, string, error) {
@@ -332,7 +357,7 @@ type manifestExport struct {
 	Description string `yaml:"description,omitempty"`
 }
 
-func (r *Resolver) loadGraderPreset(ref Ref, moduleDir string) (models.GraderConfig, error) {
+func (r *Resolver) loadGraderPreset(ref Ref, moduleDir string, allowProgram bool) (models.GraderConfig, error) {
 	if ref.Export != "" {
 		manifestDir := moduleDir
 		if ref.Path != "" {
@@ -354,14 +379,14 @@ func (r *Resolver) loadGraderPreset(ref Ref, moduleDir string) (models.GraderCon
 		if err != nil {
 			return models.GraderConfig{}, err
 		}
-		return loadGraderFile(graderPath, ref.Export)
+		return loadGraderFile(graderPath, ref.Export, allowProgram)
 	}
 	if ref.Path != "" {
 		graderPath, err := safeJoinModulePath(moduleDir, ref.Path)
 		if err != nil {
 			return models.GraderConfig{}, err
 		}
-		return loadGraderFile(graderPath, filepath.Base(ref.Path))
+		return loadGraderFile(graderPath, filepath.Base(ref.Path), allowProgram)
 	}
 	m, err := loadManifest(moduleDir)
 	if err != nil {
@@ -375,7 +400,7 @@ func (r *Resolver) loadGraderPreset(ref Ref, moduleDir string) (models.GraderCon
 		if err != nil {
 			return models.GraderConfig{}, err
 		}
-		return loadGraderFile(graderPath, name)
+		return loadGraderFile(graderPath, name, allowProgram)
 	}
 	return models.GraderConfig{}, fmt.Errorf("manifest has no grader exports")
 }
@@ -420,7 +445,7 @@ func loadManifest(dir string) (*manifest, error) {
 	return &m, nil
 }
 
-func loadGraderFile(graderPath string, fallbackName string) (models.GraderConfig, error) {
+func loadGraderFile(graderPath string, fallbackName string, allowProgram bool) (models.GraderConfig, error) {
 	resolved, err := resolveYAMLPath(graderPath)
 	if err != nil {
 		return models.GraderConfig{}, err
@@ -436,8 +461,8 @@ func loadGraderFile(graderPath string, fallbackName string) (models.GraderConfig
 	if grader.Kind == "" {
 		return models.GraderConfig{}, fmt.Errorf("remote grader %s must declare type", resolved)
 	}
-	if grader.Kind == models.GraderKindProgram {
-		return models.GraderConfig{}, fmt.Errorf("remote program graders are not supported without explicit trust")
+	if grader.Kind == models.GraderKindProgram && !allowProgram {
+		return models.GraderConfig{}, &ProgramGraderTrustError{Path: resolved}
 	}
 	if grader.Identifier == "" {
 		grader.Identifier = strings.TrimSuffix(fallbackName, filepath.Ext(fallbackName))

--- a/internal/registry/resolver_test.go
+++ b/internal/registry/resolver_test.go
@@ -116,6 +116,62 @@ tasks: []
 	}
 }
 
+func TestResolverRequiresTrustForProgramGraders(t *testing.T) {
+	repo := createProgramModuleRepo(t)
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	resolver, err := NewResolver(
+		WithCacheRoot(cacheRoot),
+		WithGitURLFunc(func(Ref) string { return repo }),
+	)
+	if err != nil {
+		t.Fatalf("NewResolver() error = %v", err)
+	}
+
+	ref := "example.com/acme/program-graders#exec@v1.0.0"
+	if _, err := resolver.ResolveRef(context.Background(), ref); !IsProgramGraderTrustError(err) {
+		t.Fatalf("ResolveRef() error = %v, want ProgramGraderTrustError", err)
+	}
+	entry, err := resolver.ResolveRefWithOptions(context.Background(), ref, ResolveOptions{AllowProgram: true})
+	if err != nil {
+		t.Fatalf("ResolveRefWithOptions() error = %v", err)
+	}
+	if !entry.Trusted {
+		t.Fatalf("Trusted = false, want true")
+	}
+
+	evalDir := t.TempDir()
+	evalPath := filepath.Join(evalDir, "eval.yaml")
+	specYAML := `name: remote-program-eval
+skill: test
+config:
+  trials_per_task: 1
+  timeout_seconds: 60
+  executor: mock
+graders:
+  - ref: example.com/acme/program-graders#exec@v1.0.0
+metrics: []
+tasks: []
+`
+	if err := os.WriteFile(evalPath, []byte(specYAML), 0o644); err != nil {
+		t.Fatalf("write eval: %v", err)
+	}
+	lock := models.NewLockfile()
+	lock.UpsertGrader(entry)
+	if err := models.WriteLockfile(filepath.Join(evalDir, models.LockfileName), lock); err != nil {
+		t.Fatalf("WriteLockfile() error = %v", err)
+	}
+	spec, err := models.LoadEvalSpec(evalPath)
+	if err != nil {
+		t.Fatalf("LoadEvalSpec() error = %v", err)
+	}
+	if err := resolver.ExpandLockedGraders(context.Background(), spec, evalPath); err != nil {
+		t.Fatalf("ExpandLockedGraders() error = %v", err)
+	}
+	if spec.Graders[0].Kind != models.GraderKindProgram {
+		t.Fatalf("Kind = %q", spec.Graders[0].Kind)
+	}
+}
+
 func TestSafeJoinModulePathRejectsTraversal(t *testing.T) {
 	for _, unsafe := range []string{"../outside.yaml", `..\outside.yaml`, "graders/../../outside.yaml"} {
 		if _, err := safeJoinModulePath(t.TempDir(), unsafe); err == nil {
@@ -189,6 +245,42 @@ config:
 		t.Fatalf("write manifest: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "graders", "factuality.yaml"), []byte(grader), 0o644); err != nil {
+		t.Fatalf("write grader: %v", err)
+	}
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "--quiet", "-m", "initial")
+	run(t, dir, "git", "tag", "v1.0.0")
+	return dir
+}
+
+func createProgramModuleRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	run(t, dir, "git", "init", "--quiet")
+	run(t, dir, "git", "config", "user.email", "waza@example.com")
+	run(t, dir, "git", "config", "user.name", "Waza Test")
+	if err := os.MkdirAll(filepath.Join(dir, "graders"), 0o755); err != nil {
+		t.Fatalf("mkdir graders: %v", err)
+	}
+	manifest := `schema_version: 1
+module: example.com/acme/program-graders
+exports:
+  graders:
+    exec:
+      path: graders/exec.yaml
+`
+	grader := `type: program
+name: exec
+config:
+  command: "true"
+`
+	if err := os.WriteFile(filepath.Join(dir, "waza.registry.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graders", "exec.yaml"), []byte(grader), 0o644); err != nil {
 		t.Fatalf("write grader: %v", err)
 	}
 	run(t, dir, "git", "add", ".")

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -243,6 +243,38 @@
         }
       },
       "additionalProperties": false
+    },
+    "registries": {
+      "type": "array",
+      "description": "Registry index sources used by 'waza registry search'.",
+      "default": [
+        {
+          "name": "public",
+          "url": "https://github.com/waza-evals"
+        }
+      ],
+      "items": {
+        "type": "object",
+        "required": ["name", "url"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Registry source name used by --registry.",
+            "minLength": 1
+          },
+          "url": {
+            "type": "string",
+            "description": "Registry index URL.",
+            "minLength": 1
+          },
+          "priority": {
+            "type": "integer",
+            "description": "Higher-priority registries are searched first.",
+            "default": 0
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -996,6 +996,63 @@ waza cache clear --cache-dir .my-cache
 
 ---
 
+## waza registry
+
+Discover shared registry artifacts and add remote grader presets to an eval.
+
+Registry discovery uses configured index sources. The default public source is `https://github.com/waza-evals`; project `.waza.yaml` files can override sources with:
+
+```yaml
+registries:
+  - name: public
+    url: https://github.com/waza-evals
+  - name: company
+    url: https://github.com/myorg/waza-registry
+    priority: 10
+```
+
+### waza registry search
+
+Search configured registry indexes.
+
+```bash
+waza registry search factual
+waza registry search factual --kind grader
+waza registry search factual --registry company
+waza registry search factual --format json
+```
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--kind` | Filter by artifact kind: `grader`, `eval`, or `dataset` |
+| `--registry` | Search only the named registry source |
+| `--format` | Output format: `table` or `json` (default: `table`) |
+
+### waza registry add
+
+Append a remote grader preset reference to `eval.yaml` and update `waza.lock`.
+
+```bash
+waza registry add github.com/waza-evals/fact#factuality@v1.0.0
+waza registry add github.com/waza-evals/fact#factuality@v1.0.0 --eval eval.yaml
+waza registry add github.com/waza-evals/fact#factuality@v1.0.0 --name factuality_strict --set config.threshold=0.9
+```
+
+Full end-to-end module resolution depends on the shared resolver from issue #15. Phase 1 writes minimal `ref:` grader entries and scaffolds lock metadata until that resolver is wired in.
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--eval` | Eval file to update (default: `eval.yaml`) |
+| `--name` | Local alias for the grader |
+| `--set` | Add a local override as `key=value`; repeatable |
+| `--allow-exec` | Allow remote program graders without interactive confirmation |
+
+---
+
 ## waza dev
 
 Improve skill compliance iteratively.

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -1013,7 +1013,7 @@ registries:
 
 ### waza registry search
 
-Search configured registry indexes.
+Search configured registry indexes. The current implementation returns bundled sample metadata while live registry index integration is pending.
 
 ```bash
 waza registry search factual
@@ -1032,7 +1032,7 @@ waza registry search factual --format json
 
 ### waza registry add
 
-Append a remote grader preset reference to `eval.yaml` and update `waza.lock`.
+Append a remote grader preset reference to `eval.yaml`, resolve it with the shared remote grader resolver, and update `waza.lock` with the pinned commit SHA and `sha256:` content digest.
 
 ```bash
 waza registry add github.com/waza-evals/fact#factuality@v1.0.0
@@ -1040,7 +1040,7 @@ waza registry add github.com/waza-evals/fact#factuality@v1.0.0 --eval eval.yaml
 waza registry add github.com/waza-evals/fact#factuality@v1.0.0 --name factuality_strict --set config.threshold=0.9
 ```
 
-Full end-to-end module resolution depends on the shared resolver from issue #15. Phase 1 writes minimal `ref:` grader entries and scaffolds lock metadata until that resolver is wired in.
+Remote program graders require `--allow-exec` or interactive confirmation before `waza.lock` marks the ref as trusted.
 
 #### Flags
 


### PR DESCRIPTION
## Summary
- Add `waza registry` with `search` and `add` subcommands.
- Add project `registries:` config defaults/schema for registry index sources.
- Append minimal `ref:` grader entries to `eval.yaml` and scaffold `waza.lock` entries pending resolver integration.
- Document registry commands in README, docs guide, and site CLI reference.

## Notes
- Closes #17.
- Full end-to-end registry resolution depends on #15's shared resolver; the resolver and registry index calls are intentionally stubbed with TODOs for that integration.
- ⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Validation
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run`

## Not run
- `cd site && npm run build` — blocked because `npm ci` could not fetch `playwright-core` from the configured package proxy/public registry in this environment (`E404` then `ENOTCONN`).