### PR TITLE
docs: fix AGENTS.md drift — Grader (not Validator), drop stale Python ref (#570)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repository contains `waza`, a CLI tool for evaluating Agent Skills. **The primary implementation is Go** in the repository root. The Python implementation (`waza/`) is legacy and no longer actively developed.
+This repository contains `waza`, a CLI tool for evaluating Agent Skills. **The implementation is Go** in the repository root. (The legacy Python implementation was removed in February 2026.)
 
 When making changes, follow these guidelines to maintain consistency and quality.
 
@@ -31,9 +31,10 @@ internal/
 │   └── outcome.go         # EvaluationOutcome (results)
 ├── orchestration/         # EvalRunner for coordinating execution
 │   └── runner.go          # Eval orchestration
-└── scoring/               # Validator interface and implementations
-    ├── validator.go       # Validator registry pattern
-    └── code_validators.go # Code and text validators
+├── graders/               # Grader interface + Create() factory (13 grader kinds)
+│   └── grader.go          # Grader interface and Create() factory switch
+└── scoring/               # Skill-adherence heuristic Scorer
+    └── scoring.go         # HeuristicScorer implementation
 go.mod
 go.sum
 Makefile                   # Build and test commands
@@ -48,7 +49,7 @@ The Go implementation uses idiomatic Go naming:
 |---------|---------|-------------------|
 | Eval configuration | `EvalSpec` | `EvalSpec` |
 | Executor | `AgentEngine` | `BaseExecutor` |
-| Grader | `Validator` | `Grader` |
+| Grader | `Grader` | `Grader` |
 | Task | `TestCase` | `Task` |
 | Result | `EvaluationOutcome` | `EvalResult` |
 
@@ -71,11 +72,9 @@ type AgentEngine interface {
 }
 ```
 
-### Validator Registry
+### Grader Factory
 ```go
-registry := scoring.NewValidatorRegistry()
-registry.Register("code", &scoring.CodeValidator{})
-registry.Register("text", &scoring.TextValidator{})
+g, err := graders.Create(identifier, params) // factory switch over models.*GraderParameters
 ```
 
 ## Building and Testing
@@ -177,7 +176,7 @@ Documentation must be updated in real-time as features change. This is enforced 
 | Changed CLI behavior | README.md, `site/` guides, docs/GUIDE.md, affected tutorials |
 | New/changed dashboard view | `site/` dashboard guide, regenerate screenshots, docs/DEMO-GUIDE.md |
 | Changed eval YAML schema | README.md YAML section, `site/` eval-yaml reference, example files |
-| New validator/grader | README.md Validators section, `site/` graders page, docs/GUIDE.md |
+| New grader | README.md Graders section, `site/` graders page, docs/GUIDE.md |
 | New sensei/dev feature | `site/` sensei guide, README.md |
 | New data in results JSON | Check if dashboard (`web/`) needs a new view, column, or chart to surface it |
 
@@ -198,10 +197,10 @@ Screenshots are saved to `docs/images/` and referenced throughout documentation.
 3. Add tests in `*_test.go` files
 4. Update the root `README.md`
 
-### Adding a Validator (Grader)
+### Adding a Grader
 
-1. Implement `Validator` interface in `internal/scoring/`
-2. Register in `ValidatorRegistry`
+1. Implement the `Grader` interface in `internal/graders/`
+2. Add a `models.<Kind>GraderParameters` case to `Create()` in `internal/graders/grader.go`
 3. Add tests
 4. Document in README
 


### PR DESCRIPTION
Closes #570.

Corrects four documentation defects in `AGENTS.md` verified against `main`:

1. **Stale Python pointer (L5)** — the `waza/` Python directory was removed in Feb 2026 (`92949e14`). Replaced the "legacy" reference with a factual note that Go is the only implementation.
2. **Deleted files in code-structure tree (L34–36)** — `internal/scoring/` no longer contains `validator.go` / `code_validators.go`. Updated the tree to show the real layout:
   - `internal/graders/` — `Grader` interface + `Create()` factory (13 grader kinds)
   - `internal/scoring/` — skill-adherence heuristic `Scorer` only
3. **Wrong Go type name in naming table (L51)** — mapped `Grader → Validator`. The actual interface is `Grader` (`internal/graders/grader.go:14`). Fixed to `Grader → Grader → Grader`.
4. **"Validator Registry" example + "Adding a Validator" section (L74–78, L201–206)** — `scoring.NewValidatorRegistry` / `CodeValidator` / `TextValidator` have zero matches repo-wide. Replaced with the real `graders.Create(identifier, params)` factory pattern, and updated the "Adding a Grader" instructions to say: implement the `Grader` interface in `internal/graders/` and add a `models.<Kind>GraderParameters` case to `Create()` in `internal/graders/grader.go`.

Also aligned the "When to Update Docs" row from `New validator/grader` → `New grader` for consistency (README section renamed accordingly).

### Verification

```bash
git ls-tree HEAD internal/scoring/        # only scoring.go, scoring_test.go
grep -rn "ValidatorRegistry\|type Validator " --include='*.go' internal/ cmd/   # no matches
sed -n '14p' internal/graders/grader.go   # type Grader interface
ls waza/                                  # not found
```

All four repro checks from the issue pass. Mechanical diff — no code changes.