### PR TITLE
fix: avoid concurrent spinner output

### DIFF
--- a/cmd/waza/dev/copilot.go
+++ b/cmd/waza/dev/copilot.go
@@ -75,9 +75,6 @@ func runDevCopilot(cfg *devConfig) error {
 		}
 	}()
 
-	stopSpinner := startDevSpinner(errOut, "Generating report with Copilot...")
-	defer stopSpinner()
-
 	triggerSpec, triggerErr := discoverTriggerSpec(sk.Frontmatter.Name)
 	if triggerErr != nil {
 		if errOut != nil {
@@ -85,6 +82,9 @@ func runDevCopilot(cfg *devConfig) error {
 		}
 		triggerSpec = nil
 	}
+
+	stopSpinner := startDevSpinner(errOut, "Generating report with Copilot...")
+	defer stopSpinner()
 
 	suggestions, err := getCopilotSuggestions(ctx, engine, skillPath, triggerSpec)
 	if err != nil {


### PR DESCRIPTION
## Summary
- discover trigger prompts before starting the Copilot progress spinner
- prevent warning output from racing with spinner writes

## Validation
- `go test -race ./cmd/waza/dev -run TestRunDev_CopilotTriggerLoadFailureWarnsAndContinues -count=10`
- `make test` (79.2% coverage)
- `make build`
- `make lint`
- dashboard: lint, build, 54 Chromium e2e tests
- docs site: build, 5 Playwright e2e tests