### PR TITLE
chore: expand default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner for everything in the repo
-* @spboyer
+* @spboyer @chlowell @richardpark-msft


### PR DESCRIPTION
## Summary

Align the default CODEOWNERS entry with the documented maintainer set so required code-owner review can be satisfied by someone other than the pull request author.