### PR TITLE
feat: Display eval prompt in dashboard task detail (#526)

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,7 @@ The dashboard displays evaluation results with:
 - Score distributions across trials
 - Model comparisons
 - Aggregated metrics and trends
+- The eval prompt used for each task (expand a task row to view, with a copy-to-clipboard button and any follow-up prompts)
 
 For detailed documentation on the dashboard and result visualization, see [docs/GUIDE.md](docs/GUIDE.md).
 

--- a/internal/models/outcome.go
+++ b/internal/models/outcome.go
@@ -152,8 +152,22 @@ type TestOutcome struct {
 	Group       string `json:"group,omitempty"`
 	// Golden mirrors TestCase.Golden so `waza gate` can identify
 	// must-pass tasks directly from results.json without re-reading YAML.
-	Golden      bool               `json:"golden,omitempty"`
-	Status      Status             `json:"status"`
+	Golden bool   `json:"golden,omitempty"`
+	Status Status `json:"status"`
+	// Prompt is the resolved initial task prompt (TestCase.Stimulus.Message),
+	// captured so the dashboard and other post-run consumers can show the
+	// exact instruction the agent received without re-reading the source YAML.
+	// It is populated at run time (after prompt_file resolution). Empty for
+	// legacy result files.
+	Prompt string `json:"prompt,omitempty"`
+	// PromptFile is the source path of Prompt when the stimulus was loaded
+	// from an external file via prompt_file. Empty when the prompt was
+	// inlined in the eval YAML.
+	PromptFile string `json:"prompt_file,omitempty"`
+	// FollowUps mirrors TestCase.Stimulus.FollowUps so consumers can see
+	// the multi-turn script alongside the initial prompt. Empty for
+	// single-turn tasks.
+	FollowUps   []string           `json:"follow_ups,omitempty"`
 	Runs        []RunResult        `json:"runs"`
 	Stats       *TestStats         `json:"stats,omitempty"`
 	SkillImpact *SkillImpactMetric `json:"skill_impact,omitempty"`

--- a/internal/orchestration/runner.go
+++ b/internal/orchestration/runner.go
@@ -840,6 +840,9 @@ func (r *EvalRunner) runSequential(ctx context.Context, testCases []*models.Test
 					DisplayName: tc.DisplayName,
 					Golden:      tc.Golden,
 					Status:      models.StatusFailed,
+					Prompt:      tc.Stimulus.Message,
+					PromptFile:  tc.Stimulus.MessageFile,
+					FollowUps:   tc.Stimulus.FollowUps,
 					Runs:        []models.RunResult{},
 				})
 				r.notifyProgress(ProgressEvent{
@@ -928,6 +931,9 @@ func (r *EvalRunner) runConcurrent(ctx context.Context, testCases []*models.Test
 						DisplayName: test.DisplayName,
 						Golden:      test.Golden,
 						Status:      models.StatusFailed,
+						Prompt:      test.Stimulus.Message,
+						PromptFile:  test.Stimulus.MessageFile,
+						FollowUps:   test.Stimulus.FollowUps,
 						Runs:        []models.RunResult{},
 					}}
 					r.notifyProgress(ProgressEvent{
@@ -1110,6 +1116,9 @@ func (r *EvalRunner) runTestUncached(ctx context.Context, tc *models.TestCase, t
 		Group:       r.resolveGroup(),
 		Golden:      tc.Golden,
 		Status:      status,
+		Prompt:      tc.Stimulus.Message,
+		PromptFile:  tc.Stimulus.MessageFile,
+		FollowUps:   tc.Stimulus.FollowUps,
 		Runs:        runs,
 		Stats:       stats,
 	}

--- a/internal/webapi/additional_test.go
+++ b/internal/webapi/additional_test.go
@@ -358,3 +358,46 @@ func TestOutcomeToDetailNoTasks(t *testing.T) {
 		t.Fatalf("expected 0 tasks, got %d", len(detail.Tasks))
 	}
 }
+
+func TestOutcomeToDetailMapsPrompt(t *testing.T) {
+	outcome := &models.EvaluationOutcome{
+		RunID:     "prompt-run",
+		BenchName: "bench-prompt",
+		Setup:     models.OutcomeSetup{ModelID: "gpt-4o"},
+		Digest:    models.OutcomeDigest{TotalTests: 2, Succeeded: 2},
+		TestOutcomes: []models.TestOutcome{
+			{
+				DisplayName: "task-with-prompt",
+				Status:      models.StatusPassed,
+				Prompt:      "Refactor the login handler to use bcrypt.",
+				PromptFile:  "prompts/refactor-login.md",
+				FollowUps:   []string{"Now add unit tests.", "Update the README."},
+			},
+			{
+				DisplayName: "task-legacy-no-prompt",
+				Status:      models.StatusPassed,
+			},
+		},
+	}
+
+	detail := outcomeToDetail(outcome)
+
+	if len(detail.Tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(detail.Tasks))
+	}
+	got := detail.Tasks[0]
+	if got.Prompt != "Refactor the login handler to use bcrypt." {
+		t.Errorf("expected prompt to round-trip, got %q", got.Prompt)
+	}
+	if got.PromptFile != "prompts/refactor-login.md" {
+		t.Errorf("expected promptFile to round-trip, got %q", got.PromptFile)
+	}
+	if len(got.FollowUps) != 2 || got.FollowUps[0] != "Now add unit tests." {
+		t.Errorf("expected followUps to round-trip, got %+v", got.FollowUps)
+	}
+
+	legacy := detail.Tasks[1]
+	if legacy.Prompt != "" || legacy.PromptFile != "" || len(legacy.FollowUps) != 0 {
+		t.Errorf("expected legacy task to have empty prompt fields, got %+v", legacy)
+	}
+}

--- a/internal/webapi/store.go
+++ b/internal/webapi/store.go
@@ -189,8 +189,11 @@ func outcomeToDetail(o *models.EvaluationOutcome) *RunDetail {
 
 	for _, to := range o.TestOutcomes {
 		tr := TaskResult{
-			Name:    to.DisplayName,
-			Outcome: string(to.Status),
+			Name:       to.DisplayName,
+			Outcome:    string(to.Status),
+			Prompt:     to.Prompt,
+			PromptFile: to.PromptFile,
+			FollowUps:  to.FollowUps,
 		}
 		if to.Stats != nil {
 			tr.Score = to.Stats.AvgScore

--- a/internal/webapi/types.go
+++ b/internal/webapi/types.go
@@ -36,6 +36,9 @@ type TaskResult struct {
 	Outcome       string                      `json:"outcome"`
 	Score         float64                     `json:"score"`
 	Duration      float64                     `json:"duration"`
+	Prompt        string                      `json:"prompt,omitempty"`
+	PromptFile    string                      `json:"promptFile,omitempty"`
+	FollowUps     []string                    `json:"followUps,omitempty"`
 	GraderResults []GraderResult              `json:"graderResults"`
 	Transcript    []TranscriptEventResponse   `json:"transcript,omitempty"`
 	SessionDigest *SessionDigestResponse      `json:"sessionDigest,omitempty"`

--- a/site/src/content/docs/guides/dashboard.mdx
+++ b/site/src/content/docs/guides/dashboard.mdx
@@ -30,6 +30,7 @@ Detailed results for a single evaluation run:
 
 - **Task List** — All tasks with pass/fail status
 - **Validator Results** — Per-validator scores and messages
+- **Prompt Panel** — Expand a task row to see the eval prompt that was sent to the agent, with a copy-to-clipboard button and a collapsible list of any follow-up prompts. If a task was loaded via `prompt_file`, the panel shows the source path. Runs recorded before this feature shipped show a "Prompt not recorded" hint instead
 - **Execution Stats** — Duration, token usage, tool calls
 - **Trajectory Viewer** — Two-mode trace inspection (see below)
 - **Export** — Download run as JSON

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>waza — eval dashboard</title>
-    <script type="module" crossorigin src="/assets/index-DMRgwpzH.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-SSZPQ-7z.css">
+    <script type="module" crossorigin src="/assets/index-DBBu14TP.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-avfgav-o.css">
   </head>
   <body class="bg-zinc-900 text-zinc-100 antialiased">
     <div id="root"></div>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -79,6 +79,9 @@ export interface TaskResult {
   score: number;
   weightedScore?: number;
   duration: number;
+  prompt?: string;
+  promptFile?: string;
+  followUps?: string[];
   graderResults: GraderResult[];
   transcript?: TranscriptEvent[];
   sessionDigest?: SessionDigest;

--- a/web/src/components/RunDetail.tsx
+++ b/web/src/components/RunDetail.tsx
@@ -7,6 +7,8 @@ import {
   ChevronRight,
   ChevronDown,
   Download,
+  Copy,
+  Check,
 } from "lucide-react";
 import { useRunDetail } from "../hooks/useApi";
 import type { TaskResult, GraderResult, ResponderInfo } from "../api/client";
@@ -163,6 +165,125 @@ function GraderRow({ grader }: { grader: GraderResult }) {
   );
 }
 
+function PromptPanel({
+  prompt,
+  promptFile,
+  followUps,
+}: {
+  prompt?: string;
+  promptFile?: string;
+  followUps?: string[];
+}) {
+  const [copied, setCopied] = useState(false);
+  const [showFollowUps, setShowFollowUps] = useState(false);
+
+  if (!prompt && !promptFile && (!followUps || followUps.length === 0)) {
+    return (
+      <tr className="border-b border-zinc-700/30 bg-zinc-900/30">
+        <td colSpan={5} className="px-12 py-3 text-xs italic text-zinc-500">
+          Prompt not recorded for this task. Re-run with a newer waza to
+          capture the eval prompt in results.
+        </td>
+      </tr>
+    );
+  }
+
+  const copyable = prompt ?? "";
+  const handleCopy = () => {
+    if (!copyable) return;
+    void navigator.clipboard.writeText(copyable).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <tr className="border-b border-zinc-700/30 bg-zinc-900/30">
+      <td colSpan={5} className="px-12 py-3">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <div className="flex items-baseline gap-2">
+            <span className="text-xs font-medium uppercase tracking-wide text-zinc-400">
+              Prompt
+            </span>
+            {promptFile && (
+              <span
+                className="text-xs text-zinc-500"
+                title={`Loaded from ${promptFile}`}
+              >
+                (from {promptFile})
+              </span>
+            )}
+          </div>
+          {prompt && (
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1 rounded border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-700"
+              aria-label="Copy prompt to clipboard"
+              data-testid="copy-prompt-button"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-3 w-3 text-green-500" /> Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="h-3 w-3" /> Copy
+                </>
+              )}
+            </button>
+          )}
+        </div>
+        {prompt ? (
+          <pre
+            className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded border border-zinc-700 bg-zinc-950/70 p-3 font-mono text-xs text-zinc-200"
+            data-testid="task-prompt"
+          >
+            {prompt}
+          </pre>
+        ) : (
+          <p className="text-xs italic text-zinc-500">
+            Prompt was loaded from an external file at run time; text not
+            captured in this result.
+          </p>
+        )}
+        {followUps && followUps.length > 0 && (
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={() => setShowFollowUps((v) => !v)}
+              className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200"
+              aria-expanded={showFollowUps}
+            >
+              {showFollowUps ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              Follow-up prompts ({followUps.length})
+            </button>
+            {showFollowUps && (
+              <ol
+                className="mt-2 space-y-2 pl-4"
+                data-testid="task-follow-ups"
+              >
+                {followUps.map((fu, i) => (
+                  <li key={i} className="text-xs text-zinc-300">
+                    <span className="mr-2 text-zinc-500">{i + 1}.</span>
+                    <pre className="mt-1 inline-block max-h-48 overflow-auto whitespace-pre-wrap break-words rounded border border-zinc-700 bg-zinc-950/70 p-2 font-mono text-xs text-zinc-200">
+                      {fu}
+                    </pre>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
 function TaskRow({ task }: { task: TaskResult }) {
   const [expanded, setExpanded] = useState(false);
   const ws = computeWeightedScore(task);
@@ -203,10 +324,18 @@ function TaskRow({ task }: { task: TaskResult }) {
           {formatDuration(task.duration)}
         </td>
       </tr>
-      {expanded &&
-        task.graderResults.map((g) => (
-          <GraderRow key={g.name} grader={g} />
-        ))}
+      {expanded && (
+        <>
+          <PromptPanel
+            prompt={task.prompt}
+            promptFile={task.promptFile}
+            followUps={task.followUps}
+          />
+          {task.graderResults.map((g) => (
+            <GraderRow key={g.name} grader={g} />
+          ))}
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
Closes #526

## Summary

Adds the eval prompt used to run each task into the dashboard, alongside graders and outcome details.

**⚠️ Draft — developed in parallel with a GPT-5.5 approach.** Please review both before merging.

## Approach (Claude Opus 4.7)

End-to-end: persist the prompt in results JSON, expose it through the webapi, render an inline panel in the expanded task row on the dashboard.

### Backend

- `internal/models/outcome.go` — `TestOutcome` now has optional `Prompt`, `PromptFile`, `FollowUps` fields (all `omitempty`, backward compatible with legacy `results.json` files).
- `internal/orchestration/runner.go` — populates the new fields from `TestCase.Stimulus` at the three `TestOutcome` construction sites: the main `runTestUncached` return path, and both the sequential and concurrent `before_task` hook-failure branches.
- `internal/webapi/types.go` + `internal/webapi/store.go` — `TaskResult` gains `prompt` / `promptFile` / `followUps` fields, and `outcomeToDetail` forwards them.
- `internal/webapi/additional_test.go` — new `TestOutcomeToDetailMapsPrompt` asserts prompt round-trips through the API and that legacy tasks without a prompt still work.

### Frontend

- `web/src/api/client.ts` — `TaskResult` interface extended with the optional prompt fields.
- `web/src/components/RunDetail.tsx` — new `PromptPanel` component rendered above graders in the expanded task row:
  - Monospace `<pre>` with wrapped/scrollable content, dark theme.
  - **Copy to clipboard** button (uses `navigator.clipboard`, flips to a `Check` icon for ~1.5s).
  - Shows the `prompt_file` source path when the prompt was loaded from a file.
  - Collapsible **Follow-up prompts** section listing each follow-up.
  - Graceful "Prompt not recorded" hint for older results.

### Docs

- `README.md` — added the prompt panel to the dashboard views bullet list.
- `site/src/content/docs/guides/dashboard.mdx` — expanded the "Run Details" list with a description of the prompt panel.

## Verification

- `go fmt ./... && go test ./...` — all packages pass.
- `golangci-lint run` — clean on our code (two `flatted/golang/pkg` govet warnings live in `web/node_modules/`, unrelated to this change).
- `cd web && npm run build` — TypeScript compiles, Vite build succeeds.
- `cd web && npm run lint` — clean.

## Design choices

- **Inline panel, not a new tab.** Keeps the prompt colocated with its graders and outcome; matches the existing expand-a-row pattern.
- **Plain-text `<pre>`, no syntax highlighting.** YAML and Markdown prompts stay readable without adding a highlighter dependency; a future PR can layer highlighting on top.
- **`omitempty` + optional TS field.** Older `results.json` files just render without the panel — no schema-version bump needed.

## Parallel approaches

This is one of two agent-generated implementations for #526. See the sibling GPT-5.5 PR for an alternative before merging.