### PR TITLE
fix: avoid duplicate Copilot skill summaries

### DIFF
--- a/internal/execution/copilot.go
+++ b/internal/execution/copilot.go
@@ -14,6 +14,7 @@ import (
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/github/copilot-sdk/go/rpc"
+	"gopkg.in/yaml.v3"
 
 	"github.com/microsoft/waza/internal/copilotevents"
 	"github.com/microsoft/waza/internal/models"
@@ -881,18 +882,6 @@ func buildSkillSystemMessage(skillDirs []string, skillName string, injectSkillBo
 		}
 	}
 
-	// Summary block for all discovered skills
-	sb.WriteString("\n<available_skills>\n")
-	for _, s := range skills {
-		sb.WriteString("<skill>\n")
-		fmt.Fprintf(&sb, "  <name>%s</name>\n", s.Name)
-		if s.Description != "" {
-			fmt.Fprintf(&sb, "  <description>%s</description>\n", s.Description)
-		}
-		sb.WriteString("</skill>\n")
-	}
-	sb.WriteString("</available_skills>\n")
-
 	return sb.String()
 }
 
@@ -964,8 +953,7 @@ func loadSkillDefinition(dir string) *skillDefinition {
 	return nil
 }
 
-// parseSkillFrontmatter extracts name and description from SKILL.md YAML
-// frontmatter. Avoids importing the skill package to keep execution decoupled.
+// parseSkillFrontmatter extracts name and description from SKILL.md YAML frontmatter.
 func parseSkillFrontmatter(content string) (name, description string) {
 	if !strings.HasPrefix(content, "---") {
 		return "", ""
@@ -984,17 +972,13 @@ func parseSkillFrontmatter(content string) (name, description string) {
 	}
 
 	yamlBlock := rest[:idx]
-
-	for _, line := range strings.Split(yamlBlock, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "name:") {
-			name = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
-			name = strings.Trim(name, "\"'")
-		} else if strings.HasPrefix(line, "description:") {
-			description = strings.TrimSpace(strings.TrimPrefix(line, "description:"))
-			description = strings.Trim(description, "\"'")
-		}
+	var frontmatter struct {
+		Name        string `yaml:"name"`
+		Description string `yaml:"description"`
+	}
+	if err := yaml.Unmarshal([]byte(yamlBlock), &frontmatter); err != nil {
+		return "", ""
 	}
 
-	return name, description
+	return frontmatter.Name, frontmatter.Description
 }

--- a/internal/execution/copilot_test.go
+++ b/internal/execution/copilot_test.go
@@ -596,7 +596,7 @@ func skipIfCopilotNotEnabled(t *testing.T) {
 	}
 }
 
-func TestCopilotCreateSession_InjectsSkillSystemMessage(t *testing.T) {
+func TestCopilotCreateSession_InjectsTargetSkillContextOnly(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	clientMock := newClientMock(ctrl)
 	sessionMock := NewMockCopilotSession(ctrl)
@@ -609,6 +609,8 @@ func TestCopilotCreateSession_InjectsSkillSystemMessage(t *testing.T) {
 
 	expectedSystemMsg := buildSkillSystemMessage([]string{sourceDir}, "test-skill", true)
 	require.NotEmpty(t, expectedSystemMsg)
+	require.Contains(t, expectedSystemMsg, "<skill_context>")
+	require.NotContains(t, expectedSystemMsg, "<available_skills>")
 
 	expectedConfig := sessionConfigMatcher{
 		t:         t,
@@ -669,6 +671,7 @@ func TestCopilotCreateSession_InjectsInstructionSystemMessage(t *testing.T) {
 		buildInstructionSystemMessage(instructions),
 	}, "\n")
 	require.NotEmpty(t, expectedSystemMsg)
+	require.NotContains(t, expectedSystemMsg, "<available_skills>")
 
 	expectedConfig := sessionConfigMatcher{
 		t:         t,
@@ -773,6 +776,7 @@ func TestCopilotResumeSession_PassesMCPServersAndSystemMessage(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte(skillContent), 0644))
 
 	expectedSystemMsg := buildSkillSystemMessage([]string{sourceDir}, "resume-skill", true)
+	require.NotContains(t, expectedSystemMsg, "<available_skills>")
 
 	mcpServers := map[string]copilot.MCPServerConfig{
 		"mcp-srv": copilot.MCPStdioServerConfig{Command: "test"},

--- a/internal/execution/engine.go
+++ b/internal/execution/engine.go
@@ -94,7 +94,7 @@ type ExecutionRequest struct {
 	SkillPaths []string // Directories to search for skills
 	NoSkills   bool     // When true, skip all skill loading
 	// SuppressSkillBody prevents full target skill content from being appended
-	// while still allowing skill discovery and compact summaries.
+	// while still allowing SDK-backed skill discovery.
 	SuppressSkillBody bool
 
 	// MCPServers configures MCP servers for the session. Keys are server names,

--- a/internal/execution/skill_injection_test.go
+++ b/internal/execution/skill_injection_test.go
@@ -26,11 +26,9 @@ func TestBuildSkillSystemMessage_DirectSkillMD(t *testing.T) {
 	assert.Contains(t, msg, "Always say hello")
 	assert.Contains(t, msg, "</skill_context>")
 
-	// Should include summary
-	assert.Contains(t, msg, "<available_skills>")
-	assert.Contains(t, msg, "<name>test-skill</name>")
-	assert.Contains(t, msg, "<description>A test skill</description>")
-	assert.Contains(t, msg, "</available_skills>")
+	// SkillDirectories already lets the Copilot SDK advertise available skills.
+	assert.NotContains(t, msg, "<available_skills>")
+	assert.NotContains(t, msg, "<description>A test skill</description>")
 }
 
 func TestBuildSkillSystemMessage_SuppressTargetSkillBody(t *testing.T) {
@@ -42,9 +40,8 @@ func TestBuildSkillSystemMessage_SuppressTargetSkillBody(t *testing.T) {
 
 	assert.NotContains(t, msg, "<skill_context>")
 	assert.NotContains(t, msg, "Always say hello")
-	assert.Contains(t, msg, "<available_skills>")
-	assert.Contains(t, msg, "<name>test-skill</name>")
-	assert.Contains(t, msg, "<description>A test skill</description>")
+	assert.NotContains(t, msg, "<available_skills>")
+	assert.Empty(t, msg)
 }
 
 func TestBuildSkillSystemMessage_NestedSkillMD(t *testing.T) {
@@ -59,10 +56,10 @@ func TestBuildSkillSystemMessage_NestedSkillMD(t *testing.T) {
 
 	assert.Contains(t, msg, "<skill_context>")
 	assert.Contains(t, msg, "Body content")
-	assert.Contains(t, msg, "<name>nested-skill</name>")
+	assert.NotContains(t, msg, "<available_skills>")
 }
 
-func TestBuildSkillSystemMessage_NonTargetSkillSummaryOnly(t *testing.T) {
+func TestBuildSkillSystemMessage_NonTargetSkillSkipped(t *testing.T) {
 	dir := t.TempDir()
 	skillContent := "---\nname: other-skill\ndescription: Other\n---\n# Secret body"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillContent), 0644))
@@ -70,21 +67,21 @@ func TestBuildSkillSystemMessage_NonTargetSkillSummaryOnly(t *testing.T) {
 	// Target is different skill
 	msg := buildSkillSystemMessage([]string{dir}, "my-target-skill", true)
 
-	// Should have summary but NOT full body
-	assert.Contains(t, msg, "<name>other-skill</name>")
-	assert.NotContains(t, msg, "<skill_context>")
+	// The SDK advertises available skills from SkillDirectories, so Waza does
+	// not append a duplicate summary for non-target skills.
+	assert.Empty(t, msg)
 }
 
-func TestBuildSkillSystemMessage_NoFrontmatter_UsesDirectoryName(t *testing.T) {
+func TestBuildSkillSystemMessage_NoFrontmatter_UsesDirectoryNameForTargetBody(t *testing.T) {
 	dir := t.TempDir()
 	skillContent := "# No frontmatter skill\nJust body."
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillContent), 0644))
 
-	msg := buildSkillSystemMessage([]string{dir}, "", true)
+	msg := buildSkillSystemMessage([]string{dir}, filepath.Base(dir), true)
 
-	assert.Contains(t, msg, "<available_skills>")
-	// Should use directory name as the skill name
-	assert.Contains(t, msg, "<name>"+filepath.Base(dir)+"</name>")
+	assert.Contains(t, msg, "<skill_context>")
+	assert.Contains(t, msg, "Just body.")
+	assert.NotContains(t, msg, "<available_skills>")
 }
 
 func TestBuildSkillSystemMessage_SkipsHiddenAndVendor(t *testing.T) {
@@ -152,6 +149,42 @@ func TestParseSkillFrontmatter(t *testing.T) {
 			content:      "---\nname: \"quoted-skill\"\ndescription: 'quoted desc'\n---\n",
 			expectedName: "quoted-skill",
 			expectedDesc: "quoted desc",
+		},
+		{
+			name: "folded strip block scalar description",
+			content: `---
+name: setup-copilot-cloud-environment
+description: >-
+  Sets up a Copilot cloud environment.
+  Use when creating remote workspaces.
+---
+body`,
+			expectedName: "setup-copilot-cloud-environment",
+			expectedDesc: "Sets up a Copilot cloud environment. Use when creating remote workspaces.",
+		},
+		{
+			name: "folded clip block scalar description",
+			content: `---
+name: create-vscode-workspace
+description: >
+  Creates a VS Code workspace.
+  Opens it after setup.
+---
+body`,
+			expectedName: "create-vscode-workspace",
+			expectedDesc: "Creates a VS Code workspace. Opens it after setup.",
+		},
+		{
+			name: "literal block scalar description",
+			content: `---
+name: multi-line-skill
+description: |
+  First line.
+  Second line.
+---
+body`,
+			expectedName: "multi-line-skill",
+			expectedDesc: "First line.\nSecond line.",
 		},
 		{
 			name:         "unclosed frontmatter",


### PR DESCRIPTION
Fixes #578

Remove Waza's synthetic `<available_skills>` inventory from Copilot SDK sessions because the SDK already advertises `SkillDirectories`. Parse frontmatter with YAML so block-scalar metadata remains valid for target-skill matching. Preserve full target skill body injection and add regression coverage for `>-`, `>`, and `|` descriptions.

Implemented and tested in parallel by GPT-5.5 and Claude Opus 4.7 coding sessions; this PR uses the focused GPT-5.5 implementation.